### PR TITLE
楽曲ローダーの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(raythm src/main.cpp
         src/chart_parser.cpp
         src/chart_parser.h
         src/data_models.h
+        src/song_loader.cpp
+        src/song_loader.h
         src/scene.cpp
         src/scene.h
         src/scene_manager.cpp
@@ -30,6 +32,14 @@ add_executable(chart_parser_smoke
         src/chart_parser.h
         src/chart_parser_smoke.cpp
         src/data_models.h)
+
+add_executable(song_loader_smoke
+        src/chart_parser.cpp
+        src/chart_parser.h
+        src/data_models.h
+        src/song_loader.cpp
+        src/song_loader.h
+        src/song_loader_smoke.cpp)
 
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass)

--- a/assets/songs/invalid_missing_field/song.json
+++ b/assets/songs/invalid_missing_field/song.json
@@ -1,0 +1,9 @@
+{
+  "songId": "broken-song",
+  "title": "Broken Song",
+  "artist": "Codex",
+  "audioFile": "audio.mp3",
+  "jacketFile": "jacket.png",
+  "previewStartMs": 8000,
+  "songVersion": 1
+}

--- a/assets/songs/invalid_no_charts/song.json
+++ b/assets/songs/invalid_no_charts/song.json
@@ -1,0 +1,10 @@
+{
+  "songId": "no-chart-song",
+  "title": "No Chart Song",
+  "artist": "Codex",
+  "baseBpm": 128.0,
+  "audioFile": "audio.mp3",
+  "jacketFile": "jacket.png",
+  "previewStartMs": 4000,
+  "songVersion": 2
+}

--- a/assets/songs/valid_song/charts/normal.chart
+++ b/assets/songs/valid_song/charts/normal.chart
@@ -1,0 +1,17 @@
+[Metadata]
+chartId=sample-song-normal
+keyCount=4
+difficulty=Normal
+level=5
+chartAuthor=Codex
+formatVersion=1
+resolution=480
+
+[Timing]
+bpm,0,150
+meter,0,4/4
+
+[Notes]
+tap,0,0
+tap,480,1
+hold,960,2,1440

--- a/assets/songs/valid_song/song.json
+++ b/assets/songs/valid_song/song.json
@@ -1,0 +1,10 @@
+{
+  "songId": "sample-song",
+  "title": "Sample Song",
+  "artist": "Codex",
+  "baseBpm": 150.0,
+  "audioFile": "audio.mp3",
+  "jacketFile": "jacket.png",
+  "previewStartMs": 12000,
+  "songVersion": 1
+}

--- a/src/data_models.h
+++ b/src/data_models.h
@@ -17,6 +17,19 @@ struct song_meta {
     int song_version = 0;
 };
 
+// 曲一覧で扱う読み込み済み楽曲データ。
+struct song_data {
+    song_meta meta;
+    std::vector<std::string> chart_paths;
+    std::string directory;
+};
+
+// 楽曲ローダーの結果。
+struct song_load_result {
+    std::vector<song_data> songs;
+    std::vector<std::string> errors;
+};
+
 // 譜面ごとの差分情報を表すメタデータ。
 struct chart_meta {
     std::string chart_id;

--- a/src/song_loader.cpp
+++ b/src/song_loader.cpp
@@ -1,0 +1,286 @@
+#include "song_loader.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string_view>
+
+namespace {
+namespace fs = std::filesystem;
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start])) != 0) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1])) != 0) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        return {};
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t value_start = colon_pos + 1;
+    while (value_start < content.size() &&
+           std::isspace(static_cast<unsigned char>(content[value_start])) != 0) {
+        ++value_start;
+    }
+
+    if (value_start >= content.size() || content[value_start] != '"') {
+        return std::nullopt;
+    }
+
+    ++value_start;
+    size_t value_end = value_start;
+    while (value_end < content.size()) {
+        if (content[value_end] == '"' && content[value_end - 1] != '\\') {
+            return content.substr(value_start, value_end - value_start);
+        }
+        ++value_end;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> extract_json_number_token(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t value_start = colon_pos + 1;
+    while (value_start < content.size() &&
+           std::isspace(static_cast<unsigned char>(content[value_start])) != 0) {
+        ++value_start;
+    }
+
+    size_t value_end = value_start;
+    while (value_end < content.size() && content[value_end] != ',' && content[value_end] != '}' &&
+           content[value_end] != '\n' && content[value_end] != '\r') {
+        ++value_end;
+    }
+
+    const std::string token_value = trim(content.substr(value_start, value_end - value_start));
+    if (token_value.empty()) {
+        return std::nullopt;
+    }
+
+    return token_value;
+}
+
+std::optional<int> parse_int(const std::string& value) {
+    try {
+        size_t parsed = 0;
+        const int result = std::stoi(value, &parsed);
+        if (parsed != value.size()) {
+            return std::nullopt;
+        }
+        return result;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> parse_float(const std::string& value) {
+    try {
+        size_t parsed = 0;
+        const float result = std::stof(value, &parsed);
+        if (parsed != value.size()) {
+            return std::nullopt;
+        }
+        return result;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<song_meta> parse_song_meta(const fs::path& song_json_path, std::vector<std::string>& errors) {
+    const std::string content = read_file(song_json_path);
+    if (content.empty()) {
+        errors.push_back("Failed to read song metadata file: " + song_json_path.string());
+        return std::nullopt;
+    }
+
+    song_meta meta;
+
+    const std::optional<std::string> song_id = extract_json_string(content, "songId");
+    const std::optional<std::string> title = extract_json_string(content, "title");
+    const std::optional<std::string> artist = extract_json_string(content, "artist");
+    const std::optional<std::string> audio_file = extract_json_string(content, "audioFile");
+    const std::optional<std::string> jacket_file = extract_json_string(content, "jacketFile");
+    const std::optional<std::string> difficulty_bpm = extract_json_number_token(content, "baseBpm");
+    const std::optional<std::string> preview_start_ms = extract_json_number_token(content, "previewStartMs");
+    const std::optional<std::string> song_version = extract_json_number_token(content, "songVersion");
+
+    if (!song_id.has_value()) {
+        errors.push_back("Missing required field songId in " + song_json_path.string());
+    } else {
+        meta.song_id = *song_id;
+    }
+
+    if (!title.has_value()) {
+        errors.push_back("Missing required field title in " + song_json_path.string());
+    } else {
+        meta.title = *title;
+    }
+
+    if (!artist.has_value()) {
+        errors.push_back("Missing required field artist in " + song_json_path.string());
+    } else {
+        meta.artist = *artist;
+    }
+
+    if (!audio_file.has_value()) {
+        errors.push_back("Missing required field audioFile in " + song_json_path.string());
+    } else {
+        meta.audio_file = *audio_file;
+    }
+
+    if (!jacket_file.has_value()) {
+        errors.push_back("Missing required field jacketFile in " + song_json_path.string());
+    } else {
+        meta.jacket_file = *jacket_file;
+    }
+
+    if (!difficulty_bpm.has_value()) {
+        errors.push_back("Missing required field baseBpm in " + song_json_path.string());
+    } else {
+        const std::optional<float> parsed = parse_float(*difficulty_bpm);
+        if (!parsed.has_value()) {
+            errors.push_back("baseBpm must be a number in " + song_json_path.string());
+        } else {
+            meta.base_bpm = *parsed;
+        }
+    }
+
+    if (!preview_start_ms.has_value()) {
+        errors.push_back("Missing required field previewStartMs in " + song_json_path.string());
+    } else {
+        const std::optional<int> parsed = parse_int(*preview_start_ms);
+        if (!parsed.has_value()) {
+            errors.push_back("previewStartMs must be an integer in " + song_json_path.string());
+        } else {
+            meta.preview_start_ms = *parsed;
+        }
+    }
+
+    if (!song_version.has_value()) {
+        errors.push_back("Missing required field songVersion in " + song_json_path.string());
+    } else {
+        const std::optional<int> parsed = parse_int(*song_version);
+        if (!parsed.has_value()) {
+            errors.push_back("songVersion must be an integer in " + song_json_path.string());
+        } else {
+            meta.song_version = *parsed;
+        }
+    }
+
+    if (!errors.empty()) {
+        return std::nullopt;
+    }
+
+    return meta;
+}
+}
+
+song_load_result song_loader::load_all(const std::string& songs_dir) {
+    song_load_result result;
+    const fs::path root = songs_dir;
+
+    if (!fs::exists(root) || !fs::is_directory(root)) {
+        result.errors.push_back("Songs directory does not exist: " + root.string());
+        return result;
+    }
+
+    for (const fs::directory_entry& entry : fs::directory_iterator(root)) {
+        if (!entry.is_directory()) {
+            continue;
+        }
+
+        const fs::path song_dir = entry.path();
+        const fs::path song_json_path = song_dir / "song.json";
+        if (!fs::exists(song_json_path)) {
+            result.errors.push_back("Skipping " + song_dir.string() + ": missing song.json");
+            continue;
+        }
+
+        std::vector<std::string> song_errors;
+        const std::optional<song_meta> meta = parse_song_meta(song_json_path, song_errors);
+        if (!meta.has_value()) {
+            result.errors.insert(result.errors.end(), song_errors.begin(), song_errors.end());
+            continue;
+        }
+
+        const fs::path charts_dir = song_dir / "charts";
+        if (!fs::exists(charts_dir) || !fs::is_directory(charts_dir)) {
+            result.errors.push_back("Skipping " + song_dir.string() + ": missing charts directory");
+            continue;
+        }
+
+        song_data song;
+        song.meta = *meta;
+        song.directory = song_dir.string();
+
+        for (const fs::directory_entry& chart_entry : fs::directory_iterator(charts_dir)) {
+            if (!chart_entry.is_regular_file()) {
+                continue;
+            }
+
+            if (chart_entry.path().extension() == ".chart") {
+                song.chart_paths.push_back(chart_entry.path().string());
+            }
+        }
+
+        if (song.chart_paths.empty()) {
+            result.errors.push_back("Skipping " + song_dir.string() + ": no chart files found");
+            continue;
+        }
+
+        std::sort(song.chart_paths.begin(), song.chart_paths.end());
+        result.songs.push_back(song);
+    }
+
+    std::sort(result.songs.begin(), result.songs.end(), [](const song_data& left, const song_data& right) {
+        return left.meta.title < right.meta.title;
+    });
+
+    return result;
+}
+
+chart_parse_result song_loader::load_chart(const std::string& path) {
+    return chart_parser::parse(path);
+}

--- a/src/song_loader.h
+++ b/src/song_loader.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+
+#include "chart_parser.h"
+#include "data_models.h"
+
+class song_loader {
+public:
+    static song_load_result load_all(const std::string& songs_dir);
+    static chart_parse_result load_chart(const std::string& path);
+};

--- a/src/song_loader_smoke.cpp
+++ b/src/song_loader_smoke.cpp
@@ -1,0 +1,60 @@
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+
+#include "song_loader.h"
+
+namespace {
+std::string songs_root() {
+    const std::filesystem::path repo_root = std::filesystem::path(__FILE__).parent_path().parent_path();
+    return (repo_root / "assets" / "songs").string();
+}
+}
+
+int main() {
+    const song_load_result load_result = song_loader::load_all(songs_root());
+
+    bool ok = true;
+    if (load_result.songs.size() != 1) {
+        std::cerr << "Expected exactly 1 valid song, got " << load_result.songs.size() << '\n';
+        ok = false;
+    }
+
+    if (load_result.errors.size() < 2) {
+        std::cerr << "Expected aggregated errors for invalid songs\n";
+        ok = false;
+    }
+
+    if (ok) {
+        const song_data& song = load_result.songs.front();
+        if (song.meta.song_id != "sample-song") {
+            std::cerr << "Unexpected song id: " << song.meta.song_id << '\n';
+            ok = false;
+        }
+
+        if (song.chart_paths.size() != 1) {
+            std::cerr << "Expected exactly 1 chart path, got " << song.chart_paths.size() << '\n';
+            ok = false;
+        } else {
+            const chart_parse_result chart_result = song_loader::load_chart(song.chart_paths.front());
+            if (!chart_result.success || !chart_result.data.has_value()) {
+                std::cerr << "Expected deferred chart load to succeed\n";
+                for (const std::string& error : chart_result.errors) {
+                    std::cerr << "  " << error << '\n';
+                }
+                ok = false;
+            }
+        }
+    }
+
+    if (!ok) {
+        for (const std::string& error : load_result.errors) {
+            std::cerr << "  " << error << '\n';
+        }
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "song_loader smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- song_data / song_load_result と song_loader を追加
- song.json の先読みと chart パス収集、譜面の遅延ロードを実装
- smoke test 用の楽曲ディレクトリと song_loader_smoke を追加

## 確認
- song_loader_smoke のビルドと実行を確認済み
- 不正な楽曲がスキップされ、エラーが集約されることを確認

Closes #6