### PR TITLE
判定システムの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,8 @@ add_executable(raythm src/main.cpp
         src/data_models.h
         src/input_handler.cpp
         src/input_handler.h
+        src/judge_system.cpp
+        src/judge_system.h
         src/song_loader.cpp
         src/song_loader.h
         src/timing_engine.cpp
@@ -56,10 +58,21 @@ add_executable(timing_engine_smoke
         src/timing_engine.h
         src/timing_engine_smoke.cpp)
 
+add_executable(judge_system_smoke
+        src/data_models.h
+        src/input_handler.cpp
+        src/input_handler.h
+        src/judge_system.cpp
+        src/judge_system.h
+        src/judge_system_smoke.cpp
+        src/timing_engine.cpp
+        src/timing_engine.h)
+
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass)
 target_link_libraries(raythm PRIVATE raylib ${CMAKE_SOURCE_DIR}/libs/bass/bass.lib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
+target_link_libraries(judge_system_smoke PRIVATE raylib)
 
 # bass.dll を実行ファイルと同じディレクトリにコピー
 add_custom_command(TARGET raythm POST_BUILD

--- a/src/data_models.h
+++ b/src/data_models.h
@@ -93,6 +93,22 @@ enum class judge_result {
     miss
 };
 
+// 判定処理用に保持する各ノートの状態。
+struct note_state {
+    note_data note_ref;
+    double target_ms = 0.0;
+    bool judged = false;
+    judge_result result = judge_result::miss;
+    bool holding = false;
+};
+
+// 1 件の判定イベント。
+struct judge_event {
+    judge_result result = judge_result::miss;
+    double offset_ms = 0.0;
+    int lane = 0;
+};
+
 // 達成率に応じたランク種別。
 enum class rank {
     ss,

--- a/src/judge_system.cpp
+++ b/src/judge_system.cpp
@@ -1,0 +1,115 @@
+#include "judge_system.h"
+
+#include <cmath>
+
+void judge_system::init(const std::vector<note_data>& notes, const timing_engine& engine) {
+    note_states_.clear();
+    note_states_.reserve(notes.size());
+    last_judge_.reset();
+
+    for (const note_data& note : notes) {
+        note_state state;
+        state.note_ref = note;
+        state.target_ms = engine.tick_to_ms(note.tick);
+        note_states_.push_back(state);
+    }
+}
+
+void judge_system::update(double current_ms, const input_handler& input) {
+    last_judge_.reset();
+
+    for (note_state& state : note_states_) {
+        if (state.note_ref.type == note_type::hold && state.holding &&
+            input.is_lane_just_released(state.note_ref.lane)) {
+            state.holding = false;
+            state.judged = true;
+            state.result = judge_result::miss;
+            emit_judge(judge_result::miss, current_ms - state.target_ms, state.note_ref.lane);
+            return;
+        }
+    }
+
+    for (int lane = 0; lane < 6; ++lane) {
+        if (!input.is_lane_just_pressed(lane)) {
+            continue;
+        }
+
+        note_state* candidate = nullptr;
+        for (note_state& state : note_states_) {
+            if (state.judged || state.note_ref.lane != lane) {
+                continue;
+            }
+
+            const double offset_ms = current_ms - state.target_ms;
+            if (offset_ms < -judge_windows_[3]) {
+                continue;
+            }
+
+            if (!is_in_judgement_window(offset_ms)) {
+                continue;
+            }
+
+            candidate = &state;
+            break;
+        }
+
+        if (candidate == nullptr) {
+            continue;
+        }
+
+        const double offset_ms = current_ms - candidate->target_ms;
+        const judge_result result = evaluate_offset(offset_ms);
+        candidate->judged = true;
+        candidate->result = result;
+        candidate->holding = candidate->note_ref.type == note_type::hold && result != judge_result::miss;
+        emit_judge(result, offset_ms, lane);
+        return;
+    }
+
+    for (note_state& state : note_states_) {
+        if (state.judged) {
+            continue;
+        }
+
+        const double offset_ms = current_ms - state.target_ms;
+        if (offset_ms > judge_windows_[3]) {
+            state.judged = true;
+            state.result = judge_result::miss;
+            emit_judge(judge_result::miss, offset_ms, state.note_ref.lane);
+            return;
+        }
+    }
+}
+
+std::optional<judge_event> judge_system::get_last_judge() const {
+    return last_judge_;
+}
+
+std::vector<note_state> judge_system::get_note_states() const {
+    return note_states_;
+}
+
+judge_result judge_system::evaluate_offset(double offset_ms) const {
+    const double absolute_offset = std::fabs(offset_ms);
+    if (absolute_offset <= judge_windows_[0]) {
+        return judge_result::perfect;
+    }
+    if (absolute_offset <= judge_windows_[1]) {
+        return judge_result::great;
+    }
+    if (absolute_offset <= judge_windows_[2]) {
+        return judge_result::good;
+    }
+    if (absolute_offset <= judge_windows_[3]) {
+        return judge_result::bad;
+    }
+    return judge_result::miss;
+}
+
+bool judge_system::is_in_judgement_window(double offset_ms) const {
+    return std::fabs(offset_ms) <= judge_windows_[3];
+}
+
+void judge_system::emit_judge(judge_result result, double offset_ms, int lane) {
+    last_judge_ = judge_event{result, offset_ms, lane};
+}

--- a/src/judge_system.h
+++ b/src/judge_system.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+#include <optional>
+#include <vector>
+
+#include "data_models.h"
+#include "input_handler.h"
+#include "timing_engine.h"
+
+class judge_system {
+public:
+    void init(const std::vector<note_data>& notes, const timing_engine& engine);
+    void update(double current_ms, const input_handler& input);
+    std::optional<judge_event> get_last_judge() const;
+    std::vector<note_state> get_note_states() const;
+
+private:
+    judge_result evaluate_offset(double offset_ms) const;
+    bool is_in_judgement_window(double offset_ms) const;
+    void emit_judge(judge_result result, double offset_ms, int lane);
+
+    std::array<double, 5> judge_windows_ = {25.0, 50.0, 90.0, 130.0, 130.0};
+    std::vector<note_state> note_states_;
+    std::optional<judge_event> last_judge_;
+};

--- a/src/judge_system_smoke.cpp
+++ b/src/judge_system_smoke.cpp
@@ -1,0 +1,69 @@
+#include <array>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "judge_system.h"
+
+int main() {
+    timing_engine engine;
+    engine.init({timing_event{timing_event_type::bpm, 0, 120.0f, 4, 4}}, 480);
+
+    std::vector<note_data> notes = {
+        {note_type::tap, 480, 0, 480},
+        {note_type::hold, 960, 1, 1440},
+        {note_type::tap, 960, 2, 960},
+    };
+
+    judge_system judge;
+    judge.init(notes, engine);
+
+    input_handler input;
+    input.set_key_count(4);
+    input.update_from_lane_states(std::array<bool, 4>{false, false, false, false});
+
+    input.update_from_lane_states(std::array<bool, 4>{true, false, false, false});
+    judge.update(500.0, input);
+    const std::optional<judge_event> tap_judge = judge.get_last_judge();
+    if (!tap_judge.has_value() || tap_judge->result != judge_result::perfect || tap_judge->lane != 0) {
+        std::cerr << "Tap perfect judge failed\n";
+        return EXIT_FAILURE;
+    }
+
+    input.update_from_lane_states(std::array<bool, 4>{false, true, true, false});
+    judge.update(1000.0, input);
+    const std::optional<judge_event> simultaneous_judge = judge.get_last_judge();
+    if (!simultaneous_judge.has_value() || simultaneous_judge->lane != 1) {
+        std::cerr << "Simultaneous press judge failed\n";
+        return EXIT_FAILURE;
+    }
+
+    judge.update(1000.0, input);
+    const std::optional<judge_event> second_simultaneous_judge = judge.get_last_judge();
+    if (!second_simultaneous_judge.has_value() || second_simultaneous_judge->lane != 2) {
+        std::cerr << "Independent simultaneous judge failed\n";
+        return EXIT_FAILURE;
+    }
+
+    input.update_from_lane_states(std::array<bool, 4>{false, false, false, false});
+    judge.update(1100.0, input);
+    const std::optional<judge_event> hold_release_judge = judge.get_last_judge();
+    if (!hold_release_judge.has_value() || hold_release_judge->result != judge_result::miss ||
+        hold_release_judge->lane != 1) {
+        std::cerr << "Hold release miss failed\n";
+        return EXIT_FAILURE;
+    }
+
+    judge_system miss_judge;
+    miss_judge.init({note_data{note_type::tap, 480, 0, 480}}, engine);
+    input.update_from_lane_states(std::array<bool, 4>{false, false, false, false});
+    miss_judge.update(700.0, input);
+    const std::optional<judge_event> auto_miss = miss_judge.get_last_judge();
+    if (!auto_miss.has_value() || auto_miss->result != judge_result::miss) {
+        std::cerr << "Automatic miss failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "judge_system smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- 
ote_state / judge_event と judge_system を追加
- Tap / Hold / Miss 判定と早押し無視、同時押しの独立処理を実装
- judge_system_smoke を追加して判定フローを検証

## 確認
- judge_system_smoke のビルドと実行を確認済み
- Tap perfect / 同時押し / Hold 離し miss / 自動 miss を確認

Closes #10