### PR TITLE
スコア・ゲージシステムの実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(raythm src/main.cpp
         src/input_handler.h
         src/judge_system.cpp
         src/judge_system.h
+        src/score_system.cpp
+        src/score_system.h
         src/song_loader.cpp
         src/song_loader.h
         src/timing_engine.cpp
@@ -67,6 +69,12 @@ add_executable(judge_system_smoke
         src/judge_system_smoke.cpp
         src/timing_engine.cpp
         src/timing_engine.h)
+
+add_executable(score_system_smoke
+        src/data_models.h
+        src/score_system.cpp
+        src/score_system.h
+        src/score_system_smoke.cpp)
 
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass)

--- a/src/score_system.cpp
+++ b/src/score_system.cpp
@@ -1,0 +1,162 @@
+#include "score_system.h"
+
+#include <algorithm>
+
+namespace {
+constexpr int kMaxScore = 1000000;
+constexpr int kPerfectBase = 1000;
+constexpr int kGreatBase = 800;
+constexpr int kGoodBase = 500;
+constexpr int kBadBase = 200;
+constexpr int kMissBase = 0;
+
+size_t judge_index(judge_result result) {
+    switch (result) {
+        case judge_result::perfect:
+            return 0;
+        case judge_result::great:
+            return 1;
+        case judge_result::good:
+            return 2;
+        case judge_result::bad:
+            return 3;
+        case judge_result::miss:
+            return 4;
+    }
+
+    return 4;
+}
+
+int base_score(judge_result result) {
+    switch (result) {
+        case judge_result::perfect:
+            return kPerfectBase;
+        case judge_result::great:
+            return kGreatBase;
+        case judge_result::good:
+            return kGoodBase;
+        case judge_result::bad:
+            return kBadBase;
+        case judge_result::miss:
+            return kMissBase;
+    }
+
+    return 0;
+}
+}
+
+void score_system::init(int total_notes) {
+    total_notes_ = std::max(total_notes, 0);
+    score_ = 0;
+    combo_ = 0;
+    max_combo_ = 0;
+    judge_counts_.fill(0);
+    fast_count_ = 0;
+    slow_count_ = 0;
+    offset_sum_ = 0.0;
+    judged_notes_ = 0;
+}
+
+void score_system::on_judge(const judge_event& event) {
+    ++judge_counts_[judge_index(event.result)];
+    ++judged_notes_;
+
+    if (event.offset_ms < 0.0) {
+        ++fast_count_;
+    } else if (event.offset_ms > 0.0) {
+        ++slow_count_;
+    }
+    offset_sum_ += event.offset_ms;
+
+    if (event.result == judge_result::bad || event.result == judge_result::miss) {
+        combo_ = 0;
+    } else {
+        ++combo_;
+        max_combo_ = std::max(max_combo_, combo_);
+    }
+
+    const int raw = base_score(event.result);
+    const double combo_bonus = 1.0 + std::min(combo_, 100) * 0.002;
+    score_ += static_cast<int>(raw * combo_bonus);
+}
+
+int score_system::get_score() const {
+    return score_;
+}
+
+int score_system::get_combo() const {
+    return combo_;
+}
+
+result_data score_system::get_result_data() const {
+    result_data result;
+    result.score = score_;
+    result.judge_counts = judge_counts_;
+    result.max_combo = max_combo_;
+    result.avg_offset = judged_notes_ > 0 ? static_cast<float>(offset_sum_ / static_cast<double>(judged_notes_)) : 0.0f;
+    result.fast_count = fast_count_;
+    result.slow_count = slow_count_;
+    result.is_full_combo = judge_counts_[judge_index(judge_result::bad)] == 0 &&
+                           judge_counts_[judge_index(judge_result::miss)] == 0;
+    result.is_all_perfect = judged_notes_ > 0 &&
+                            judge_counts_[judge_index(judge_result::perfect)] == judged_notes_;
+
+    const double max_achievement_points = static_cast<double>(std::max(total_notes_, 1) * kPerfectBase);
+    const double earned_achievement_points =
+        static_cast<double>(judge_counts_[judge_index(judge_result::perfect)] * kPerfectBase +
+                            judge_counts_[judge_index(judge_result::great)] * kGreatBase +
+                            judge_counts_[judge_index(judge_result::good)] * kGoodBase +
+                            judge_counts_[judge_index(judge_result::bad)] * kBadBase);
+    result.achievement = static_cast<float>((earned_achievement_points / max_achievement_points) * 100.0);
+
+    if (result.achievement >= 99.0f) {
+        result.clear_rank = rank::ss;
+    } else if (result.achievement >= 95.0f) {
+        result.clear_rank = rank::s;
+    } else if (result.achievement >= 85.0f) {
+        result.clear_rank = rank::a;
+    } else if (result.achievement >= 70.0f) {
+        result.clear_rank = rank::b;
+    } else if (result.achievement >= 50.0f) {
+        result.clear_rank = rank::c;
+    } else {
+        result.clear_rank = rank::f;
+    }
+
+    if (total_notes_ > 0) {
+        const double normalized = static_cast<double>(score_) /
+                                  static_cast<double>(total_notes_ * static_cast<int>(kPerfectBase * 1.2));
+        result.score = static_cast<int>(std::clamp(normalized, 0.0, 1.0) * kMaxScore);
+    }
+
+    return result;
+}
+
+void gauge::on_judge(judge_result result) {
+    switch (result) {
+        case judge_result::perfect:
+            value_ += 2.0f;
+            break;
+        case judge_result::great:
+            value_ += 1.0f;
+            break;
+        case judge_result::good:
+            break;
+        case judge_result::bad:
+            value_ -= 6.0f;
+            break;
+        case judge_result::miss:
+            value_ -= 10.0f;
+            break;
+    }
+
+    value_ = std::clamp(value_, 0.0f, 100.0f);
+}
+
+float gauge::get_value() const {
+    return value_;
+}
+
+bool gauge::is_cleared() const {
+    return value_ >= 70.0f;
+}

--- a/src/score_system.h
+++ b/src/score_system.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <array>
+
+#include "data_models.h"
+
+class score_system {
+public:
+    void init(int total_notes);
+    void on_judge(const judge_event& event);
+    int get_score() const;
+    int get_combo() const;
+    result_data get_result_data() const;
+
+private:
+    int score_ = 0;
+    int combo_ = 0;
+    int max_combo_ = 0;
+    std::array<int, 5> judge_counts_ = {};
+    int total_notes_ = 0;
+    int fast_count_ = 0;
+    int slow_count_ = 0;
+    double offset_sum_ = 0.0;
+    int judged_notes_ = 0;
+};
+
+class gauge {
+public:
+    void on_judge(judge_result result);
+    float get_value() const;
+    bool is_cleared() const;
+
+private:
+    float value_ = 100.0f;
+};

--- a/src/score_system_smoke.cpp
+++ b/src/score_system_smoke.cpp
@@ -1,0 +1,65 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "score_system.h"
+
+int main() {
+    score_system score;
+    score.init(4);
+
+    score.on_judge({judge_result::perfect, -10.0, 0});
+    score.on_judge({judge_result::great, 12.0, 1});
+    score.on_judge({judge_result::good, 40.0, 2});
+    score.on_judge({judge_result::miss, 150.0, 3});
+
+    if (score.get_combo() != 0) {
+        std::cerr << "Combo reset failed\n";
+        return EXIT_FAILURE;
+    }
+
+    const result_data result = score.get_result_data();
+    if (result.max_combo != 3) {
+        std::cerr << "Max combo aggregation failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (result.judge_counts[0] != 1 || result.judge_counts[1] != 1 || result.judge_counts[2] != 1 ||
+        result.judge_counts[4] != 1) {
+        std::cerr << "Judge counts aggregation failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (result.fast_count != 1 || result.slow_count != 3) {
+        std::cerr << "Fast/slow aggregation failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (result.is_full_combo || result.is_all_perfect) {
+        std::cerr << "Result flag aggregation failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (result.score <= 0 || result.achievement <= 0.0f) {
+        std::cerr << "Score normalization failed\n";
+        return EXIT_FAILURE;
+    }
+
+    gauge life_gauge;
+    life_gauge.on_judge(judge_result::perfect);
+    life_gauge.on_judge(judge_result::great);
+    life_gauge.on_judge(judge_result::bad);
+    life_gauge.on_judge(judge_result::miss);
+
+    if (life_gauge.get_value() != 84.0f) {
+        std::cerr << "Gauge accumulation failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!life_gauge.is_cleared()) {
+        std::cerr << "Gauge clear threshold failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "score_system smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- score_system と gauge を追加
- 判定結果からスコア、コンボ、Fast/Slow、リザルト用集計を実装
- ゲージ増減、クリア判定、rank / FullCombo / AllPerfect 算出を実装
- score_system_smoke を追加して集計結果を検証

## 確認
- score_system_smoke のビルドと実行を確認済み
- スコア正規化、コンボ、judge count、Fast/Slow、ゲージ値を確認

Closes #11