### PR TITLE
リザルト画面リデザイン・譜面完了スキップ・フェード遷移

### DIFF
--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -26,6 +26,8 @@ constexpr float kFailureFadeDurationSeconds = 1.0f;
 constexpr float kFailureHoldDurationSeconds = 1.0f;
 constexpr float kFailureTransitionDurationSeconds
     = kFailureFadeDurationSeconds + kFailureHoldDurationSeconds;
+constexpr float kResultTransitionDurationSeconds = 1.0f;
+constexpr float kResultFadeMaxAlpha = 0.65f;  // 暗転しきらない
 constexpr float kJudgementLineScreenRatioFromBottom = 0.10f;
 constexpr float kCameraHeight = 42.0f;
 constexpr float kCameraFovY = 42.0f;
@@ -329,7 +331,19 @@ void play_scene::update(float dt) {
     if (failure_transition_playing_) {
         failure_transition_timer_ = std::max(0.0f, failure_transition_timer_ - dt);
         if (failure_transition_timer_ <= 0.0f) {
-            manager_.change_scene(std::make_unique<result_scene>(manager_, final_result_, ranking_enabled_));
+            manager_.change_scene(std::make_unique<result_scene>(
+                manager_, final_result_, ranking_enabled_,
+                *song_data_, selected_chart_path_.value_or(""), chart_data_->meta, key_count_));
+        }
+        return;
+    }
+
+    if (result_transition_playing_) {
+        result_transition_timer_ = std::min(kResultTransitionDurationSeconds, result_transition_timer_ + dt);
+        if (result_transition_timer_ >= kResultTransitionDurationSeconds) {
+            manager_.change_scene(std::make_unique<result_scene>(
+                manager_, final_result_, ranking_enabled_,
+                *song_data_, selected_chart_path_.value_or(""), chart_data_->meta, key_count_));
         }
         return;
     }
@@ -384,10 +398,24 @@ void play_scene::update(float dt) {
         }
     }
 
+    // 全ノーツ判定済みなら Enter/クリックでリザルトへスキップ可能
+    const auto& states = judge_system_.note_states();
+    const bool chart_finished = !states.empty() &&
+        std::all_of(states.begin(), states.end(), [](const note_state& s) { return s.judged; });
+
+    if (chart_finished && (IsKeyPressed(KEY_ENTER) || IsMouseButtonPressed(MOUSE_BUTTON_LEFT))) {
+        final_result_ = score_system_.get_result_data();
+        result_transition_playing_ = true;
+        result_transition_timer_ = 0.0f;
+        audio_player_.pause();
+        return;
+    }
+
     // 曲終了でリザルト画面へ、Backspace で曲選択へ戻る
     if (current_ms_ >= song_end_ms_) {
         final_result_ = score_system_.get_result_data();
-        manager_.change_scene(std::make_unique<result_scene>(manager_, final_result_, ranking_enabled_));
+        result_transition_playing_ = true;
+        result_transition_timer_ = 0.0f;
     } else if (IsKeyPressed(KEY_BACKSPACE)) {
         manager_.change_scene(std::make_unique<song_select_scene>(manager_));
     }
@@ -485,6 +513,9 @@ void play_scene::draw() {
     }
     if (failure_transition_playing_) {
         draw_failure_overlay();
+    }
+    if (result_transition_playing_) {
+        draw_result_transition_overlay();
     }
     if (paused_) {
         draw_pause_overlay();
@@ -697,6 +728,12 @@ void play_scene::draw_failure_overlay() const {
     const char* text = "FAILED...";
     DrawText(text, kScreenWidth / 2 - MeasureText(text, 44) / 2, kScreenHeight / 2 - 22, 44,
              Fade({244, 246, 250, 255}, std::min(fade_progress * 1.15f, 1.0f)));
+}
+
+void play_scene::draw_result_transition_overlay() const {
+    const float progress = std::clamp(result_transition_timer_ / kResultTransitionDurationSeconds, 0.0f, 1.0f);
+    const unsigned char alpha = static_cast<unsigned char>(progress * kResultFadeMaxAlpha * 255.0f);
+    DrawRectangle(0, 0, kScreenWidth, kScreenHeight, {0, 0, 0, alpha});
 }
 
 double play_scene::get_visual_ms() const {

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -38,6 +38,8 @@ private:
     void draw_intro_overlay() const;
     // 失敗時の暗転演出を描画する。
     void draw_failure_overlay() const;
+    // リザルト遷移時のフェード演出を描画する。
+    void draw_result_transition_overlay() const;
     // カメラの高さ・角度・FOVから、判定ラインが画面上の指定位置に来るようカメラを構築する。
     Camera3D make_play_camera() const;
     // カメラの可視範囲からレーンのZ方向の手前端・判定位置・奥端を計算する。
@@ -76,6 +78,8 @@ private:
     float intro_timer_ = 2.0f;
     bool failure_transition_playing_ = false;
     float failure_transition_timer_ = 0.0f;
+    bool result_transition_playing_ = false;
+    float result_transition_timer_ = 0.0f;
 
     // 描画用スライディングウィンドウ。
     // 各レーンごとに inactive / active を持ち、レーン内では target_ms 昇順を保証する。

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -1,72 +1,216 @@
 #include "result_scene.h"
 
+#include <algorithm>
 #include <memory>
 
+#include "play_scene.h"
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
 #include "song_select_scene.h"
-#include "title_scene.h"
 #include "virtual_screen.h"
 
-result_scene::result_scene(scene_manager& manager, result_data result, bool ranking_enabled)
-    : scene(manager), result_(result), ranking_enabled_(ranking_enabled) {
+namespace {
+
+constexpr Rectangle kMainPanel = {24.0f, 24.0f, 1232.0f, 672.0f};
+constexpr Rectangle kSongInfoRect = {48.0f, 48.0f, 580.0f, 108.0f};
+constexpr Rectangle kRankRect = {660.0f, 48.0f, 200.0f, 168.0f};
+constexpr Rectangle kScoreRect = {48.0f, 180.0f, 580.0f, 108.0f};
+constexpr Rectangle kJudgeRect = {48.0f, 312.0f, 580.0f, 260.0f};
+constexpr Rectangle kStatsRect = {660.0f, 240.0f, 572.0f, 332.0f};
+
+Color rank_color(rank r) {
+    switch (r) {
+        case rank::ss: return {200, 50, 200, 255};  // マゼンタ
+        case rank::s:  return {200, 50, 200, 255};
+        case rank::a:  return {220, 50, 50, 255};    // 赤
+        case rank::b:  return {50, 100, 220, 255};   // 青
+        case rank::c:  return {210, 180, 30, 255};   // 黄色
+        case rank::f:  return {120, 120, 120, 255};  // グレー
+    }
+    return DARKGRAY;
 }
 
-// ENTER で曲選択へ、ESC でタイトルへ遷移する。
+const char* rank_label(rank r) {
+    switch (r) {
+        case rank::ss: return "SS";
+        case rank::s:  return "S";
+        case rank::a:  return "A";
+        case rank::b:  return "B";
+        case rank::c:  return "C";
+        case rank::f:  return "F";
+    }
+    return "?";
+}
+
+const char* key_mode_label(int key_count) {
+    return key_count == 6 ? "6K" : "4K";
+}
+
+}  // namespace
+
+result_scene::result_scene(scene_manager& manager, result_data result, bool ranking_enabled,
+                           song_data song, std::string chart_path, chart_meta chart, int key_count)
+    : scene(manager), result_(result), ranking_enabled_(ranking_enabled),
+      song_(std::move(song)), chart_path_(std::move(chart_path)), chart_(std::move(chart)), key_count_(key_count) {
+}
+
 void result_scene::update(float dt) {
-    (void)dt;
+    fade_in_timer_ = std::max(0.0f, fade_in_timer_ - dt);
 
     if (IsKeyPressed(KEY_ENTER)) {
         manager_.change_scene(std::make_unique<song_select_scene>(manager_));
     } else if (IsKeyPressed(KEY_ESCAPE)) {
-        manager_.change_scene(std::make_unique<title_scene>(manager_));
+        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+    } else if (IsKeyPressed(KEY_R)) {
+        manager_.change_scene(std::make_unique<play_scene>(manager_, song_, chart_path_, key_count_));
     }
 }
 
-// スコア・ランク・達成率・判定内訳・コンボ情報・ランキング資格を表示する。
 void result_scene::draw() {
     virtual_screen::begin();
-    draw_scene_frame("Result", "ENTER: Retry Flow    ESC: Title", {202, 138, 4, 255});
+    ClearBackground(RAYWHITE);
+    DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, {255, 255, 255, 255}, {241, 243, 246, 255});
+
+    // メインパネル
+    DrawRectangleRec(kMainPanel, Color{248, 249, 251, 255});
+    DrawRectangleLinesEx(kMainPanel, 2.0f, Color{206, 210, 218, 255});
+
+    // 楽曲情報
+    DrawRectangleRec(kSongInfoRect, Color{240, 242, 246, 255});
+    DrawRectangleLinesEx(kSongInfoRect, 1.5f, Color{216, 220, 228, 255});
+    const float song_info_max_w = kSongInfoRect.width - 32.0f;
+    const double now = GetTime();
+    {
+        const int sy = static_cast<int>(kSongInfoRect.y + (kSongInfoRect.height - 82) * 0.5f);
+        const int lx = static_cast<int>(kSongInfoRect.x + 16);
+        draw_marquee_text(song_.meta.title.c_str(), lx, sy, 32, BLACK, song_info_max_w, now);
+        draw_marquee_text(song_.meta.artist.c_str(), lx, sy + 38, 22, Color{100, 104, 112, 255}, song_info_max_w, now);
+        const char* chart_label = TextFormat("%s %s Lv.%d", key_mode_label(chart_.key_count),
+                                             chart_.difficulty.c_str(), chart_.level);
+        const int chart_label_w = MeasureText(chart_label, 20);
+        DrawText(chart_label, lx, sy + 66, 20, Color{124, 58, 237, 255});
+        DrawText(chart_.chart_author.c_str(), lx + chart_label_w + 16, sy + 66, 20, Color{132, 136, 146, 255});
+    }
+
+    // ランク表示
+    DrawRectangleRec(kRankRect, Color{240, 242, 246, 255});
+    DrawRectangleLinesEx(kRankRect, 1.5f, Color{216, 220, 228, 255});
+    const char* rlabel = rank_label(result_.clear_rank);
+    const Color rcolor = rank_color(result_.clear_rank);
+    const int rank_text_w = MeasureText(rlabel, 96);
+    DrawText(rlabel,
+             static_cast<int>(kRankRect.x + kRankRect.width * 0.5f) - rank_text_w / 2,
+             static_cast<int>(kRankRect.y + kRankRect.height * 0.5f) - 48,
+             96, rcolor);
+
+    // 称号（Full Combo / All Perfect）
+    if (result_.is_all_perfect) {
+        DrawText("ALL PERFECT",
+                 static_cast<int>(kRankRect.x + kRankRect.width * 0.5f) - MeasureText("ALL PERFECT", 20) / 2,
+                 static_cast<int>(kRankRect.y + kRankRect.height - 28), 20, Color{200, 50, 200, 255});
+    } else if (result_.is_full_combo) {
+        DrawText("FULL COMBO",
+                 static_cast<int>(kRankRect.x + kRankRect.width * 0.5f) - MeasureText("FULL COMBO", 20) / 2,
+                 static_cast<int>(kRankRect.y + kRankRect.height - 28), 20, Color{14, 146, 108, 255});
+    }
+
+    // FAILED 表示
     if (result_.failed) {
-        DrawText("FAILED", 130, 228, 48, Color{220, 38, 38, 255});
-    }
-    DrawText(TextFormat("Score: %07d", result_.score), 130, 280, 40, BLACK);
-
-    const char* rank_label = "F";
-    switch (result_.clear_rank) {
-        case rank::ss:
-            rank_label = "SS";
-            break;
-        case rank::s:
-            rank_label = "S";
-            break;
-        case rank::a:
-            rank_label = "A";
-            break;
-        case rank::b:
-            rank_label = "B";
-            break;
-        case rank::c:
-            rank_label = "C";
-            break;
-        case rank::f:
-            rank_label = "F";
-            break;
+        DrawText("FAILED",
+                 static_cast<int>(kRankRect.x + kRankRect.width + 20),
+                 static_cast<int>(kRankRect.y + 20), 40, Color{220, 38, 38, 255});
     }
 
-    DrawText(TextFormat("Rank: %s", rank_label), 130, 338, 40, BLACK);
-    DrawText(TextFormat("Accuracy: %.2f%%", result_.achievement), 130, 390, 28, DARKGRAY);
-    DrawText(TextFormat("Perfect %d  Great %d  Good %d  Bad %d  Miss %d", result_.judge_counts[0],
-                        result_.judge_counts[1], result_.judge_counts[2], result_.judge_counts[3],
-                        result_.judge_counts[4]),
-             130, 438, 28, DARKGRAY);
-    DrawText(TextFormat("Max Combo %d  Fast %d  Slow %d", result_.max_combo, result_.fast_count, result_.slow_count), 130,
-             478, 26, GRAY);
-    DrawText(ranking_enabled_ ? "Ranking: Eligible" : "Ranking: Disabled", 130, 522, 24,
-             ranking_enabled_ ? Color{14, 146, 108, 255} : Color{220, 38, 38, 255});
+    // スコア・精度（フレーム中央に配置）
+    DrawRectangleRec(kScoreRect, Color{240, 242, 246, 255});
+    DrawRectangleLinesEx(kScoreRect, 1.5f, Color{216, 220, 228, 255});
+    {
+        const int content_h = 36 + 8 + 36;  // 2行 + 間隔
+        const int start_y = static_cast<int>(kScoreRect.y + (kScoreRect.height - content_h) * 0.5f);
+        const int lx = static_cast<int>(kScoreRect.x + 16);
+        DrawText("SCORE", lx, start_y + 6, 20, Color{120, 124, 132, 255});
+        DrawText(TextFormat("%07d", result_.score), lx + 100, start_y, 36, BLACK);
+        DrawText("ACCURACY", lx, start_y + 8 + 36 + 6, 20, Color{120, 124, 132, 255});
+        DrawText(TextFormat("%.2f%%", result_.achievement), lx + 140, start_y + 8 + 36, 36, Color{50, 54, 62, 255});
+    }
+
+    // 判定内訳（フレーム中央に配置）
+    DrawRectangleRec(kJudgeRect, Color{240, 242, 246, 255});
+    DrawRectangleLinesEx(kJudgeRect, 1.5f, Color{216, 220, 228, 255});
+
+    struct judge_row {
+        const char* label;
+        int count;
+        Color color;
+    };
+    const judge_row rows[] = {
+        {"PERFECT", result_.judge_counts[0], {239, 244, 255, 255}},
+        {"GREAT",   result_.judge_counts[1], {123, 211, 255, 255}},
+        {"GOOD",    result_.judge_counts[2], {141, 211, 173, 255}},
+        {"BAD",     result_.judge_counts[3], {255, 190, 92, 255}},
+        {"MISS",    result_.judge_counts[4], {255, 107, 107, 255}},
+    };
+
+    {
+        constexpr int judge_row_h = 42;
+        constexpr int judge_count = 5;
+        const int judge_content_h = judge_count * judge_row_h - (judge_row_h - 30);
+        int jy = static_cast<int>(kJudgeRect.y + (kJudgeRect.height - judge_content_h) * 0.5f);
+        const int jx = static_cast<int>(kJudgeRect.x + 16);
+        for (const auto& row : rows) {
+            DrawRectangle(jx, jy - 2, 160, 30, row.color);
+            DrawText(row.label, jx + 8, jy + 2, 22, Color{30, 34, 42, 255});
+            DrawText(TextFormat("%d", row.count), jx + 176, jy + 2, 22, BLACK);
+            jy += judge_row_h;
+        }
+    }
+
+    // 統計情報（フレーム中央に配置）
+    DrawRectangleRec(kStatsRect, Color{240, 242, 246, 255});
+    DrawRectangleLinesEx(kStatsRect, 1.5f, Color{216, 220, 228, 255});
+
+    {
+        constexpr int stat_row_h = 40;
+        constexpr int stat_count = 5;
+        const int stat_content_h = stat_count * stat_row_h;
+        int sy = static_cast<int>(kStatsRect.y + (kStatsRect.height - stat_content_h - 40) * 0.5f);
+        const int sx = static_cast<int>(kStatsRect.x + 24);
+        const int sv = static_cast<int>(kStatsRect.x + 200);
+        const Color label_color = {120, 124, 132, 255};
+
+        DrawText("Max Combo", sx, sy, 24, label_color);
+        DrawText(TextFormat("%d", result_.max_combo), sv, sy, 24, BLACK);
+        sy += stat_row_h;
+
+        DrawText("Avg Offset", sx, sy, 24, label_color);
+        DrawText(TextFormat("%.1f ms", result_.avg_offset), sv, sy, 24, BLACK);
+        sy += stat_row_h;
+
+        DrawText("Fast", sx, sy, 24, label_color);
+        DrawText(TextFormat("%d", result_.fast_count), sv, sy, 24, Color{50, 120, 220, 255});
+        sy += stat_row_h;
+
+        DrawText("Slow", sx, sy, 24, label_color);
+        DrawText(TextFormat("%d", result_.slow_count), sv, sy, 24, Color{220, 120, 50, 255});
+        sy += stat_row_h;
+
+        DrawText("Ranking", sx, sy, 24, label_color);
+        DrawText(ranking_enabled_ ? "Eligible" : "Disabled", sv, sy, 24,
+                 ranking_enabled_ ? Color{14, 146, 108, 255} : Color{220, 38, 38, 255});
+        sy += stat_row_h + 10;
+
+        // 操作案内
+        DrawText("ENTER: Song Select    R: Retry", sx, sy, 20, Color{160, 164, 172, 255});
+    }
+
+    // フェードイン（暗い状態から明るくなる）
+    if (fade_in_timer_ > 0.0f) {
+        const unsigned char alpha = static_cast<unsigned char>(std::min(fade_in_timer_, 1.0f) * 0.65f * 255.0f);
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight, {0, 0, 0, alpha});
+    }
+
     virtual_screen::end();
-
     ClearBackground(BLACK);
     virtual_screen::draw_to_screen();
 }

--- a/src/scenes/result_scene.h
+++ b/src/scenes/result_scene.h
@@ -1,12 +1,16 @@
 #pragma once
 
+#include <string>
+
+#include "data_models.h"
 #include "scene.h"
 #include "score_system.h"
 
 // リザルト画面。プレイ終了後のスコア・ランク・判定内訳を表示する。
 class result_scene final : public scene {
 public:
-    result_scene(scene_manager& manager, result_data result, bool ranking_enabled);
+    result_scene(scene_manager& manager, result_data result, bool ranking_enabled,
+                 song_data song, std::string chart_path, chart_meta chart, int key_count);
 
     void update(float dt) override;
     void draw() override;
@@ -14,4 +18,9 @@ public:
 private:
     result_data result_;
     bool ranking_enabled_ = true;
+    song_data song_;
+    std::string chart_path_;
+    chart_meta chart_;
+    int key_count_ = 4;
+    float fade_in_timer_ = 1.0f;
 };


### PR DESCRIPTION
## Summary
- **Issue #16**: リザルト画面を全面リデザイン。パネルレイアウト、色分けランク表示、マーキーテキスト（曲名・アーティスト名）、判定内訳のカラーバー、統計情報パネル、Rキーでリトライ機能を追加
- **Issue #26**: 全ノーツ判定済み時にEnter/クリックでリザルト画面へスキップ可能に（`std::all_of` で判定状態を検出）
- **フェード遷移**: プレイ→リザルト間に1秒のフェード演出を追加（最大65%の暗転、完全に暗くならない仕様）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `result_scene.h/cpp` | パネルベースのレイアウトに全面書き換え。楽曲情報・ランク・スコア・判定・統計の5パネル構成 |
| `play_scene.h/cpp` | リザルト遷移フェード、譜面完了検出・スキップ、曲終了時のフェード遷移を追加 |

## 主な仕様
- ランク色: SS/S=マゼンタ、A=赤、B=青、C=黄、F=グレー
- ALL PERFECT / FULL COMBO の称号表示
- FAILED 表示
- リザルト画面の操作: Enter→曲選択、R→リトライ、ESC→曲選択
- フェードイン/アウト: 1秒、最大不透明度65%

Closes #16, closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)