### PR TITLE
BGMとPreviewの再生処理を新基盤へ移行する

### DIFF
--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -205,9 +205,10 @@ void play_scene::on_enter() {
     score_system_.init(static_cast<int>(chart_data_->notes.size()));
     gauge_ = gauge{};
 
+    audio_manager& audio = audio_manager::instance();
     const std::filesystem::path audio_path =
         std::filesystem::path(song_data_->directory) / song_data_->meta.audio_file;
-    audio_player_.load(audio_path.string());
+    audio.load_bgm(audio_path.string());
 
     // 描画キューの初期化: 各レーンごとにノート index を集め、target_ms 昇順で inactive に積む
     const std::vector<note_state>& init_states = judge_system_.note_states();
@@ -242,7 +243,7 @@ void play_scene::on_enter() {
     }
 
     song_end_ms_ = std::max(timing_engine_.tick_to_ms(last_tick) + 2000.0,
-                            audio_player_.get_length_seconds() * 1000.0);
+                            audio.get_bgm_length_seconds() * 1000.0);
     current_ms_ = 0.0;
     paused_ms_ = 0.0;
     paused_ = false;
@@ -261,7 +262,7 @@ void play_scene::on_enter() {
 
 // オーディオを停止する。
 void play_scene::on_exit() {
-    audio_player_.stop();
+    audio_manager::instance().stop_bgm();
 }
 
 // 時刻進行・入力処理・判定更新・シーン遷移を行う。
@@ -282,7 +283,7 @@ void play_scene::update(float dt) {
             auto_paused_by_focus_ = true;
             ranking_enabled_ = false;
             paused_ms_ = current_ms_;
-            audio_player_.pause();
+            audio_manager::instance().pause_bgm();
         }
     }
 
@@ -292,9 +293,9 @@ void play_scene::update(float dt) {
         paused_ms_ = current_ms_;
         if (paused_) {
             ranking_enabled_ = false;
-            audio_player_.pause();
-        } else if (audio_player_.is_loaded() && !intro_playing_) {
-            audio_player_.play(false);
+            audio_manager::instance().pause_bgm();
+        } else if (audio_manager::instance().is_bgm_loaded() && !intro_playing_) {
+            audio_manager::instance().play_bgm(false);
             auto_paused_by_focus_ = false;
         }
     }
@@ -304,8 +305,8 @@ void play_scene::update(float dt) {
         if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
             if (CheckCollisionPointRec(mouse, kPauseResumeRect)) {
                 paused_ = false;
-                if (audio_player_.is_loaded() && !intro_playing_) {
-                    audio_player_.play(false);
+                if (audio_manager::instance().is_bgm_loaded() && !intro_playing_) {
+                    audio_manager::instance().play_bgm(false);
                 }
                 auto_paused_by_focus_ = false;
                 return;
@@ -359,15 +360,17 @@ void play_scene::update(float dt) {
 
         if (intro_timer_ <= 0.0f) {
             intro_playing_ = false;
-            if (audio_player_.is_loaded()) {
-                audio_player_.play();
+            if (audio_manager::instance().is_bgm_loaded()) {
+                audio_manager::instance().play_bgm();
             }
         }
         return;
     }
 
     // 時刻をオーディオ位置から取得（オーディオ無しなら dt で進行）
-    current_ms_ = audio_player_.is_loaded() ? audio_player_.get_position_seconds() * 1000.0 : current_ms_ + dt * 1000.0;
+    current_ms_ = audio_manager::instance().is_bgm_loaded()
+                      ? audio_manager::instance().get_bgm_position_seconds() * 1000.0
+                      : current_ms_ + dt * 1000.0;
     input_handler_.update();
     judge_system_.update(current_ms_, input_handler_);
     last_judge_ = judge_system_.get_last_judge();
@@ -385,7 +388,7 @@ void play_scene::update(float dt) {
         ranking_enabled_ = false;
         failure_transition_playing_ = true;
         failure_transition_timer_ = kFailureTransitionDurationSeconds;
-        audio_player_.pause();
+        audio_manager::instance().pause_bgm();
         return;
     }
 
@@ -407,7 +410,7 @@ void play_scene::update(float dt) {
         final_result_ = score_system_.get_result_data();
         result_transition_playing_ = true;
         result_transition_timer_ = 0.0f;
-        audio_player_.pause();
+        audio_manager::instance().pause_bgm();
         return;
     }
 

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-#include "audio.h"
+#include "audio_manager.h"
 #include "judge_system.h"
 #include "scene.h"
 #include "score_system.h"
@@ -65,7 +65,6 @@ private:
     input_handler input_handler_;
     timing_engine timing_engine_;
     judge_system judge_system_;
-    audio audio_player_;
     std::optional<chart_data> chart_data_;
     std::optional<song_data> song_data_;
     std::optional<std::string> selected_chart_path_;

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -95,7 +95,7 @@ void song_select_scene::on_enter() {
 }
 
 void song_select_scene::on_exit() {
-    preview_audio_.stop();
+    audio_manager::instance().stop_preview();
     preview_song_id_.clear();
     pending_preview_song_.reset();
     active_preview_song_.reset();
@@ -162,7 +162,7 @@ void song_select_scene::queue_preview_for_selected_song() {
     }
 
     pending_preview_song_ = song->song;
-    if (preview_song_id_.empty() || !preview_audio_.is_loaded()) {
+    if (preview_song_id_.empty() || !audio_manager::instance().is_preview_loaded()) {
         start_preview(*song);
         return;
     }
@@ -171,18 +171,19 @@ void song_select_scene::queue_preview_for_selected_song() {
 }
 
 void song_select_scene::start_preview(const song_entry& song) {
+    audio_manager& audio = audio_manager::instance();
     const std::filesystem::path audio_path = std::filesystem::path(song.song.directory) / song.song.meta.audio_file;
-    preview_audio_.load(audio_path.string());
-    if (!preview_audio_.is_loaded()) {
+    audio.load_preview(audio_path.string());
+    if (!audio.is_preview_loaded()) {
         preview_song_id_.clear();
         preview_volume_ = 0.0f;
         preview_fade_direction_ = 0;
         return;
     }
 
-    preview_audio_.set_position_seconds(song.song.meta.preview_start_seconds);
-    preview_audio_.set_volume(0.0f);
-    preview_audio_.play(false);
+    audio.seek_preview(song.song.meta.preview_start_seconds);
+    audio.set_preview_volume(0.0f);
+    audio.play_preview(false);
     preview_volume_ = 0.0f;
     preview_song_id_ = song.song.meta.song_id;
     active_preview_song_ = song.song;
@@ -193,9 +194,9 @@ void song_select_scene::start_preview(const song_entry& song) {
 void song_select_scene::update_preview(float dt) {
     if (preview_fade_direction_ < 0) {
         preview_volume_ = std::max(0.0f, preview_volume_ - dt * kPreviewFadeSpeed);
-        preview_audio_.set_volume(preview_volume_);
+        audio_manager::instance().set_preview_volume(preview_volume_);
         if (preview_volume_ <= 0.0f) {
-            preview_audio_.stop();
+            audio_manager::instance().stop_preview();
             preview_song_id_.clear();
             active_preview_song_.reset();
             preview_fade_direction_ = 0;
@@ -210,12 +211,13 @@ void song_select_scene::update_preview(float dt) {
         }
     } else if (preview_fade_direction_ > 0) {
         preview_volume_ = std::min(kPreviewMaxVolume, preview_volume_ + dt * kPreviewFadeSpeed);
-        preview_audio_.set_volume(preview_volume_);
+        audio_manager::instance().set_preview_volume(preview_volume_);
         if (preview_volume_ >= kPreviewMaxVolume) {
             preview_fade_direction_ = 0;
         }
-    } else if (active_preview_song_.has_value() && preview_audio_.is_loaded()) {
-        const double remaining = preview_audio_.get_length_seconds() - preview_audio_.get_position_seconds();
+    } else if (active_preview_song_.has_value() && audio_manager::instance().is_preview_loaded()) {
+        const double remaining = audio_manager::instance().get_preview_length_seconds() -
+                                 audio_manager::instance().get_preview_position_seconds();
         if (remaining <= 1.0) {
             preview_fade_direction_ = -1;
             pending_preview_song_ = *active_preview_song_;

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "raylib.h"
-#include "audio.h"
+#include "audio_manager.h"
 #include "data_models.h"
 #include "scene.h"
 
@@ -48,7 +48,6 @@ private:
     float settings_hover_t_ = 0.0f;
     float song_change_anim_t_ = 0.0f;
     float scene_fade_in_t_ = 1.0f;
-    audio preview_audio_;
     std::optional<song_data> pending_preview_song_;
     std::optional<song_data> active_preview_song_;
     std::string preview_song_id_;


### PR DESCRIPTION
## 概要
- play_scene の BGM 再生を AudioManager 経由へ移行
- song_select_scene の preview 再生を AudioManager 経由へ移行
- scene から audio 直利用を除去

## 確認
- ユーザー環境で play_scene の BGM 再生を確認
- ユーザー環境で song_select_scene の preview 再生を確認
- pause / resume / scene 遷移時の停止を確認

Closes #40