### PR TITLE
入力ハンドラーの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ add_executable(raythm src/main.cpp
         src/chart_parser.cpp
         src/chart_parser.h
         src/data_models.h
+        src/input_handler.cpp
+        src/input_handler.h
         src/song_loader.cpp
         src/song_loader.h
         src/scene.cpp
@@ -41,9 +43,15 @@ add_executable(song_loader_smoke
         src/song_loader.h
         src/song_loader_smoke.cpp)
 
+add_executable(input_handler_smoke
+        src/input_handler.cpp
+        src/input_handler.h
+        src/input_handler_smoke.cpp)
+
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass)
 target_link_libraries(raythm PRIVATE raylib ${CMAKE_SOURCE_DIR}/libs/bass/bass.lib)
+target_link_libraries(input_handler_smoke PRIVATE raylib)
 
 # bass.dll を実行ファイルと同じディレクトリにコピー
 add_custom_command(TARGET raythm POST_BUILD

--- a/src/input_handler.cpp
+++ b/src/input_handler.cpp
@@ -1,0 +1,79 @@
+#include "input_handler.h"
+
+#include <algorithm>
+#include <stdexcept>
+
+std::span<const KeyboardKey> key_config::get_lane_keys(int key_count) const {
+    if (key_count == 4) {
+        return std::span<const KeyboardKey>(keys_4);
+    }
+
+    if (key_count == 6) {
+        return std::span<const KeyboardKey>(keys_6);
+    }
+
+    throw std::invalid_argument("key_count must be 4 or 6");
+}
+
+input_handler::input_handler(key_config config) : key_config_(config) {
+}
+
+void input_handler::set_key_count(int key_count) {
+    if (key_count != 4 && key_count != 6) {
+        throw std::invalid_argument("key_count must be 4 or 6");
+    }
+
+    key_count_ = key_count;
+    prev_state_.fill(false);
+    curr_state_.fill(false);
+}
+
+void input_handler::update() {
+    std::array<bool, kMaxLanes> next_state = {};
+    const std::span<const KeyboardKey> lane_keys = key_config_.get_lane_keys(key_count_);
+
+    for (int lane = 0; lane < key_count_; ++lane) {
+        next_state[static_cast<size_t>(lane)] = IsKeyDown(lane_keys[static_cast<size_t>(lane)]);
+    }
+
+    prev_state_ = curr_state_;
+    curr_state_ = next_state;
+}
+
+void input_handler::update_from_lane_states(std::span<const bool> lane_states) {
+    if (lane_states.size() != static_cast<size_t>(key_count_)) {
+        throw std::invalid_argument("lane_states size must match key_count");
+    }
+
+    std::array<bool, kMaxLanes> next_state = {};
+    std::copy(lane_states.begin(), lane_states.end(), next_state.begin());
+
+    prev_state_ = curr_state_;
+    curr_state_ = next_state;
+}
+
+bool input_handler::is_lane_just_pressed(int lane) const {
+    if (lane < 0 || lane >= key_count_) {
+        return false;
+    }
+
+    const size_t index = static_cast<size_t>(lane);
+    return curr_state_[index] && !prev_state_[index];
+}
+
+bool input_handler::is_lane_held(int lane) const {
+    if (lane < 0 || lane >= key_count_) {
+        return false;
+    }
+
+    return curr_state_[static_cast<size_t>(lane)];
+}
+
+bool input_handler::is_lane_just_released(int lane) const {
+    if (lane < 0 || lane >= key_count_) {
+        return false;
+    }
+
+    const size_t index = static_cast<size_t>(lane);
+    return !curr_state_[index] && prev_state_[index];
+}

--- a/src/input_handler.h
+++ b/src/input_handler.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <array>
+#include <span>
+
+#include "raylib.h"
+
+struct key_config {
+    std::array<KeyboardKey, 4> keys_4 = {KEY_D, KEY_F, KEY_J, KEY_K};
+    std::array<KeyboardKey, 6> keys_6 = {KEY_S, KEY_D, KEY_F, KEY_J, KEY_K, KEY_L};
+
+    std::span<const KeyboardKey> get_lane_keys(int key_count) const;
+};
+
+class input_handler {
+public:
+    explicit input_handler(key_config config = {});
+
+    void set_key_count(int key_count);
+    void update();
+    void update_from_lane_states(std::span<const bool> lane_states);
+
+    bool is_lane_just_pressed(int lane) const;
+    bool is_lane_held(int lane) const;
+    bool is_lane_just_released(int lane) const;
+
+private:
+    static constexpr int kMaxLanes = 6;
+
+    key_config key_config_;
+    int key_count_ = 4;
+    std::array<bool, kMaxLanes> prev_state_ = {};
+    std::array<bool, kMaxLanes> curr_state_ = {};
+};

--- a/src/input_handler_smoke.cpp
+++ b/src/input_handler_smoke.cpp
@@ -1,0 +1,38 @@
+#include <array>
+#include <cstdlib>
+#include <iostream>
+
+#include "input_handler.h"
+
+int main() {
+    input_handler handler;
+
+    handler.update_from_lane_states(std::array<bool, 4>{false, false, false, false});
+    handler.update_from_lane_states(std::array<bool, 4>{true, false, false, false});
+    if (!handler.is_lane_just_pressed(0) || !handler.is_lane_held(0) || handler.is_lane_just_released(0)) {
+        std::cerr << "4-key press detection failed\n";
+        return EXIT_FAILURE;
+    }
+
+    handler.update_from_lane_states(std::array<bool, 4>{true, false, false, false});
+    if (handler.is_lane_just_pressed(0) || !handler.is_lane_held(0) || handler.is_lane_just_released(0)) {
+        std::cerr << "Hold detection failed\n";
+        return EXIT_FAILURE;
+    }
+
+    handler.update_from_lane_states(std::array<bool, 4>{false, false, false, false});
+    if (handler.is_lane_just_pressed(0) || handler.is_lane_held(0) || !handler.is_lane_just_released(0)) {
+        std::cerr << "Release detection failed\n";
+        return EXIT_FAILURE;
+    }
+
+    handler.set_key_count(6);
+    handler.update_from_lane_states(std::array<bool, 6>{false, false, false, false, false, true});
+    if (!handler.is_lane_just_pressed(5) || !handler.is_lane_held(5) || handler.is_lane_just_released(5)) {
+        std::cerr << "6-key mode detection failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "input_handler smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- key_config と input_handler を追加
- 前フレーム/現フレーム差分で押下・保持・離し判定を実装
- 4キー/6キー切替と smoke test 用 executable を追加

## 確認
- input_handler_smoke のビルドと実行を確認済み
- 4キー/6キーで press / hold / release が検出できることを確認

Closes #8