### PR TITLE
AudioManagerによる新しい再生基盤を導入する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,8 @@ add_executable(raythm src/main.cpp
         libs/bass/bass.h
         src/audio/audio.cpp
         src/audio/audio.h
+        src/audio/audio_manager.cpp
+        src/audio/audio_manager.h
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
         src/models/data_models.h
@@ -93,6 +95,14 @@ add_executable(score_system_smoke
         src/gameplay/score_system.h
         src/tests/score_system_smoke.cpp)
 
+add_executable(audio_manager_smoke
+        libs/bass/bass.h
+        src/audio/audio.cpp
+        src/audio/audio.h
+        src/audio/audio_manager.cpp
+        src/audio/audio_manager.h
+        src/tests/audio_manager_smoke.cpp)
+
 set(RAYTHM_INCLUDE_DIRS
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_SOURCE_DIR}/src/audio
@@ -111,13 +121,21 @@ target_include_directories(input_handler_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(timing_engine_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(judge_system_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(score_system_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(audio_manager_smoke PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass ${RAYTHM_INCLUDE_DIRS})
 target_link_libraries(raythm PRIVATE raylib ${CMAKE_SOURCE_DIR}/libs/bass/bass.lib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
 target_link_libraries(judge_system_smoke PRIVATE raylib)
+target_link_libraries(audio_manager_smoke PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass/bass.lib)
 
 # bass.dll を実行ファイルと同じディレクトリにコピー
 add_custom_command(TARGET raythm POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_if_different
         ${CMAKE_SOURCE_DIR}/libs/bass/bass.dll
         $<TARGET_FILE_DIR:raythm>/bass.dll
+)
+
+add_custom_command(TARGET audio_manager_smoke POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different
+        ${CMAKE_SOURCE_DIR}/libs/bass/bass.dll
+        $<TARGET_FILE_DIR:audio_manager_smoke>/bass.dll
 )

--- a/src/audio/audio.cpp
+++ b/src/audio/audio.cpp
@@ -5,17 +5,12 @@
 #include "audio.h"
 
 #include <algorithm>
-#include <iostream>
 
+#include "audio_manager.h"
 #include "bass.h"
 
-int audio::instance_count_ = 0;
-
 audio::audio() {
-    if (instance_count_ == 0 && !BASS_Init(-1, 44100, 0, nullptr, nullptr)) {
-        std::cout << "[audio/Error] An error occurred during initialization";
-    }
-    ++instance_count_;
+    audio_manager::instance().retain_legacy_client();
 }
 
 audio::~audio() {
@@ -24,11 +19,7 @@ audio::~audio() {
         BASS_StreamFree(handle_);
         handle_ = 0;
     }
-
-    --instance_count_;
-    if (instance_count_ == 0) {
-        BASS_Free();
-    }
+    audio_manager::instance().release_legacy_client();
 }
 
 void audio::load(const std::string& file_path) {

--- a/src/audio/audio.h
+++ b/src/audio/audio.h
@@ -6,6 +6,8 @@
 
 #include <string>
 
+// 移行期間中の互換ラッパ。
+// BASS 初期化責務は audio_manager に寄せ、既存 scene は次段の issue で置換する。
 class audio {
 public:
     audio();
@@ -24,5 +26,4 @@ public:
 
 private:
     unsigned long handle_ = 0;
-    static int instance_count_;
 };

--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -1,0 +1,294 @@
+#include "audio_manager.h"
+
+#include <algorithm>
+#include <unordered_map>
+
+#include "bass.h"
+
+namespace {
+struct se_voice_entry {
+    unsigned long handle = 0;
+    float local_volume = 1.0f;
+};
+
+std::unordered_map<int, se_voice_entry>& se_voices() {
+    static std::unordered_map<int, se_voice_entry> voices;
+    return voices;
+}
+}
+
+audio_manager& audio_manager::instance() {
+    static audio_manager manager;
+    return manager;
+}
+
+audio_manager::~audio_manager() {
+    shutdown();
+}
+
+bool audio_manager::initialize() {
+    if (initialized_) {
+        return true;
+    }
+
+    initialized_ = BASS_Init(-1, 44100, 0, nullptr, nullptr) != FALSE;
+    return initialized_;
+}
+
+void audio_manager::shutdown() {
+    stop_all_se();
+    free_voice(bgm_handle_);
+    free_voice(preview_handle_);
+
+    if (initialized_) {
+        BASS_Free();
+        initialized_ = false;
+    }
+}
+
+bool audio_manager::is_initialized() const {
+    return initialized_;
+}
+
+bool audio_manager::load_bgm(const std::string& file_path) {
+    if (!ensure_initialized()) {
+        return false;
+    }
+    replace_voice(bgm_handle_, file_path);
+    apply_bgm_volume();
+    return is_voice_loaded(bgm_handle_);
+}
+
+void audio_manager::play_bgm(bool restart) {
+    play_voice(bgm_handle_, restart);
+}
+
+void audio_manager::pause_bgm() {
+    pause_voice(bgm_handle_);
+}
+
+void audio_manager::stop_bgm() {
+    stop_voice(bgm_handle_);
+}
+
+void audio_manager::set_bgm_volume(float volume) {
+    bgm_volume_ = std::clamp(volume, 0.0f, 1.0f);
+    apply_bgm_volume();
+}
+
+void audio_manager::seek_bgm(double seconds) {
+    set_voice_position_seconds(bgm_handle_, seconds);
+}
+
+bool audio_manager::is_bgm_loaded() const {
+    return is_voice_loaded(bgm_handle_);
+}
+
+bool audio_manager::is_bgm_playing() const {
+    return is_voice_playing(bgm_handle_);
+}
+
+double audio_manager::get_bgm_position_seconds() const {
+    return get_voice_position_seconds(bgm_handle_);
+}
+
+double audio_manager::get_bgm_length_seconds() const {
+    return get_voice_length_seconds(bgm_handle_);
+}
+
+bool audio_manager::load_preview(const std::string& file_path) {
+    if (!ensure_initialized()) {
+        return false;
+    }
+    replace_voice(preview_handle_, file_path);
+    apply_preview_volume();
+    return is_voice_loaded(preview_handle_);
+}
+
+void audio_manager::play_preview(bool restart) {
+    play_voice(preview_handle_, restart);
+}
+
+void audio_manager::pause_preview() {
+    pause_voice(preview_handle_);
+}
+
+void audio_manager::stop_preview() {
+    stop_voice(preview_handle_);
+}
+
+void audio_manager::set_preview_volume(float volume) {
+    preview_volume_ = std::clamp(volume, 0.0f, 1.0f);
+    apply_preview_volume();
+}
+
+void audio_manager::seek_preview(double seconds) {
+    set_voice_position_seconds(preview_handle_, seconds);
+}
+
+bool audio_manager::is_preview_loaded() const {
+    return is_voice_loaded(preview_handle_);
+}
+
+bool audio_manager::is_preview_playing() const {
+    return is_voice_playing(preview_handle_);
+}
+
+double audio_manager::get_preview_position_seconds() const {
+    return get_voice_position_seconds(preview_handle_);
+}
+
+double audio_manager::get_preview_length_seconds() const {
+    return get_voice_length_seconds(preview_handle_);
+}
+
+int audio_manager::play_se(const std::string& file_path, float volume) {
+    if (!ensure_initialized()) {
+        return 0;
+    }
+
+    unsigned long handle = create_stream(file_path);
+    if (!is_voice_loaded(handle)) {
+        return 0;
+    }
+
+    const int voice_id = next_se_voice_id_++;
+    se_voices()[voice_id] = {handle, std::clamp(volume, 0.0f, 1.0f)};
+    BASS_ChannelSetAttribute(handle, BASS_ATTRIB_VOL, se_voices()[voice_id].local_volume * se_volume_);
+    play_voice(handle, true);
+    return voice_id;
+}
+
+void audio_manager::stop_se(int voice_id) {
+    auto it = se_voices().find(voice_id);
+    if (it == se_voices().end()) {
+        return;
+    }
+
+    stop_voice(it->second.handle);
+    free_voice(it->second.handle);
+    se_voices().erase(it);
+}
+
+void audio_manager::stop_all_se() {
+    for (auto& [voice_id, voice] : se_voices()) {
+        (void)voice_id;
+        stop_voice(voice.handle);
+        free_voice(voice.handle);
+    }
+    se_voices().clear();
+}
+
+void audio_manager::set_se_volume(float volume) {
+    se_volume_ = std::clamp(volume, 0.0f, 1.0f);
+    for (auto& [voice_id, voice] : se_voices()) {
+        (void)voice_id;
+        if (is_voice_loaded(voice.handle)) {
+            BASS_ChannelSetAttribute(voice.handle, BASS_ATTRIB_VOL, voice.local_volume * se_volume_);
+        }
+    }
+}
+
+void audio_manager::update() {
+    for (auto it = se_voices().begin(); it != se_voices().end();) {
+        if (!is_voice_loaded(it->second.handle) || BASS_ChannelIsActive(it->second.handle) == BASS_ACTIVE_STOPPED) {
+            free_voice(it->second.handle);
+            it = se_voices().erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
+void audio_manager::retain_legacy_client() {
+    if (ensure_initialized()) {
+        ++legacy_client_count_;
+    }
+}
+
+void audio_manager::release_legacy_client() {
+    legacy_client_count_ = std::max(0, legacy_client_count_ - 1);
+}
+
+bool audio_manager::is_voice_loaded(unsigned long handle) {
+    return handle != 0;
+}
+
+bool audio_manager::is_voice_playing(unsigned long handle) {
+    return handle != 0 && BASS_ChannelIsActive(handle) == BASS_ACTIVE_PLAYING;
+}
+
+double audio_manager::get_voice_position_seconds(unsigned long handle) {
+    if (handle == 0) {
+        return 0.0;
+    }
+
+    const QWORD position = BASS_ChannelGetPosition(handle, BASS_POS_BYTE);
+    return BASS_ChannelBytes2Seconds(handle, position);
+}
+
+double audio_manager::get_voice_length_seconds(unsigned long handle) {
+    if (handle == 0) {
+        return 0.0;
+    }
+
+    const QWORD length = BASS_ChannelGetLength(handle, BASS_POS_BYTE);
+    return BASS_ChannelBytes2Seconds(handle, length);
+}
+
+void audio_manager::play_voice(unsigned long handle, bool restart) {
+    if (handle != 0) {
+        BASS_ChannelPlay(handle, restart ? TRUE : FALSE);
+    }
+}
+
+void audio_manager::pause_voice(unsigned long handle) {
+    if (handle != 0) {
+        BASS_ChannelPause(handle);
+    }
+}
+
+void audio_manager::stop_voice(unsigned long handle) {
+    if (handle != 0) {
+        BASS_ChannelStop(handle);
+    }
+}
+
+void audio_manager::set_voice_position_seconds(unsigned long handle, double seconds) {
+    if (handle != 0) {
+        const QWORD position = BASS_ChannelSeconds2Bytes(handle, std::max(0.0, seconds));
+        BASS_ChannelSetPosition(handle, position, BASS_POS_BYTE);
+    }
+}
+
+void audio_manager::free_voice(unsigned long& handle) {
+    if (handle != 0) {
+        BASS_StreamFree(handle);
+        handle = 0;
+    }
+}
+
+bool audio_manager::ensure_initialized() {
+    return initialize();
+}
+
+unsigned long audio_manager::create_stream(const std::string& file_path) const {
+    return BASS_StreamCreateFile(FALSE, file_path.c_str(), 0, 0, 0);
+}
+
+void audio_manager::replace_voice(unsigned long& handle, const std::string& file_path) const {
+    free_voice(handle);
+    handle = create_stream(file_path);
+}
+
+void audio_manager::apply_bgm_volume() const {
+    if (is_voice_loaded(bgm_handle_)) {
+        BASS_ChannelSetAttribute(bgm_handle_, BASS_ATTRIB_VOL, bgm_volume_);
+    }
+}
+
+void audio_manager::apply_preview_volume() const {
+    if (is_voice_loaded(preview_handle_)) {
+        BASS_ChannelSetAttribute(preview_handle_, BASS_ATTRIB_VOL, preview_volume_);
+    }
+}

--- a/src/audio/audio_manager.h
+++ b/src/audio/audio_manager.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <string>
+
+class audio;
+
+class audio_manager final {
+public:
+    static audio_manager& instance();
+
+    audio_manager(const audio_manager&) = delete;
+    audio_manager& operator=(const audio_manager&) = delete;
+
+    bool initialize();
+    void shutdown();
+    bool is_initialized() const;
+
+    bool load_bgm(const std::string& file_path);
+    void play_bgm(bool restart = true);
+    void pause_bgm();
+    void stop_bgm();
+    void set_bgm_volume(float volume);
+    void seek_bgm(double seconds);
+    bool is_bgm_loaded() const;
+    bool is_bgm_playing() const;
+    double get_bgm_position_seconds() const;
+    double get_bgm_length_seconds() const;
+
+    bool load_preview(const std::string& file_path);
+    void play_preview(bool restart = true);
+    void pause_preview();
+    void stop_preview();
+    void set_preview_volume(float volume);
+    void seek_preview(double seconds);
+    bool is_preview_loaded() const;
+    bool is_preview_playing() const;
+    double get_preview_position_seconds() const;
+    double get_preview_length_seconds() const;
+
+    int play_se(const std::string& file_path, float volume = 1.0f);
+    void stop_se(int voice_id);
+    void stop_all_se();
+    void set_se_volume(float volume);
+    void update();
+
+private:
+    friend class audio;
+
+    audio_manager() = default;
+    ~audio_manager();
+
+    struct managed_voice;
+
+    void retain_legacy_client();
+    void release_legacy_client();
+
+    static bool is_voice_loaded(unsigned long handle);
+    static bool is_voice_playing(unsigned long handle);
+    static double get_voice_position_seconds(unsigned long handle);
+    static double get_voice_length_seconds(unsigned long handle);
+    static void play_voice(unsigned long handle, bool restart);
+    static void pause_voice(unsigned long handle);
+    static void stop_voice(unsigned long handle);
+    static void set_voice_position_seconds(unsigned long handle, double seconds);
+    static void free_voice(unsigned long& handle);
+
+    bool ensure_initialized();
+    unsigned long create_stream(const std::string& file_path) const;
+    void replace_voice(unsigned long& handle, const std::string& file_path) const;
+    void apply_bgm_volume() const;
+    void apply_preview_volume() const;
+
+    bool initialized_ = false;
+    int legacy_client_count_ = 0;
+    float bgm_volume_ = 1.0f;
+    float preview_volume_ = 1.0f;
+    float se_volume_ = 1.0f;
+    unsigned long bgm_handle_ = 0;
+    unsigned long preview_handle_ = 0;
+    int next_se_voice_id_ = 1;
+};

--- a/src/tests/audio_manager_smoke.cpp
+++ b/src/tests/audio_manager_smoke.cpp
@@ -1,0 +1,63 @@
+#include <chrono>
+#include <filesystem>
+#include <iostream>
+#include <thread>
+
+#include "audio_manager.h"
+
+namespace {
+std::filesystem::path repo_root() {
+    return std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
+}
+}
+
+int main() {
+    const std::filesystem::path audio_path = repo_root() / "assets" / "songs" / "valid_song" / "audio.mp3";
+    if (!std::filesystem::exists(audio_path)) {
+        std::cerr << "Audio asset not found: " << audio_path.string() << '\n';
+        return 1;
+    }
+
+    audio_manager& manager = audio_manager::instance();
+    if (!manager.initialize()) {
+        std::cerr << "AudioManager initialization failed\n";
+        return 1;
+    }
+
+    if (!manager.load_bgm(audio_path.string())) {
+        std::cerr << "BGM load failed\n";
+        return 1;
+    }
+    manager.set_bgm_volume(0.2f);
+    manager.play_bgm();
+
+    if (!manager.load_preview(audio_path.string())) {
+        std::cerr << "Preview load failed\n";
+        return 1;
+    }
+    manager.seek_preview(1.0);
+    manager.set_preview_volume(0.1f);
+    manager.play_preview();
+
+    const int se_voice = manager.play_se(audio_path.string(), 0.05f);
+    if (se_voice == 0) {
+        std::cerr << "SE play failed\n";
+        return 1;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    manager.update();
+
+    if (!manager.is_bgm_loaded() || !manager.is_preview_loaded()) {
+        std::cerr << "Loaded voices became unavailable\n";
+        return 1;
+    }
+
+    manager.stop_preview();
+    manager.stop_bgm();
+    manager.stop_all_se();
+    manager.shutdown();
+
+    std::cout << "audio_manager smoke test passed\n";
+    return 0;
+}


### PR DESCRIPTION
## 概要
- AudioManager を追加し、BGM / Preview / SE を分けて扱える再生基盤を導入
- 既存 audio は移行期間用の互換ラッパとして整理し、BASS 初期化責務を AudioManager に集約
- audio_manager_smoke を追加して基盤の最小確認経路を用意

## 確認
- cmake --build cmake-build-debug --target audio_manager_smoke
- .\\cmake-build-debug\\audio_manager_smoke.exe
- audio_manager smoke test passed を確認
- 音声再生を耳で確認

Closes #39