### PR TITLE
タイトル画面と設定画面を実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ add_executable(raythm src/main.cpp
         src/core/scene_manager.cpp
         src/core/scene_manager.h
         src/gameplay/game_settings.h
+        src/gameplay/key_names.h
+        src/gameplay/settings_io.cpp
+        src/gameplay/settings_io.h
         src/scenes/scene_common.cpp
         src/scenes/scene_common.h
         src/scenes/title_scene.cpp

--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -1,5 +1,21 @@
 #pragma once
 
+#include "input_handler.h"
+
+// 解像度プリセット
+struct resolution_preset {
+    int width;
+    int height;
+    const char* label;
+};
+
+inline constexpr resolution_preset kResolutionPresets[] = {
+    {1280, 720, "1280x720"},
+    {1920, 1080, "1920x1080"},
+    {2560, 1440, "2560x1440"},
+};
+inline constexpr int kResolutionPresetCount = 3;
+
 // シーン間で共有されるゲーム設定。
 // settings_scene で変更され、play_scene / song_select_scene で参照される。
 struct game_settings {
@@ -8,6 +24,9 @@ struct game_settings {
     float lane_width = 3.5f;
     float note_speed = 0.045f;
     int target_fps = 144;
+    key_config keys;
+    int resolution_index = 1;  // デフォルト 1920x1080
+    bool fullscreen = false;
 };
 
 inline game_settings g_settings;

--- a/src/gameplay/key_names.h
+++ b/src/gameplay/key_names.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include "raylib.h"
+
+// raylib の KeyboardKey 列挙値を表示用文字列に変換する。
+inline const char* get_key_name(int key) {
+    switch (key) {
+        case KEY_A: return "A";
+        case KEY_B: return "B";
+        case KEY_C: return "C";
+        case KEY_D: return "D";
+        case KEY_E: return "E";
+        case KEY_F: return "F";
+        case KEY_G: return "G";
+        case KEY_H: return "H";
+        case KEY_I: return "I";
+        case KEY_J: return "J";
+        case KEY_K: return "K";
+        case KEY_L: return "L";
+        case KEY_M: return "M";
+        case KEY_N: return "N";
+        case KEY_O: return "O";
+        case KEY_P: return "P";
+        case KEY_Q: return "Q";
+        case KEY_R: return "R";
+        case KEY_S: return "S";
+        case KEY_T: return "T";
+        case KEY_U: return "U";
+        case KEY_V: return "V";
+        case KEY_W: return "W";
+        case KEY_X: return "X";
+        case KEY_Y: return "Y";
+        case KEY_Z: return "Z";
+        case KEY_ZERO: return "0";
+        case KEY_ONE: return "1";
+        case KEY_TWO: return "2";
+        case KEY_THREE: return "3";
+        case KEY_FOUR: return "4";
+        case KEY_FIVE: return "5";
+        case KEY_SIX: return "6";
+        case KEY_SEVEN: return "7";
+        case KEY_EIGHT: return "8";
+        case KEY_NINE: return "9";
+        case KEY_SPACE: return "SPACE";
+        case KEY_LEFT_SHIFT: return "L-SHIFT";
+        case KEY_RIGHT_SHIFT: return "R-SHIFT";
+        case KEY_LEFT_CONTROL: return "L-CTRL";
+        case KEY_RIGHT_CONTROL: return "R-CTRL";
+        case KEY_LEFT_ALT: return "L-ALT";
+        case KEY_RIGHT_ALT: return "R-ALT";
+        case KEY_TAB: return "TAB";
+        case KEY_COMMA: return ",";
+        case KEY_PERIOD: return ".";
+        case KEY_SLASH: return "/";
+        case KEY_SEMICOLON: return ";";
+        case KEY_APOSTROPHE: return "'";
+        case KEY_LEFT_BRACKET: return "[";
+        case KEY_RIGHT_BRACKET: return "]";
+        case KEY_BACKSLASH: return "\\";
+        case KEY_MINUS: return "-";
+        case KEY_EQUAL: return "=";
+        case KEY_GRAVE: return "`";
+        case KEY_F1: return "F1";
+        case KEY_F2: return "F2";
+        case KEY_F3: return "F3";
+        case KEY_F4: return "F4";
+        case KEY_F5: return "F5";
+        case KEY_F6: return "F6";
+        case KEY_F7: return "F7";
+        case KEY_F8: return "F8";
+        case KEY_F9: return "F9";
+        case KEY_F10: return "F10";
+        case KEY_F11: return "F11";
+        case KEY_F12: return "F12";
+        case KEY_UP: return "UP";
+        case KEY_DOWN: return "DOWN";
+        case KEY_LEFT: return "LEFT";
+        case KEY_RIGHT: return "RIGHT";
+        default: return "???";
+    }
+}

--- a/src/gameplay/settings_io.cpp
+++ b/src/gameplay/settings_io.cpp
@@ -1,0 +1,157 @@
+#include "settings_io.h"
+
+#include <algorithm>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+
+namespace {
+namespace fs = std::filesystem;
+
+fs::path settings_path() {
+    return fs::path(__FILE__).parent_path().parent_path().parent_path() / "settings.json";
+}
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+// JSON から文字列値を取り出す。
+std::optional<std::string> extract_string(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) return std::nullopt;
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string::npos) return std::nullopt;
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) ++start;
+    if (start >= content.size() || content[start] != '"') return std::nullopt;
+    ++start;
+
+    std::string result;
+    for (size_t i = start; i < content.size(); ++i) {
+        if (content[i] == '"') return result;
+        if (content[i] == '\\' && i + 1 < content.size()) {
+            result += content[++i];
+        } else {
+            result += content[i];
+        }
+    }
+    return std::nullopt;
+}
+
+// JSON から数値トークンを取り出す。
+std::optional<std::string> extract_number_token(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) return std::nullopt;
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string::npos) return std::nullopt;
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) ++start;
+
+    size_t end = start;
+    while (end < content.size() && (std::isdigit(static_cast<unsigned char>(content[end])) ||
+           content[end] == '.' || content[end] == '-' || content[end] == '+')) ++end;
+
+    if (end == start) return std::nullopt;
+    return std::string(content, start, end - start);
+}
+
+// JSON から bool 値を取り出す。
+std::optional<bool> extract_bool(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) return std::nullopt;
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string::npos) return std::nullopt;
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) ++start;
+
+    if (content.compare(start, 4, "true") == 0) return true;
+    if (content.compare(start, 5, "false") == 0) return false;
+    return std::nullopt;
+}
+
+// カンマ区切り整数文字列 → KeyboardKey 配列にパース。
+template <size_t N>
+void parse_key_array(const std::string& csv, std::array<KeyboardKey, N>& keys) {
+    size_t index = 0;
+    std::istringstream stream(csv);
+    std::string token;
+    while (std::getline(stream, token, ',') && index < N) {
+        try {
+            keys[index++] = static_cast<KeyboardKey>(std::stoi(token));
+        } catch (...) {
+            // 不正な値はスキップ
+        }
+    }
+}
+
+// KeyboardKey 配列 → カンマ区切り整数文字列に変換。
+template <size_t N>
+std::string keys_to_csv(const std::array<KeyboardKey, N>& keys) {
+    std::string result;
+    for (size_t i = 0; i < N; ++i) {
+        if (i > 0) result += ',';
+        result += std::to_string(static_cast<int>(keys[i]));
+    }
+    return result;
+}
+
+}  // namespace
+
+void load_settings(game_settings& settings) {
+    const std::string content = read_file(settings_path());
+    if (content.empty()) return;
+
+    if (auto v = extract_number_token(content, "cameraAngle"))
+        settings.camera_angle_degrees = std::clamp(std::stof(*v), 5.0f, 90.0f);
+    if (auto v = extract_number_token(content, "laneWidth"))
+        settings.lane_width = std::clamp(std::stof(*v), 0.6f, 5.0f);
+    if (auto v = extract_number_token(content, "noteSpeed"))
+        settings.note_speed = std::clamp(std::stof(*v), 0.020f, 0.090f);
+    if (auto v = extract_number_token(content, "targetFps"))
+        settings.target_fps = std::stoi(*v);
+    if (auto v = extract_number_token(content, "resolutionIndex"))
+        settings.resolution_index = std::clamp(std::stoi(*v), 0, kResolutionPresetCount - 1);
+    if (auto v = extract_bool(content, "fullscreen"))
+        settings.fullscreen = *v;
+
+    if (auto v = extract_string(content, "keys4"))
+        parse_key_array(*v, settings.keys.keys_4);
+    if (auto v = extract_string(content, "keys6"))
+        parse_key_array(*v, settings.keys.keys_6);
+}
+
+void save_settings(const game_settings& settings) {
+    std::ofstream out(settings_path());
+    if (!out.is_open()) return;
+
+    out << "{\n";
+    out << "  \"cameraAngle\": " << settings.camera_angle_degrees << ",\n";
+    out << "  \"laneWidth\": " << settings.lane_width << ",\n";
+    out << "  \"noteSpeed\": " << settings.note_speed << ",\n";
+    out << "  \"targetFps\": " << settings.target_fps << ",\n";
+    out << "  \"resolutionIndex\": " << settings.resolution_index << ",\n";
+    out << "  \"fullscreen\": " << (settings.fullscreen ? "true" : "false") << ",\n";
+    out << "  \"keys4\": \"" << keys_to_csv(settings.keys.keys_4) << "\",\n";
+    out << "  \"keys6\": \"" << keys_to_csv(settings.keys.keys_6) << "\"\n";
+    out << "}\n";
+}

--- a/src/gameplay/settings_io.h
+++ b/src/gameplay/settings_io.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "game_settings.h"
+
+// settings.json からゲーム設定を読み込む。ファイルが存在しない場合はデフォルト値のまま。
+void load_settings(game_settings& settings);
+
+// ゲーム設定を settings.json に書き出す。
+void save_settings(const game_settings& settings);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,13 +2,21 @@
 #include "game_settings.h"
 #include "raylib.h"
 #include "scene_manager.h"
+#include "settings_io.h"
 #include "virtual_screen.h"
 
 int main() {
-    InitWindow(1311, 603, "raythm");
+    load_settings(g_settings);
+
+    const resolution_preset& preset = kResolutionPresets[g_settings.resolution_index];
+    InitWindow(preset.width, preset.height, "raythm");
     SetTraceLogLevel(LOG_WARNING);
     SetTargetFPS(g_settings.target_fps);
     SetExitKey(KEY_NULL);
+
+    if (g_settings.fullscreen) {
+        ToggleFullscreen();
+    }
 
     virtual_screen::init();
 

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -152,6 +152,7 @@ play_scene::play_scene(scene_manager& manager, song_data song, std::string chart
 void play_scene::on_enter() {
     camera_angle_degrees_ = g_settings.camera_angle_degrees;
     lane_speed_ = g_settings.note_speed;
+    input_handler_ = input_handler(g_settings.keys);
     input_handler_.set_key_count(key_count_);
 
     if (!song_data_.has_value()) {

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -2,83 +2,454 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <memory>
+#include <span>
 
 #include "game_settings.h"
+#include "key_names.h"
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
+#include "settings_io.h"
+#include "song_select_scene.h"
 #include "title_scene.h"
 #include "virtual_screen.h"
 
-settings_scene::settings_scene(scene_manager& manager) : scene(manager) {
+namespace {
+constexpr int kPageCount = 2;
+const char* kPageNames[] = {"General", "Key Config"};
+constexpr Rectangle kSidebarRect = {24.0f, 44.0f, 256.0f, 660.0f};
+constexpr Rectangle kContentRect = {300.0f, 44.0f, 956.0f, 660.0f};
+constexpr Rectangle kTabRects[kPageCount] = {
+    {48.0f, 196.0f, 208.0f, 42.0f},
+    {48.0f, 246.0f, 208.0f, 42.0f},
+};
+constexpr Rectangle kBackRect = {48.0f, 622.0f, 208.0f, 42.0f};
+constexpr Rectangle kGeneralRows[] = {
+    {330.0f, 170.0f, 890.0f, 64.0f},
+    {330.0f, 248.0f, 890.0f, 64.0f},
+    {330.0f, 326.0f, 890.0f, 64.0f},
+    {330.0f, 404.0f, 890.0f, 64.0f},
+    {330.0f, 482.0f, 890.0f, 64.0f},
+    {330.0f, 560.0f, 890.0f, 64.0f},
+};
+constexpr Rectangle kKeyModeRect = {330.0f, 170.0f, 890.0f, 64.0f};
+constexpr float kSliderLeft = 548.0f;
+constexpr float kSliderWidth = 630.0f;
+constexpr float kSliderTopOffset = 34.0f;
+constexpr float kArrowButtonSize = 34.0f;
+
+// キーコンフィグで使用可能なキーかどうか（UIキーと衝突しないもの）。
+bool is_valid_play_key(int key) {
+    return key != KEY_ESCAPE && key != KEY_ENTER && key != KEY_UP && key != KEY_DOWN &&
+           key != KEY_LEFT && key != KEY_RIGHT && key != KEY_BACKSPACE && key != KEY_NULL;
 }
 
-// 左右でカメラ角度、上下でノート速度、Q/Eでレーン幅を調整する。
-void settings_scene::update(float dt) {
-    (void)dt;
+float clamp01(float value) {
+    return std::clamp(value, 0.0f, 1.0f);
+}
 
+Rectangle slider_track_rect(const Rectangle& row_rect) {
+    return {kSliderLeft, row_rect.y + kSliderTopOffset, kSliderWidth, 6.0f};
+}
+
+Rectangle arrow_left_rect(const Rectangle& row_rect) {
+    return {row_rect.x + row_rect.width - 94.0f, row_rect.y + 15.0f, kArrowButtonSize, kArrowButtonSize};
+}
+
+Rectangle arrow_right_rect(const Rectangle& row_rect) {
+    return {row_rect.x + row_rect.width - 50.0f, row_rect.y + 15.0f, kArrowButtonSize, kArrowButtonSize};
+}
+
+float slider_ratio_from_mouse(const Rectangle& row_rect, Vector2 mouse) {
+    const Rectangle track = slider_track_rect(row_rect);
+    return clamp01((mouse.x - track.x) / track.width);
+}
+
+int fps_option_index(int target_fps) {
     constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
-    const bool previous_frame_rate = IsKeyPressed(KEY_Z);
-    const bool next_frame_rate = IsKeyPressed(KEY_X);
+    for (int i = 0; i < static_cast<int>(kFrameRateOptions.size()); ++i) {
+        if (kFrameRateOptions[static_cast<size_t>(i)] == target_fps) {
+            return i;
+        }
+    }
+    return 1;
+}
 
-    if (IsKeyPressed(KEY_LEFT)) {
-        g_settings.camera_angle_degrees = std::max(5.0f, g_settings.camera_angle_degrees - 5.0f);
-    } else if (IsKeyPressed(KEY_RIGHT)) {
-        g_settings.camera_angle_degrees = std::min(90.0f, g_settings.camera_angle_degrees + 5.0f);
+Color lerp_color(Color from, Color to, float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    return {
+        static_cast<unsigned char>(from.r + (to.r - from.r) * clamped),
+        static_cast<unsigned char>(from.g + (to.g - from.g) * clamped),
+        static_cast<unsigned char>(from.b + (to.b - from.b) * clamped),
+        static_cast<unsigned char>(from.a + (to.a - from.a) * clamped),
+    };
+}
+
+Rectangle inset_rect(Rectangle rect, float amount) {
+    return {rect.x + amount, rect.y + amount, rect.width - amount * 2.0f, rect.height - amount * 2.0f};
+}
+}  // namespace
+
+settings_scene::settings_scene(scene_manager& manager, return_target target) : scene(manager), return_target_(target) {
+}
+
+void settings_scene::update(float dt) {
+    error_timer_ = std::max(0.0f, error_timer_ - dt);
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+
+    // リスニング中はページ切り替え・画面遷移を無効にする
+    if (listening_) {
+        update_key_config();
+        return;
     }
 
-    if (IsKeyPressed(KEY_UP)) {
-        g_settings.note_speed = std::min(0.090f, g_settings.note_speed + 0.005f);
-    } else if (IsKeyPressed(KEY_DOWN)) {
-        g_settings.note_speed = std::max(0.020f, g_settings.note_speed - 0.005f);
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, kBackRect)) {
+        save_settings(g_settings);
+        if (return_target_ == return_target::song_select) {
+            manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+        } else {
+            manager_.change_scene(std::make_unique<title_scene>(manager_));
+        }
+        return;
     }
 
-    if (IsKeyPressed(KEY_Q)) {
-        g_settings.lane_width = std::max(0.6f, g_settings.lane_width - 0.2f);
-    } else if (IsKeyPressed(KEY_E)) {
-        g_settings.lane_width = std::min(5.0f, g_settings.lane_width + 0.2f);
-    }
-
-    if (previous_frame_rate || next_frame_rate) {
-        size_t current_index = 0;
-        for (size_t i = 0; i < kFrameRateOptions.size(); ++i) {
-            if (kFrameRateOptions[i] == g_settings.target_fps) {
-                current_index = i;
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        for (int i = 0; i < kPageCount; ++i) {
+            if (CheckCollisionPointRec(mouse, kTabRects[i])) {
+                current_page_ = static_cast<page>(i);
+                key_config_slot_ = -1;
+                listening_ = false;
                 break;
             }
         }
-
-        if (previous_frame_rate) {
-            current_index = (current_index + kFrameRateOptions.size() - 1) % kFrameRateOptions.size();
-        } else {
-            current_index = (current_index + 1) % kFrameRateOptions.size();
-        }
-
-        g_settings.target_fps = kFrameRateOptions[current_index];
     }
 
-    if (IsKeyPressed(KEY_ESCAPE) || IsKeyPressed(KEY_ENTER)) {
-        manager_.change_scene(std::make_unique<title_scene>(manager_));
+    switch (current_page_) {
+        case page::general:
+            update_general();
+            break;
+        case page::key_config:
+            update_key_config();
+            break;
     }
 }
 
-// 現在の設定値と操作案内を表示する。
+void settings_scene::update_general() {
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
+    if (IsKeyPressed(KEY_Z)) {
+        size_t idx = 0;
+        for (size_t i = 0; i < kFrameRateOptions.size(); ++i) {
+            if (kFrameRateOptions[i] == g_settings.target_fps) { idx = i; break; }
+        }
+        idx = (idx + kFrameRateOptions.size() - 1) % kFrameRateOptions.size();
+        g_settings.target_fps = kFrameRateOptions[idx];
+    } else if (IsKeyPressed(KEY_X)) {
+        size_t idx = 0;
+        for (size_t i = 0; i < kFrameRateOptions.size(); ++i) {
+            if (kFrameRateOptions[i] == g_settings.target_fps) { idx = i; break; }
+        }
+        idx = (idx + 1) % kFrameRateOptions.size();
+        g_settings.target_fps = kFrameRateOptions[idx];
+    }
+
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        active_slider_ = general_slider::none;
+    }
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        if (CheckCollisionPointRec(mouse, kGeneralRows[0])) {
+            active_slider_ = general_slider::note_speed;
+        } else if (CheckCollisionPointRec(mouse, kGeneralRows[1])) {
+            active_slider_ = general_slider::camera_angle;
+        } else if (CheckCollisionPointRec(mouse, kGeneralRows[2])) {
+            active_slider_ = general_slider::lane_width;
+        } else if (CheckCollisionPointRec(mouse, kGeneralRows[3])) {
+            active_slider_ = general_slider::frame_rate;
+        }
+    }
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        if (active_slider_ == general_slider::note_speed) {
+            const float ratio = slider_ratio_from_mouse(kGeneralRows[0], mouse);
+            g_settings.note_speed = 0.020f + ratio * (0.090f - 0.020f);
+        } else if (active_slider_ == general_slider::camera_angle) {
+            const float ratio = slider_ratio_from_mouse(kGeneralRows[1], mouse);
+            g_settings.camera_angle_degrees = 5.0f + ratio * (90.0f - 5.0f);
+        } else if (active_slider_ == general_slider::lane_width) {
+            const float ratio = slider_ratio_from_mouse(kGeneralRows[2], mouse);
+            g_settings.lane_width = 0.6f + ratio * (5.0f - 0.6f);
+        } else if (active_slider_ == general_slider::frame_rate) {
+            const float ratio = slider_ratio_from_mouse(kGeneralRows[3], mouse);
+            const int index = static_cast<int>(std::round(ratio * static_cast<float>(kFrameRateOptions.size() - 1)));
+            g_settings.target_fps =
+                kFrameRateOptions[static_cast<size_t>(std::clamp(index, 0, static_cast<int>(kFrameRateOptions.size()) - 1))];
+        }
+    }
+
+    bool resolution_changed = false;
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        if (CheckCollisionPointRec(mouse, arrow_left_rect(kGeneralRows[4]))) {
+            g_settings.resolution_index = std::max(0, g_settings.resolution_index - 1);
+            resolution_changed = true;
+        } else if (CheckCollisionPointRec(mouse, arrow_right_rect(kGeneralRows[4]))) {
+            g_settings.resolution_index = std::min(kResolutionPresetCount - 1, g_settings.resolution_index + 1);
+            resolution_changed = true;
+        }
+    }
+
+    if (resolution_changed) {
+        const resolution_preset& preset = kResolutionPresets[g_settings.resolution_index];
+        SetWindowSize(preset.width, preset.height);
+    }
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        if (CheckCollisionPointRec(mouse, arrow_left_rect(kGeneralRows[5])) ||
+            CheckCollisionPointRec(mouse, arrow_right_rect(kGeneralRows[5]))) {
+            g_settings.fullscreen = !g_settings.fullscreen;
+            ToggleFullscreen();
+        }
+    }
+}
+
+void settings_scene::update_key_config() {
+    const int max_keys = key_config_mode_ == 0 ? 4 : 6;
+
+    if (listening_) {
+        // ESC でリスニングキャンセル
+        if (IsKeyPressed(KEY_ESCAPE)) {
+            listening_ = false;
+            return;
+        }
+
+        // 押されたキーを検出
+        const int pressed = GetKeyPressed();
+        if (pressed == KEY_NULL) return;
+
+        if (!is_valid_play_key(pressed)) {
+            key_config_error_ = "This key cannot be assigned";
+            error_timer_ = 2.0f;
+            return;
+        }
+
+        // 重複チェック
+        const std::span<KeyboardKey> keys = key_config_mode_ == 0
+            ? std::span<KeyboardKey>(g_settings.keys.keys_4)
+            : std::span<KeyboardKey>(g_settings.keys.keys_6);
+        const int count = key_config_mode_ == 0 ? 4 : 6;
+        for (int i = 0; i < count; ++i) {
+            if (i != key_config_slot_ && keys[static_cast<size_t>(i)] == static_cast<KeyboardKey>(pressed)) {
+                key_config_error_ = TextFormat("Key '%s' is already assigned to Lane %d", get_key_name(pressed), i + 1);
+                error_timer_ = 2.0f;
+                return;
+            }
+        }
+
+        keys[static_cast<size_t>(key_config_slot_)] = static_cast<KeyboardKey>(pressed);
+        listening_ = false;
+        key_config_error_.clear();
+        return;
+    }
+
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        const Rectangle mode_left = {kKeyModeRect.x + kKeyModeRect.width - 94.0f, kKeyModeRect.y + 15.0f, kArrowButtonSize, kArrowButtonSize};
+        const Rectangle mode_right = {kKeyModeRect.x + kKeyModeRect.width - 50.0f, kKeyModeRect.y + 15.0f, kArrowButtonSize, kArrowButtonSize};
+        if (CheckCollisionPointRec(mouse, mode_left) || CheckCollisionPointRec(mouse, mode_right)) {
+            key_config_mode_ = 1 - key_config_mode_;
+            key_config_slot_ = -1;
+            return;
+        }
+
+        int y = 258;
+        for (int i = 0; i < max_keys; ++i) {
+            const Rectangle row_rect = {330.0f, static_cast<float>(y), 560.0f, 48.0f};
+            if (CheckCollisionPointRec(mouse, row_rect)) {
+                if (key_config_slot_ == i) {
+                    listening_ = true;
+                    key_config_error_.clear();
+                } else {
+                    key_config_slot_ = i;
+                }
+                return;
+            }
+            y += 62;
+        }
+    }
+}
+
 void settings_scene::draw() {
-    const char* frame_rate_label = g_settings.target_fps == 0 ? "Unlimited" : TextFormat("%d", g_settings.target_fps);
-
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    const bool mouse_down = IsMouseButtonDown(MOUSE_BUTTON_LEFT);
     virtual_screen::begin();
-    draw_scene_frame("Settings", "ENTER or ESC: Back to Title", {124, 58, 237, 255});
-    DrawText("Audio Offset: 0 ms", 130, 300, 36, BLACK);
-    DrawText(TextFormat("Note Speed: %.3f", g_settings.note_speed), 130, 360, 36, BLACK);
-    DrawText(TextFormat("Camera Angle: %.0f deg", g_settings.camera_angle_degrees), 130, 420, 36, BLACK);
-    DrawText(TextFormat("Lane Width: %.1f", g_settings.lane_width), 130, 480, 36, BLACK);
-    DrawText(TextFormat("Frame Rate: %s", frame_rate_label), 130, 540, 36, BLACK);
-    DrawText("LEFT/RIGHT: Camera Angle", 130, 586, 24, GRAY);
-    DrawText("UP/DOWN: Note Speed    Q/E: Lane Width", 130, 620, 24, GRAY);
-    DrawText("Z/X: Frame Rate", 130, 654, 24, GRAY);
-    virtual_screen::end();
+    ClearBackground(RAYWHITE);
+    DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, {255, 255, 255, 255}, {241, 243, 246, 255});
+    DrawRectangleRec(kSidebarRect, Color{248, 249, 251, 255});
+    DrawRectangleRec(kContentRect, Color{248, 249, 251, 255});
+    DrawRectangleLinesEx(kSidebarRect, 2.0f, Color{206, 210, 218, 255});
+    DrawRectangleLinesEx(kContentRect, 2.0f, Color{206, 210, 218, 255});
 
+    DrawText("SETTINGS", 46, 70, 34, BLACK);
+    DrawText("Saved on exit", 48, 112, 20, Color{132, 136, 146, 255});
+
+    for (int i = 0; i < kPageCount; ++i) {
+        const bool active = static_cast<int>(current_page_) == i;
+        const bool hovered = CheckCollisionPointRec(mouse, kTabRects[i]);
+        const bool pressed = hovered && mouse_down;
+        const Rectangle draw_rect = pressed ? inset_rect(kTabRects[i], 1.5f) : kTabRects[i];
+        const Color fill = active ? lerp_color(Color{223, 228, 234, 255}, Color{210, 216, 224, 255}, hovered ? 1.0f : 0.0f)
+                                  : lerp_color(Color{243, 245, 248, 255}, Color{228, 233, 239, 255}, hovered ? 1.0f : 0.0f);
+        const Color border = active ? Color{182, 186, 194, 255} : Color{206, 210, 218, 255};
+        DrawRectangleRec(draw_rect, fill);
+        DrawRectangleLinesEx(draw_rect, 2.0f, border);
+        DrawText(kPageNames[i], static_cast<int>(draw_rect.x + 14.0f), static_cast<int>(draw_rect.y + 10.0f), 22,
+                 active ? BLACK : DARKGRAY);
+    }
+
+    DrawText("Click tabs to switch pages", 48, 324, 20, Color{132, 136, 146, 255});
+    const bool back_hovered = CheckCollisionPointRec(mouse, kBackRect);
+    const bool back_pressed = back_hovered && mouse_down;
+    const Rectangle back_draw_rect = back_pressed ? inset_rect(kBackRect, 1.5f) : kBackRect;
+    DrawRectangleRec(back_draw_rect, lerp_color(Color{243, 245, 248, 255}, Color{228, 233, 239, 255}, back_hovered ? 1.0f : 0.0f));
+    DrawRectangleLinesEx(back_draw_rect, 2.0f, Color{206, 210, 218, 255});
+    DrawText("BACK", static_cast<int>(back_draw_rect.x + 72.0f), static_cast<int>(back_draw_rect.y + 10.0f), 22, BLACK);
+
+    DrawText(current_page_ == page::general ? "General" : "Key Config", 330, 74, 34, BLACK);
+    DrawText(current_page_ == page::general ? "Display and play settings" : "Per-lane keyboard bindings",
+             332, 114, 20, Color{132, 136, 146, 255});
+
+    switch (current_page_) {
+        case page::general:
+            draw_general();
+            break;
+        case page::key_config:
+            draw_key_config();
+            break;
+    }
+
+    virtual_screen::end();
     ClearBackground(BLACK);
     virtual_screen::draw_to_screen();
+}
+
+void settings_scene::draw_general() {
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    const bool mouse_down = IsMouseButtonDown(MOUSE_BUTTON_LEFT);
+    const char* fps_label = g_settings.target_fps == 0 ? "Unlimited" : TextFormat("%d", g_settings.target_fps);
+    const char* res_label = kResolutionPresets[g_settings.resolution_index].label;
+    const char* labels[] = {"Note Speed", "Camera Angle", "Lane Width", "Frame Rate", "Resolution", "Display"};
+    const char* values[] = {
+        TextFormat("%.3f", g_settings.note_speed),
+        TextFormat("%.0f deg", g_settings.camera_angle_degrees),
+        TextFormat("%.1f", g_settings.lane_width),
+        fps_label,
+        res_label,
+        g_settings.fullscreen ? "Fullscreen" : "Windowed",
+    };
+
+    for (int i = 0; i < 6; ++i) {
+        DrawRectangleRec(kGeneralRows[i], Color{243, 245, 248, 255});
+        DrawRectangleLinesEx(kGeneralRows[i], 2.0f, Color{206, 210, 218, 255});
+        DrawText(labels[i], static_cast<int>(kGeneralRows[i].x + 18.0f), static_cast<int>(kGeneralRows[i].y + 16.0f), 24, BLACK);
+        if (i <= 3) {
+            const Rectangle track = slider_track_rect(kGeneralRows[i]);
+            DrawRectangleRec(track, Color{214, 219, 226, 255});
+
+            float ratio = 0.0f;
+            if (i == 0) {
+                ratio = (g_settings.note_speed - 0.020f) / (0.090f - 0.020f);
+            } else if (i == 1) {
+                ratio = (g_settings.camera_angle_degrees - 5.0f) / (90.0f - 5.0f);
+            } else if (i == 2) {
+                ratio = (g_settings.lane_width - 0.6f) / (5.0f - 0.6f);
+            } else {
+                ratio = static_cast<float>(fps_option_index(g_settings.target_fps)) / 3.0f;
+            }
+            ratio = clamp01(ratio);
+
+            DrawRectangle(static_cast<int>(track.x), static_cast<int>(track.y), static_cast<int>(track.width * ratio), static_cast<int>(track.height),
+                          Color{132, 136, 146, 255});
+            const int knob_x = static_cast<int>(track.x + track.width * ratio);
+            DrawRectangle(knob_x - 6, static_cast<int>(track.y - 8.0f), 12, 22, Color{72, 72, 72, 255});
+
+            const int value_width = MeasureText(values[i], 22);
+            DrawText(values[i], static_cast<int>(track.x + track.width - value_width), static_cast<int>(kGeneralRows[i].y + 10.0f), 22,
+                     Color{96, 100, 108, 255});
+        } else {
+            const Rectangle left_arrow = arrow_left_rect(kGeneralRows[i]);
+            const Rectangle right_arrow = arrow_right_rect(kGeneralRows[i]);
+            const bool left_hovered = CheckCollisionPointRec(mouse, left_arrow);
+            const bool right_hovered = CheckCollisionPointRec(mouse, right_arrow);
+            const Rectangle left_draw_rect = (left_hovered && mouse_down) ? inset_rect(left_arrow, 1.5f) : left_arrow;
+            const Rectangle right_draw_rect = (right_hovered && mouse_down) ? inset_rect(right_arrow, 1.5f) : right_arrow;
+            DrawRectangleRec(left_draw_rect, lerp_color(Color{229, 233, 238, 255}, Color{214, 220, 227, 255}, left_hovered ? 1.0f : 0.0f));
+            DrawRectangleRec(right_draw_rect, lerp_color(Color{229, 233, 238, 255}, Color{214, 220, 227, 255}, right_hovered ? 1.0f : 0.0f));
+            DrawRectangleLinesEx(left_draw_rect, 2.0f, Color{206, 210, 218, 255});
+            DrawRectangleLinesEx(right_draw_rect, 2.0f, Color{206, 210, 218, 255});
+            DrawText("<", static_cast<int>(left_draw_rect.x + 11.0f), static_cast<int>(left_draw_rect.y + 5.0f), 24, BLACK);
+            DrawText(">", static_cast<int>(right_draw_rect.x + 10.0f), static_cast<int>(right_draw_rect.y + 5.0f), 24, BLACK);
+
+            const int value_width = MeasureText(values[i], 24);
+            DrawText(values[i], static_cast<int>(left_arrow.x - value_width - 16.0f), static_cast<int>(kGeneralRows[i].y + 16.0f), 24,
+                     Color{96, 100, 108, 255});
+        }
+    }
+}
+
+void settings_scene::draw_key_config() {
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    const bool mouse_down = IsMouseButtonDown(MOUSE_BUTTON_LEFT);
+    DrawRectangleRec(kKeyModeRect, Color{243, 245, 248, 255});
+    DrawRectangleLinesEx(kKeyModeRect, 2.0f, Color{206, 210, 218, 255});
+    DrawText("Mode", static_cast<int>(kKeyModeRect.x + 18.0f), static_cast<int>(kKeyModeRect.y + 16.0f), 24, BLACK);
+    const Rectangle mode_left = {kKeyModeRect.x + kKeyModeRect.width - 94.0f, kKeyModeRect.y + 15.0f, kArrowButtonSize, kArrowButtonSize};
+    const Rectangle mode_right = {kKeyModeRect.x + kKeyModeRect.width - 50.0f, kKeyModeRect.y + 15.0f, kArrowButtonSize, kArrowButtonSize};
+    const char* mode_label = key_config_mode_ == 0 ? "4K" : "6K";
+    const int mode_label_width = MeasureText(mode_label, 24);
+    DrawText(mode_label, static_cast<int>(mode_left.x - mode_label_width - 18.0f),
+             static_cast<int>(kKeyModeRect.y + 16.0f), 24, Color{96, 100, 108, 255});
+    const bool mode_left_hovered = CheckCollisionPointRec(mouse, mode_left);
+    const bool mode_right_hovered = CheckCollisionPointRec(mouse, mode_right);
+    const Rectangle mode_left_draw = (mode_left_hovered && mouse_down) ? inset_rect(mode_left, 1.5f) : mode_left;
+    const Rectangle mode_right_draw = (mode_right_hovered && mouse_down) ? inset_rect(mode_right, 1.5f) : mode_right;
+    DrawRectangleRec(mode_left_draw, lerp_color(Color{229, 233, 238, 255}, Color{214, 220, 227, 255}, mode_left_hovered ? 1.0f : 0.0f));
+    DrawRectangleRec(mode_right_draw, lerp_color(Color{229, 233, 238, 255}, Color{214, 220, 227, 255}, mode_right_hovered ? 1.0f : 0.0f));
+    DrawRectangleLinesEx(mode_left_draw, 2.0f, Color{206, 210, 218, 255});
+    DrawRectangleLinesEx(mode_right_draw, 2.0f, Color{206, 210, 218, 255});
+    DrawText("<", static_cast<int>(mode_left_draw.x + 11.0f), static_cast<int>(mode_left_draw.y + 5.0f), 24, BLACK);
+    DrawText(">", static_cast<int>(mode_right_draw.x + 10.0f), static_cast<int>(mode_right_draw.y + 5.0f), 24, BLACK);
+
+    int y = 258;
+
+    // キースロット表示
+    const std::span<const KeyboardKey> keys = key_config_mode_ == 0
+        ? std::span<const KeyboardKey>(g_settings.keys.keys_4)
+        : std::span<const KeyboardKey>(g_settings.keys.keys_6);
+    const int count = key_config_mode_ == 0 ? 4 : 6;
+    for (int i = 0; i < count; ++i) {
+        const bool selected = key_config_slot_ == i;
+        const bool is_listening = selected && listening_;
+        const Rectangle row_rect = {330.0f, static_cast<float>(y), 560.0f, 48.0f};
+        const bool hovered = CheckCollisionPointRec(mouse, row_rect);
+        const Rectangle draw_rect = (hovered && mouse_down) ? inset_rect(row_rect, 1.5f) : row_rect;
+        const Color fill = selected ? lerp_color(Color{223, 228, 234, 255}, Color{210, 216, 224, 255}, hovered ? 1.0f : 0.0f)
+                                    : lerp_color(Color{243, 245, 248, 255}, Color{228, 233, 239, 255}, hovered ? 1.0f : 0.0f);
+        DrawRectangleRec(draw_rect, fill);
+        DrawRectangleLinesEx(draw_rect, 2.0f, selected ? Color{182, 186, 194, 255} : Color{206, 210, 218, 255});
+        const char* key_label = is_listening ? "Press a key..." : get_key_name(keys[static_cast<size_t>(i)]);
+        DrawText(TextFormat("Lane %d", i + 1), static_cast<int>(draw_rect.x + 18.0f), static_cast<int>(draw_rect.y + 12.0f), 24, BLACK);
+        const int key_width = MeasureText(key_label, 24);
+        DrawText(key_label, static_cast<int>(draw_rect.x + draw_rect.width - key_width - 18.0f), static_cast<int>(draw_rect.y + 12.0f), 24,
+                 is_listening ? Color{220, 38, 38, 255} : Color{96, 100, 108, 255});
+        y += 62;
+    }
+
+    if (error_timer_ > 0.0f && !key_config_error_.empty()) {
+        const unsigned char alpha = static_cast<unsigned char>(std::min(error_timer_ / 0.3f, 1.0f) * 255.0f);
+        DrawText(key_config_error_.c_str(), 330, y + 8, 22, Color{220, 38, 38, alpha});
+    }
 }

--- a/src/scenes/settings_scene.h
+++ b/src/scenes/settings_scene.h
@@ -1,12 +1,36 @@
 #pragma once
 
+#include <string>
+
 #include "scene.h"
 
-// 設定画面。ノート速度・カメラ角度・レーン幅を調整する。
+// 設定画面。General ページと Key Config ページの2ページ構成。
 class settings_scene final : public scene {
 public:
-    explicit settings_scene(scene_manager& manager);
+    enum class return_target { title, song_select };
+
+    explicit settings_scene(scene_manager& manager, return_target target = return_target::title);
 
     void update(float dt) override;
     void draw() override;
+
+private:
+    enum class page { general, key_config };
+    enum class general_slider { none, note_speed, camera_angle, lane_width, frame_rate };
+
+    void update_general();
+    void update_key_config();
+    void draw_general();
+    void draw_key_config();
+
+    page current_page_ = page::general;
+
+    // キーコンフィグ用状態
+    int key_config_mode_ = 0;       // 0 = 4K, 1 = 6K
+    int key_config_slot_ = -1;      // 選択中のスロット（-1 = 未選択）
+    bool listening_ = false;        // キー入力待ち状態
+    std::string key_config_error_;  // 重複エラーメッセージ
+    float error_timer_ = 0.0f;     // エラー表示タイマー
+    general_slider active_slider_ = general_slider::none;
+    return_target return_target_ = return_target::title;
 };

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -10,6 +10,7 @@
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
+#include "settings_scene.h"
 #include "song_loader.h"
 #include "title_scene.h"
 #include "virtual_screen.h"
@@ -18,6 +19,7 @@ namespace {
 constexpr float kRowHeight = 60.0f;
 constexpr float kScrollWheelStep = 80.0f;
 constexpr float kScrollLerpSpeed = 12.0f;
+constexpr Rectangle kSettingsButtonRect = {1094.0f, 8.0f, 162.0f, 30.0f};
 constexpr Rectangle kSongListRect = {790.0f, 44.0f, 466.0f, 660.0f};
 constexpr Rectangle kLeftPanelRect = {24.0f, 44.0f, 750.0f, 660.0f};
 constexpr Rectangle kJacketRect = {44.0f, 68.0f, 320.0f, 320.0f};
@@ -30,6 +32,16 @@ std::filesystem::path repo_root() {
 
 std::string key_mode_label(int key_count) {
     return key_count == 6 ? "6K" : "4K";
+}
+
+Color lerp_color(Color from, Color to, float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    return {
+        static_cast<unsigned char>(from.r + (to.r - from.r) * clamped),
+        static_cast<unsigned char>(from.g + (to.g - from.g) * clamped),
+        static_cast<unsigned char>(from.b + (to.b - from.b) * clamped),
+        static_cast<unsigned char>(from.a + (to.a - from.a) * clamped),
+    };
 }
 
 }
@@ -45,6 +57,7 @@ void song_select_scene::on_enter() {
     scroll_y_ = 0.0f;
     scroll_y_target_ = 0.0f;
     song_change_anim_t_ = 1.0f;
+    scene_fade_in_t_ = 1.0f;
 
     const song_load_result load_result = song_loader::load_all((repo_root() / "assets" / "songs").string());
     load_errors_ = load_result.errors;
@@ -234,7 +247,16 @@ void song_select_scene::update(float dt) {
 
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const float wheel = GetMouseWheelMove();
+    if (IsKeyPressed(KEY_F1) ||
+        (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, kSettingsButtonRect))) {
+        manager_.change_scene(std::make_unique<settings_scene>(manager_, settings_scene::return_target::song_select));
+        return;
+    }
+
+    settings_hover_t_ =
+        std::clamp(settings_hover_t_ + (CheckCollisionPointRec(mouse, kSettingsButtonRect) ? dt * 8.0f : -dt * 8.0f), 0.0f, 1.0f);
     song_change_anim_t_ = std::max(0.0f, song_change_anim_t_ - dt * 4.0f);
+    scene_fade_in_t_ = std::max(0.0f, scene_fade_in_t_ - dt / 0.3f);
 
     if (songs_.empty()) {
         return;
@@ -286,7 +308,7 @@ void song_select_scene::update(float dt) {
 
     // リスト内クリック: スクロールオフセットを考慮して当たり判定
     if (CheckCollisionPointRec(mouse, kSongListRect) && IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        const float list_top = kSongListRect.y + 60.0f;
+        const float list_top = kSongListRect.y + 12.0f;
         float item_y = list_top - scroll_y_;
         for (int i = 0; i < static_cast<int>(songs_.size()); ++i) {
             float row_h = kRowHeight;
@@ -342,6 +364,9 @@ void song_select_scene::draw() {
     DrawRectangleLinesEx(kLeftPanelRect, 2.0f, Color{206, 210, 218, 255});
     DrawRectangleLinesEx(kSongListRect, 2.0f, Color{206, 210, 218, 255});
     DrawText("SONG SELECT", 30, 12, 30, BLACK);
+    DrawRectangleRec(kSettingsButtonRect, lerp_color(Color{243, 245, 248, 255}, Color{228, 233, 239, 255}, settings_hover_t_));
+    DrawRectangleLinesEx(kSettingsButtonRect, 2.0f, Color{206, 210, 218, 255});
+    DrawText("SETTINGS", static_cast<int>(kSettingsButtonRect.x + 22.0f), static_cast<int>(kSettingsButtonRect.y + 6.0f), 20, BLACK);
 
     if (songs_.empty()) {
         DrawText("No songs found", 50, 300, 36, BLACK);
@@ -392,12 +417,12 @@ void song_select_scene::draw() {
                  static_cast<int>(kJacketRect.y + 186.0f), 20, Color{132, 136, 146, content_alpha});
     }
 
-    DrawText("Songs", static_cast<int>(kSongListRect.x + 20.0f), static_cast<int>(kSongListRect.y + 22.0f), 28, BLACK);
+    DrawText("Songs", static_cast<int>(kSongListRect.x + 20.0f), static_cast<int>(kSongListRect.y + 10.0f), 28, BLACK);
     DrawRectangleRec(kSongListRect, song_list_fill);
     DrawRectangleLinesEx(kSongListRect, 2.0f, panel_border);
 
     // スクロールオフセットを適用してリストを描画。クリッピング領域外のアイテムはスキップ。
-    const float list_top = kSongListRect.y + 60.0f;
+    const float list_top = kSongListRect.y + 12.0f;
     const float list_bottom = kSongListRect.y + kSongListRect.height - 12.0f;
     const Rectangle list_clip = {kSongListRect.x, list_top, kSongListRect.width, list_bottom - list_top};
     BeginScissorMode(static_cast<int>(list_clip.x), static_cast<int>(list_clip.y),
@@ -476,6 +501,11 @@ void song_select_scene::draw() {
                       static_cast<int>(kSongListRect.y + 12.0f), 6, static_cast<int>(track_h), Color{226, 230, 236, 255});
         DrawRectangle(static_cast<int>(kSongListRect.x + kSongListRect.width - 14.0f),
                       static_cast<int>(thumb_y), 6, static_cast<int>(thumb_h), Color{172, 178, 188, 255});
+    }
+
+    if (scene_fade_in_t_ > 0.0f) {
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
+                      Color{0, 0, 0, static_cast<unsigned char>(scene_fade_in_t_ * 0.65f * 255.0f)});
     }
 
     virtual_screen::end();

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -45,7 +45,9 @@ private:
     int difficulty_index_ = 0;
     float scroll_y_ = 0.0f;
     float scroll_y_target_ = 0.0f;
+    float settings_hover_t_ = 0.0f;
     float song_change_anim_t_ = 0.0f;
+    float scene_fade_in_t_ = 1.0f;
     audio preview_audio_;
     std::optional<song_data> pending_preview_song_;
     std::optional<song_data> active_preview_song_;

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -5,7 +5,6 @@
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
-#include "settings_scene.h"
 #include "song_select_scene.h"
 #include "virtual_screen.h"
 
@@ -14,21 +13,57 @@ title_scene::title_scene(scene_manager& manager) : scene(manager) {
 
 // ENTER で曲選択、S で設定画面へ遷移する。
 void title_scene::update(float dt) {
-    (void)dt;
+    if (transitioning_to_song_select_) {
+        transition_fade_t_ = std::min(1.0f, transition_fade_t_ + dt / 0.3f);
+        if (transition_fade_t_ >= 1.0f) {
+            manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+        }
+        return;
+    }
+
+    if (quitting_) {
+        quit_fade_t_ = std::min(1.0f, quit_fade_t_ + dt / 1.5f);
+        if (quit_fade_t_ >= 1.0f) {
+            CloseWindow();
+        }
+        return;
+    }
 
     if (IsKeyPressed(KEY_ENTER)) {
-        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
-    } else if (IsKeyPressed(KEY_S)) {
-        manager_.change_scene(std::make_unique<settings_scene>(manager_));
+        transitioning_to_song_select_ = true;
+        transition_fade_t_ = 0.0f;
+        return;
+    }
+
+    if (IsKeyDown(KEY_ESCAPE)) {
+        esc_hold_t_ += dt;
+        if (esc_hold_t_ >= 0.3f) {
+            esc_hold_t_ = 0.0f;
+            quitting_ = true;
+            quit_fade_t_ = 0.0f;
+        }
+    } else {
+        esc_hold_t_ = 0.0f;
     }
 }
 
 // タイトルロゴと操作案内を描画する。
 void title_scene::draw() {
     virtual_screen::begin();
-    draw_scene_frame("Title", "ENTER: Song Select    S: Settings", {32, 129, 226, 255});
-    DrawText("raythm", 130, 300, 92, BLACK);
-    DrawText("Scene management bootstrap", 136, 400, 28, GRAY);
+    ClearBackground(RAYWHITE);
+    DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, {255, 255, 255, 255}, {241, 243, 246, 255});
+    DrawText("raythm", 72, 84, 124, BLACK);
+    DrawText("trace the line before the beat disappears", 82, 212, 30, Color{102, 106, 114, 255});
+    DrawText("ENTER: Song Select", 82, 644, 22, Color{132, 136, 146, 255});
+    DrawText("ESC: Quit", 82, 674, 22, Color{132, 136, 146, 255});
+    if (transitioning_to_song_select_) {
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
+                      Color{0, 0, 0, static_cast<unsigned char>(std::min(0.65f, transition_fade_t_ * 0.65f) * 255.0f)});
+    }
+    if (quitting_) {
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
+                      Color{0, 0, 0, static_cast<unsigned char>(std::min(1.0f, quit_fade_t_) * 255.0f)});
+    }
     virtual_screen::end();
 
     ClearBackground(BLACK);

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -9,4 +9,11 @@ public:
 
     void update(float dt) override;
     void draw() override;
+
+private:
+    bool quitting_ = false;
+    float quit_fade_t_ = 0.0f;
+    float esc_hold_t_ = 0.0f;
+    bool transitioning_to_song_select_ = false;
+    float transition_fade_t_ = 0.0f;
 };


### PR DESCRIPTION
## 概要
- タイトル画面と設定画面のフローを実装し、タイトル画面から曲選択画面への遷移を洗練させる
- 設定情報の永続化機能と適用キーを追加し、解像度、表示、ゲームプレイの設定を適用する
- マウス操作によるナビゲーションに対応するため、曲選択画面と設定画面の操作感を再設計する

Closes #17