### PR TITLE
SEの多重再生に対応する

### DIFF
--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -159,6 +159,19 @@ int audio_manager::play_se(const std::string& file_path, float volume) {
     return voice_id;
 }
 
+bool audio_manager::is_se_voice_active(int voice_id) const {
+    const auto it = se_voices().find(voice_id);
+    if (it == se_voices().end()) {
+        return false;
+    }
+
+    return is_voice_loaded(it->second.handle) && BASS_ChannelIsActive(it->second.handle) != BASS_ACTIVE_STOPPED;
+}
+
+std::size_t audio_manager::get_active_se_voice_count() const {
+    return se_voices().size();
+}
+
 void audio_manager::stop_se(int voice_id) {
     auto it = se_voices().find(voice_id);
     if (it == se_voices().end()) {

--- a/src/audio/audio_manager.h
+++ b/src/audio/audio_manager.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 
 class audio;
@@ -38,6 +39,8 @@ public:
     double get_preview_length_seconds() const;
 
     int play_se(const std::string& file_path, float volume = 1.0f);
+    bool is_se_voice_active(int voice_id) const;
+    std::size_t get_active_se_voice_count() const;
     void stop_se(int voice_id);
     void stop_all_se();
     void set_se_volume(float volume);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "audio_manager.h"
 #include "game_scenes.h"
 #include "game_settings.h"
 #include "raylib.h"
@@ -30,6 +31,7 @@ int main() {
             applied_target_fps = g_settings.target_fps;
         }
         const float dt = GetFrameTime();
+        audio_manager::instance().update();
         manager.update(dt);
 
         BeginDrawing();
@@ -38,5 +40,6 @@ int main() {
     }
 
     virtual_screen::cleanup();
+    audio_manager::instance().shutdown();
     CloseWindow();
 }

--- a/src/tests/audio_manager_smoke.cpp
+++ b/src/tests/audio_manager_smoke.cpp
@@ -12,7 +12,7 @@ std::filesystem::path repo_root() {
 }
 
 int main() {
-    const std::filesystem::path audio_path = repo_root() / "assets" / "songs" / "valid_song" / "audio.mp3";
+    const std::filesystem::path audio_path = repo_root() / "assets" / "audio" / "hitsound.mp3" ;
     if (!std::filesystem::exists(audio_path)) {
         std::cerr << "Audio asset not found: " << audio_path.string() << '\n';
         return 1;
@@ -38,14 +38,35 @@ int main() {
     manager.seek_preview(1.0);
     manager.set_preview_volume(0.1f);
     manager.play_preview();
-
-    const int se_voice = manager.play_se(audio_path.string(), 0.05f);
-    if (se_voice == 0) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    const int se_voice_1 = manager.play_se(audio_path.string(), 0.5f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    const int se_voice_2 = manager.play_se(audio_path.string(), 0.5f);
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
+    const int se_voice_3 = manager.play_se(audio_path.string(), 0.5f);
+    if (se_voice_1 == 0 || se_voice_2 == 0 || se_voice_3 == 0) {
         std::cerr << "SE play failed\n";
         return 1;
     }
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(150));
+    if (se_voice_1 == se_voice_2 || se_voice_2 == se_voice_3 || se_voice_1 == se_voice_3) {
+        std::cerr << "SE voice ids were reused\n";
+        return 1;
+    }
+
+    if (manager.get_active_se_voice_count() < 3) {
+        std::cerr << "SE voice count did not grow for overlapping playback\n";
+        return 1;
+    }
+
+    const std::size_t active_count_before_stop = manager.get_active_se_voice_count();
+    manager.stop_se(se_voice_2);
+    if (manager.get_active_se_voice_count() >= active_count_before_stop) {
+        std::cerr << "SE voice count did not decrease after stop\n";
+        return 1;
+    }
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(1500));
     manager.update();
 
     if (!manager.is_bgm_loaded() || !manager.is_preview_loaded()) {


### PR DESCRIPTION
## 概要
- AudioManager に SE voice の状態確認 API を追加
- メインループで AudioManager の update を回して終了済み SE を回収
- audio_manager_smoke を同一 SE の重ね再生確認に強化

## 確認
- ユーザー環境で audio_manager_smoke の通過を確認
- 同一 SE を連続再生して voice 数が増えることを確認
- stop_se による任意 voice 停止を確認

Closes #41