### PR TITLE
シーン管理システムを導入する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,12 @@ add_executable(raythm src/main.cpp
         libs/bass/bass.h
         src/audio.cpp
         src/audio.h
-        src/ui/button.cpp
-        src/ui/button.h
-        src/ui/ui_element.h
-        src/ui/ui_render_queue.cpp
-        src/ui/ui_render_queue.h
-        src/ui/ui_renderer.cpp
-        src/ui/ui_renderer.h)
+        src/scene.cpp
+        src/scene.h
+        src/scene_manager.cpp
+        src/scene_manager.h
+        src/game_scenes.cpp
+        src/game_scenes.h)
 
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass)

--- a/docs/class-diagram.md
+++ b/docs/class-diagram.md
@@ -155,3 +155,61 @@ classDiagram
     result_data --> rank
     result_data --> judge_result
 ```
+
+## Phase 2-1: 譜面パーサー
+
+```mermaid
+classDiagram
+    class chart_parser {
+        <<static>>
+        +parse(string file_path) chart_parse_result
+        -parse_metadata(vector~string~ lines) chart_meta
+        -parse_timing(vector~string~ lines) vector~timing_event~
+        -parse_notes(vector~string~ lines) vector~note_data~
+        -validate(chart_data data) vector~string~
+    }
+
+    class chart_data {
+        +chart_meta meta
+        +vector~timing_event~ timing_events
+        +vector~note_data~ notes
+    }
+
+    class chart_parse_result {
+        +bool success
+        +optional~chart_data~ data
+        +vector~string~ errors
+    }
+
+    chart_parser --> chart_parse_result : returns
+    chart_parse_result --> chart_data : contains
+    chart_data --> chart_meta
+    chart_data --> timing_event
+    chart_data --> note_data
+```
+
+## Phase 2-2: 楽曲ローダー
+
+```mermaid
+classDiagram
+    class song_loader {
+        +load_all(string songs_dir) song_load_result
+        +load_chart(string path) chart_parse_result
+    }
+
+    class song_data {
+        +song_meta meta
+        +vector~string~ chart_paths
+        +string directory
+    }
+
+    class song_load_result {
+        +vector~song_data~ songs
+        +vector~string~ errors
+    }
+
+    song_loader --> song_load_result : returns
+    song_loader --> chart_parse_result : returns
+    song_load_result --> song_data : contains
+    song_data --> song_meta
+```

--- a/src/game_scenes.cpp
+++ b/src/game_scenes.cpp
@@ -1,0 +1,148 @@
+#include "game_scenes.h"
+
+#include <array>
+#include <memory>
+
+#include "raylib.h"
+#include "scene_manager.h"
+
+namespace {
+constexpr int kScreenWidth = 1280;
+constexpr int kScreenHeight = 720;
+
+void draw_scene_frame(const char* title, const char* subtitle, Color accent) {
+    ClearBackground({18, 24, 38, 255});
+
+    DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, {28, 36, 54, 255}, {12, 16, 26, 255});
+    DrawRectangleRounded({80.0f, 80.0f, 1120.0f, 560.0f}, 0.04f, 8, {245, 247, 250, 235});
+    DrawRectangleRoundedLinesEx({80.0f, 80.0f, 1120.0f, 560.0f}, 0.04f, 8, 3.0f, accent);
+
+    DrawText(title, 130, 130, 44, accent);
+    DrawText(subtitle, 130, 190, 24, DARKGRAY);
+}
+}
+
+title_scene::title_scene(scene_manager& manager) : scene(manager) {
+}
+
+void title_scene::update(float dt) {
+    (void)dt;
+
+    if (IsKeyPressed(KEY_ENTER)) {
+        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+    } else if (IsKeyPressed(KEY_S)) {
+        manager_.change_scene(std::make_unique<settings_scene>(manager_));
+    }
+}
+
+void title_scene::draw() {
+    draw_scene_frame("Title", "ENTER: Song Select    S: Settings", {32, 129, 226, 255});
+    DrawText("raythm", 130, 300, 92, BLACK);
+    DrawText("Scene management bootstrap", 136, 400, 28, GRAY);
+}
+
+song_select_scene::song_select_scene(scene_manager& manager) : scene(manager) {
+}
+
+void song_select_scene::update(float dt) {
+    (void)dt;
+
+    constexpr std::array<const char*, 3> kDifficulties = {"Normal", "Hyper", "Another"};
+    constexpr std::array<const char*, 2> kKeyModes = {"4 Keys", "6 Keys"};
+
+    if (IsKeyPressed(KEY_LEFT)) {
+        difficulty_index_ = (difficulty_index_ + static_cast<int>(kDifficulties.size()) - 1) %
+                            static_cast<int>(kDifficulties.size());
+    } else if (IsKeyPressed(KEY_RIGHT)) {
+        difficulty_index_ = (difficulty_index_ + 1) % static_cast<int>(kDifficulties.size());
+    }
+
+    if (IsKeyPressed(KEY_UP) || IsKeyPressed(KEY_DOWN)) {
+        key_mode_index_ = (key_mode_index_ + 1) % static_cast<int>(kKeyModes.size());
+    }
+
+    if (IsKeyPressed(KEY_ENTER)) {
+        manager_.change_scene(std::make_unique<play_scene>(manager_));
+    } else if (IsKeyPressed(KEY_ESCAPE)) {
+        manager_.change_scene(std::make_unique<title_scene>(manager_));
+    }
+}
+
+void song_select_scene::draw() {
+    constexpr std::array<const char*, 3> kDifficulties = {"Normal", "Hyper", "Another"};
+    constexpr std::array<const char*, 2> kKeyModes = {"4 Keys", "6 Keys"};
+
+    draw_scene_frame("Song Select", "LEFT/RIGHT: Difficulty    UP/DOWN: Key Mode    ENTER: Play", {14, 146, 108, 255});
+    DrawText("Selected Song: Placeholder Track", 130, 290, 36, BLACK);
+    DrawText(TextFormat("Difficulty: %s", kDifficulties[difficulty_index_]), 130, 360, 30, DARKGRAY);
+    DrawText(TextFormat("Mode: %s", kKeyModes[key_mode_index_]), 130, 405, 30, DARKGRAY);
+    DrawText("ESC: Back to Title", 130, 490, 24, GRAY);
+}
+
+play_scene::play_scene(scene_manager& manager) : scene(manager) {
+}
+
+void play_scene::update(float dt) {
+    elapsed_seconds_ += dt;
+
+    if (IsKeyPressed(KEY_R)) {
+        manager_.change_scene(std::make_unique<result_scene>(manager_));
+    } else if (IsKeyPressed(KEY_ESCAPE)) {
+        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+    }
+}
+
+void play_scene::draw() {
+    draw_scene_frame("Play", "R: Result    ESC: Song Select", {220, 38, 38, 255});
+
+    DrawRectangle(150, 260, 780, 260, {30, 41, 59, 255});
+    DrawRectangleLinesEx({150.0f, 260.0f, 780.0f, 260.0f}, 3.0f, {148, 163, 184, 255});
+
+    for (int lane = 1; lane < 4; ++lane) {
+        DrawLine(150 + lane * 195, 260, 150 + lane * 195, 520, {71, 85, 105, 255});
+    }
+
+    DrawCircle(245, 330, 18.0f, {96, 165, 250, 255});
+    DrawText(TextFormat("Elapsed: %.2f s", elapsed_seconds_), 980, 290, 28, BLACK);
+    DrawText("Score: 0000000", 980, 350, 28, BLACK);
+    DrawText("Combo: 000", 980, 395, 28, BLACK);
+    DrawText("Gauge: 100%", 980, 440, 28, BLACK);
+}
+
+result_scene::result_scene(scene_manager& manager) : scene(manager) {
+}
+
+void result_scene::update(float dt) {
+    (void)dt;
+
+    if (IsKeyPressed(KEY_ENTER)) {
+        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+    } else if (IsKeyPressed(KEY_ESCAPE)) {
+        manager_.change_scene(std::make_unique<title_scene>(manager_));
+    }
+}
+
+void result_scene::draw() {
+    draw_scene_frame("Result", "ENTER: Retry Flow    ESC: Title", {202, 138, 4, 255});
+    DrawText("Score: 987654", 130, 300, 40, BLACK);
+    DrawText("Rank: A", 130, 360, 40, BLACK);
+    DrawText("Perfect 321  Great 24  Good 3  Miss 1", 130, 420, 28, DARKGRAY);
+}
+
+settings_scene::settings_scene(scene_manager& manager) : scene(manager) {
+}
+
+void settings_scene::update(float dt) {
+    (void)dt;
+
+    if (IsKeyPressed(KEY_ESCAPE) || IsKeyPressed(KEY_ENTER)) {
+        manager_.change_scene(std::make_unique<title_scene>(manager_));
+    }
+}
+
+void settings_scene::draw() {
+    draw_scene_frame("Settings", "ENTER or ESC: Back to Title", {124, 58, 237, 255});
+    DrawText("Audio Offset: 0 ms", 130, 300, 36, BLACK);
+    DrawText("Lane Speed: 6.5", 130, 360, 36, BLACK);
+    DrawText("Key Config: pending", 130, 420, 36, BLACK);
+}

--- a/src/game_scenes.h
+++ b/src/game_scenes.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include "scene.h"
+
+class title_scene final : public scene {
+public:
+    explicit title_scene(scene_manager& manager);
+
+    void update(float dt) override;
+    void draw() override;
+};
+
+class song_select_scene final : public scene {
+public:
+    explicit song_select_scene(scene_manager& manager);
+
+    void update(float dt) override;
+    void draw() override;
+
+private:
+    int difficulty_index_ = 0;
+    int key_mode_index_ = 0;
+};
+
+class play_scene final : public scene {
+public:
+    explicit play_scene(scene_manager& manager);
+
+    void update(float dt) override;
+    void draw() override;
+
+private:
+    float elapsed_seconds_ = 0.0f;
+};
+
+class result_scene final : public scene {
+public:
+    explicit result_scene(scene_manager& manager);
+
+    void update(float dt) override;
+    void draw() override;
+};
+
+class settings_scene final : public scene {
+public:
+    explicit settings_scene(scene_manager& manager);
+
+    void update(float dt) override;
+    void draw() override;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,27 +1,22 @@
+#include "game_scenes.h"
 #include "raylib.h"
-#include "audio.h"
+#include "scene_manager.h"
 
 int main() {
-    InitWindow(1280, 720, "test");
+    InitWindow(1280, 720, "raythm");
     SetTargetFPS(120);
 
-    Camera3D camera = {};
-    camera.position = { 0.0f, 5.0f, 10.0f };
-    camera.target   = { 0.0f, 0.0f, 0.0f };
-    camera.up       = { 0.0f, 1.0f, 0.0f };
-    camera.fovy     = 45.0f;
-    camera.projection = CAMERA_PERSPECTIVE;
-
-    audio audio;
-    audio.load("../assets/audio/music.mp3");
-    audio.play();
+    scene_manager manager;
+    manager.set_initial_scene(std::unique_ptr<scene>(new title_scene(manager)));
 
     while (!WindowShouldClose()) {
+        const float dt = GetFrameTime();
+        manager.update(dt);
+
         BeginDrawing();
-            ClearBackground(WHITE);
-            BeginMode3D(camera);
-                DrawPlane({ 0, 0, 0 }, { 5, 3 }, GRAY);
-            EndMode3D();
+        manager.draw();
         EndDrawing();
     }
+
+    CloseWindow();
 }

--- a/src/scene.cpp
+++ b/src/scene.cpp
@@ -1,0 +1,10 @@
+#include "scene.h"
+
+scene::scene(scene_manager& manager) : manager_(manager) {
+}
+
+void scene::on_enter() {
+}
+
+void scene::on_exit() {
+}

--- a/src/scene.h
+++ b/src/scene.h
@@ -1,0 +1,17 @@
+#pragma once
+
+class scene_manager;
+
+class scene {
+public:
+    explicit scene(scene_manager& manager);
+    virtual ~scene() = default;
+
+    virtual void update(float dt) = 0;
+    virtual void draw() = 0;
+    virtual void on_enter();
+    virtual void on_exit();
+
+protected:
+    scene_manager& manager_;
+};

--- a/src/scene_manager.cpp
+++ b/src/scene_manager.cpp
@@ -1,0 +1,44 @@
+#include "scene_manager.h"
+
+#include "scene.h"
+
+void scene_manager::update(float dt) {
+    apply_pending_transition();
+
+    if (current_scene_ != nullptr) {
+        current_scene_->update(dt);
+    }
+
+    apply_pending_transition();
+}
+
+void scene_manager::draw() {
+    if (current_scene_ != nullptr) {
+        current_scene_->draw();
+    }
+}
+
+void scene_manager::change_scene(std::unique_ptr<scene> next_scene) {
+    next_scene_ = std::move(next_scene);
+}
+
+void scene_manager::set_initial_scene(std::unique_ptr<scene> initial_scene) {
+    current_scene_ = std::move(initial_scene);
+
+    if (current_scene_ != nullptr) {
+        current_scene_->on_enter();
+    }
+}
+
+void scene_manager::apply_pending_transition() {
+    if (next_scene_ == nullptr) {
+        return;
+    }
+
+    if (current_scene_ != nullptr) {
+        current_scene_->on_exit();
+    }
+
+    current_scene_ = std::move(next_scene_);
+    current_scene_->on_enter();
+}

--- a/src/scene_manager.h
+++ b/src/scene_manager.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+class scene;
+
+class scene_manager {
+public:
+    scene_manager() = default;
+
+    void update(float dt);
+    void draw();
+    void change_scene(std::unique_ptr<scene> next_scene);
+    void set_initial_scene(std::unique_ptr<scene> initial_scene);
+
+private:
+    void apply_pending_transition();
+
+    std::unique_ptr<scene> current_scene_;
+    std::unique_ptr<scene> next_scene_;
+};


### PR DESCRIPTION
## Summary
- add a scene base class and deferred scene manager
- add initial title, song select, play, result, and settings scene stubs
- refactor main.cpp to run through the scene manager
- update CMake target sources and include the class diagram changes already present on this branch

## Notes
- this PR targets the GitHub Project task for the scene management system
- local verification in this environment was partially constrained by sandbox/compiler output issues, so final validation should also be checked in the normal local workflow

Closes #2