### PR TITLE
タイミングエンジンの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(raythm src/main.cpp
         src/input_handler.h
         src/song_loader.cpp
         src/song_loader.h
+        src/timing_engine.cpp
+        src/timing_engine.h
         src/scene.cpp
         src/scene.h
         src/scene_manager.cpp
@@ -47,6 +49,12 @@ add_executable(input_handler_smoke
         src/input_handler.cpp
         src/input_handler.h
         src/input_handler_smoke.cpp)
+
+add_executable(timing_engine_smoke
+        src/data_models.h
+        src/timing_engine.cpp
+        src/timing_engine.h
+        src/timing_engine_smoke.cpp)
 
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass)

--- a/src/timing_engine.cpp
+++ b/src/timing_engine.cpp
@@ -1,0 +1,107 @@
+#include "timing_engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+
+namespace {
+double tick_delta_to_ms(int tick_delta, float bpm, int resolution) {
+    return static_cast<double>(tick_delta) * 60000.0 / (static_cast<double>(resolution) * static_cast<double>(bpm));
+}
+}
+
+void timing_engine::init(std::vector<timing_event> events, int resolution) {
+    if (resolution <= 0) {
+        throw std::invalid_argument("resolution must be greater than zero");
+    }
+
+    resolution_ = resolution;
+    bpm_segments_.clear();
+
+    std::vector<timing_event> bpm_events;
+    for (const timing_event& event : events) {
+        if (event.type == timing_event_type::bpm) {
+            bpm_events.push_back(event);
+        }
+    }
+
+    std::sort(bpm_events.begin(), bpm_events.end(), [](const timing_event& left, const timing_event& right) {
+        if (left.tick != right.tick) {
+            return left.tick < right.tick;
+        }
+        return left.bpm < right.bpm;
+    });
+
+    if (bpm_events.empty() || bpm_events.front().tick != 0) {
+        bpm_segments_.push_back({0, 0.0, 120.0f});
+    }
+
+    for (const timing_event& event : bpm_events) {
+        if (event.bpm <= 0.0f) {
+            throw std::invalid_argument("bpm must be greater than zero");
+        }
+
+        if (!bpm_segments_.empty() && bpm_segments_.back().start_tick == event.tick) {
+            bpm_segments_.back().bpm = event.bpm;
+            continue;
+        }
+
+        bpm_segment segment;
+        segment.start_tick = event.tick;
+        segment.bpm = event.bpm;
+
+        if (bpm_segments_.empty()) {
+            segment.start_ms = 0.0;
+        } else {
+            const bpm_segment& previous = bpm_segments_.back();
+            segment.start_ms = previous.start_ms +
+                               tick_delta_to_ms(event.tick - previous.start_tick, previous.bpm, resolution_);
+        }
+
+        bpm_segments_.push_back(segment);
+    }
+
+    if (bpm_segments_.empty()) {
+        bpm_segments_.push_back({0, 0.0, 120.0f});
+    }
+}
+
+double timing_engine::tick_to_ms(int tick) const {
+    if (tick < 0) {
+        throw std::invalid_argument("tick must be zero or greater");
+    }
+
+    const auto upper = std::upper_bound(
+        bpm_segments_.begin(), bpm_segments_.end(), tick,
+        [](int target_tick, const bpm_segment& segment) { return target_tick < segment.start_tick; });
+    const bpm_segment& segment = upper == bpm_segments_.begin() ? bpm_segments_.front() : *std::prev(upper);
+
+    return segment.start_ms + tick_delta_to_ms(tick - segment.start_tick, segment.bpm, resolution_);
+}
+
+int timing_engine::ms_to_tick(double ms) const {
+    if (ms < 0.0) {
+        throw std::invalid_argument("ms must be zero or greater");
+    }
+
+    const auto upper = std::upper_bound(
+        bpm_segments_.begin(), bpm_segments_.end(), ms,
+        [](double target_ms, const bpm_segment& segment) { return target_ms < segment.start_ms; });
+    const bpm_segment& segment = upper == bpm_segments_.begin() ? bpm_segments_.front() : *std::prev(upper);
+
+    const double tick_delta = ms * 0.0 + (ms - segment.start_ms) * static_cast<double>(resolution_) *
+                              static_cast<double>(segment.bpm) / 60000.0;
+    return segment.start_tick + static_cast<int>(std::lround(tick_delta));
+}
+
+float timing_engine::get_bpm_at(int tick) const {
+    if (tick < 0) {
+        throw std::invalid_argument("tick must be zero or greater");
+    }
+
+    const auto upper = std::upper_bound(
+        bpm_segments_.begin(), bpm_segments_.end(), tick,
+        [](int target_tick, const bpm_segment& segment) { return target_tick < segment.start_tick; });
+    const bpm_segment& segment = upper == bpm_segments_.begin() ? bpm_segments_.front() : *std::prev(upper);
+    return segment.bpm;
+}

--- a/src/timing_engine.h
+++ b/src/timing_engine.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <vector>
+
+#include "data_models.h"
+
+class timing_engine {
+public:
+    void init(std::vector<timing_event> events, int resolution);
+    double tick_to_ms(int tick) const;
+    int ms_to_tick(double ms) const;
+    float get_bpm_at(int tick) const;
+
+private:
+    struct bpm_segment {
+        int start_tick = 0;
+        double start_ms = 0.0;
+        float bpm = 120.0f;
+    };
+
+    std::vector<bpm_segment> bpm_segments_;
+    int resolution_ = 480;
+};

--- a/src/timing_engine_smoke.cpp
+++ b/src/timing_engine_smoke.cpp
@@ -1,0 +1,78 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "timing_engine.h"
+
+namespace {
+bool nearly_equal(double left, double right) {
+    return std::fabs(left - right) < 0.001;
+}
+}
+
+int main() {
+    timing_engine engine;
+
+    std::vector<timing_event> events = {
+        {timing_event_type::bpm, 0, 120.0f, 4, 4},
+        {timing_event_type::meter, 0, 0.0f, 4, 4},
+        {timing_event_type::bpm, 480, 240.0f, 4, 4},
+        {timing_event_type::bpm, 960, 60.0f, 4, 4},
+    };
+
+    engine.init(events, 480);
+
+    if (!nearly_equal(engine.tick_to_ms(0), 0.0)) {
+        std::cerr << "tick_to_ms at 0 failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!nearly_equal(engine.tick_to_ms(480), 500.0)) {
+        std::cerr << "tick_to_ms at first bpm change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!nearly_equal(engine.tick_to_ms(960), 750.0)) {
+        std::cerr << "tick_to_ms at second bpm change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!nearly_equal(engine.tick_to_ms(1440), 1750.0)) {
+        std::cerr << "tick_to_ms after second bpm change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (engine.ms_to_tick(500.0) != 480) {
+        std::cerr << "ms_to_tick at first bpm change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (engine.ms_to_tick(750.0) != 960) {
+        std::cerr << "ms_to_tick at second bpm change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (engine.ms_to_tick(1750.0) != 1440) {
+        std::cerr << "ms_to_tick after second bpm change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (engine.get_bpm_at(0) != 120.0f || engine.get_bpm_at(479) != 120.0f) {
+        std::cerr << "get_bpm_at before change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (engine.get_bpm_at(480) != 240.0f || engine.get_bpm_at(959) != 240.0f) {
+        std::cerr << "get_bpm_at first change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (engine.get_bpm_at(960) != 60.0f) {
+        std::cerr << "get_bpm_at second change failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "timing_engine smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- 	iming_engine を追加し、tick と ms の相互変換を実装
- BPM変更を考慮した 	ick_to_ms / ms_to_tick / get_bpm_at を実装
- 複数 BPM 変更を含む 	iming_engine_smoke を追加

## 確認
- 	iming_engine_smoke のビルドと実行を確認済み
- 単一 BPM と複数 BPM 変更を含む変換結果を確認

Closes #9