### PR TITLE
同時押し判定を1フレーム複数イベント対応にする

### DIFF
--- a/src/gameplay/judge_system.cpp
+++ b/src/gameplay/judge_system.cpp
@@ -6,6 +6,7 @@ void judge_system::init(const std::vector<note_data>& notes, const timing_engine
     note_states_.clear();
     note_states_.reserve(notes.size());
     last_judge_.reset();
+    judge_events_.clear();
 
     for (const note_data& note : notes) {
         note_state state;
@@ -18,6 +19,7 @@ void judge_system::init(const std::vector<note_data>& notes, const timing_engine
 
 void judge_system::update(double current_ms, const input_handler& input) {
     last_judge_.reset();
+    judge_events_.clear();
 
     for (note_state& state : note_states_) {
         if (state.note_ref.type != note_type::hold || !state.holding) {
@@ -34,7 +36,6 @@ void judge_system::update(double current_ms, const input_handler& input) {
             state.judged = true;
             state.result = judge_result::miss;
             emit_judge(judge_result::miss, current_ms - state.target_ms, state.note_ref.lane);
-            return;
         }
     }
 
@@ -72,7 +73,6 @@ void judge_system::update(double current_ms, const input_handler& input) {
         candidate->result = result;
         candidate->holding = candidate->note_ref.type == note_type::hold && result != judge_result::miss;
         emit_judge(result, offset_ms, lane);
-        return;
     }
 
     for (note_state& state : note_states_) {
@@ -85,13 +85,16 @@ void judge_system::update(double current_ms, const input_handler& input) {
             state.judged = true;
             state.result = judge_result::miss;
             emit_judge(judge_result::miss, offset_ms, state.note_ref.lane);
-            return;
         }
     }
 }
 
 std::optional<judge_event> judge_system::get_last_judge() const {
     return last_judge_;
+}
+
+const std::vector<judge_event>& judge_system::get_judge_events() const {
+    return judge_events_;
 }
 
 std::vector<note_state> judge_system::get_note_states() const {
@@ -124,5 +127,7 @@ bool judge_system::is_in_judgement_window(double offset_ms) const {
 }
 
 void judge_system::emit_judge(judge_result result, double offset_ms, int lane) {
-    last_judge_ = judge_event{result, offset_ms, lane};
+    judge_event event{result, offset_ms, lane};
+    judge_events_.push_back(event);
+    last_judge_ = event;
 }

--- a/src/gameplay/judge_system.h
+++ b/src/gameplay/judge_system.h
@@ -13,6 +13,7 @@ public:
     void init(const std::vector<note_data>& notes, const timing_engine& engine);
     void update(double current_ms, const input_handler& input);
     std::optional<judge_event> get_last_judge() const;
+    const std::vector<judge_event>& get_judge_events() const;
     std::vector<note_state> get_note_states() const;
     const std::vector<note_state>& note_states() const;
 
@@ -24,4 +25,5 @@ private:
     std::array<double, 5> judge_windows_ = {25.0, 50.0, 90.0, 130.0, 130.0};
     std::vector<note_state> note_states_;
     std::optional<judge_event> last_judge_;
+    std::vector<judge_event> judge_events_;
 };

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -381,17 +381,18 @@ void play_scene::update(float dt) {
                       : current_ms_ + dt * 1000.0;
     input_handler_.update();
     judge_system_.update(current_ms_, input_handler_);
+    const std::vector<judge_event>& judge_events = judge_system_.get_judge_events();
     last_judge_ = judge_system_.get_last_judge();
-    if (last_judge_.has_value()) {
-        score_system_.on_judge(*last_judge_);
-        gauge_.on_judge(last_judge_->result);
-        if (!hitsound_path_.empty() && last_judge_->result != judge_result::miss) {
+    for (const judge_event& event : judge_events) {
+        score_system_.on_judge(event);
+        gauge_.on_judge(event.result);
+        if (!hitsound_path_.empty() && event.result != judge_result::miss) {
             audio_manager::instance().play_se(hitsound_path_);
         }
-        combo_display_ = score_system_.get_combo();
-        display_judge_ = last_judge_;
+        display_judge_ = event;
         judge_feedback_timer_ = 1.0f;
     }
+    combo_display_ = score_system_.get_combo();
 
     if (gauge_.get_value() <= 0.0f) {
         final_result_ = score_system_.get_result_data();

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -182,7 +182,7 @@ void settings_scene::update_gameplay() {
             g_settings.camera_angle_degrees = 5.0f + ratio * (90.0f - 5.0f);
         } else if (active_slider_ == general_slider::lane_width) {
             const float ratio = slider_ratio_from_mouse(kGeneralRows[2], mouse);
-            g_settings.lane_width = 0.6f + ratio * (5.0f - 0.6f);
+            g_settings.lane_width = 0.6f + ratio * (10.0f - 0.6f);
         }
     }
 }
@@ -425,13 +425,14 @@ void settings_scene::draw_gameplay() {
         const Rectangle track = slider_track_rect(kGeneralRows[i]);
         DrawRectangleRec(track, Color{214, 219, 226, 255});
 
+        // スライダーの最大値
         float ratio = 0.0f;
         if (i == 0) {
             ratio = (g_settings.note_speed - 0.020f) / (0.090f - 0.020f);
         } else if (i == 1) {
             ratio = (g_settings.camera_angle_degrees - 5.0f) / (90.0f - 5.0f);
         } else {
-            ratio = (g_settings.lane_width - 0.6f) / (5.0f - 0.6f);
+            ratio = (g_settings.lane_width - 0.6f) / (10.0f - 0.6f);
         }
         ratio = clamp01(ratio);
 

--- a/src/tests/judge_system_smoke.cpp
+++ b/src/tests/judge_system_smoke.cpp
@@ -32,16 +32,14 @@ int main() {
 
     input.update_from_lane_states(std::array<bool, 4>{false, true, true, false});
     judge.update(1000.0, input);
-    const std::optional<judge_event> simultaneous_judge = judge.get_last_judge();
-    if (!simultaneous_judge.has_value() || simultaneous_judge->lane != 1) {
-        std::cerr << "Simultaneous press judge failed\n";
+    const std::vector<judge_event>& simultaneous_judges = judge.get_judge_events();
+    if (simultaneous_judges.size() != 2 || simultaneous_judges[0].lane != 1 || simultaneous_judges[1].lane != 2) {
+        std::cerr << "Simultaneous press judges failed\n";
         return EXIT_FAILURE;
     }
-
-    judge.update(1000.0, input);
-    const std::optional<judge_event> second_simultaneous_judge = judge.get_last_judge();
-    if (!second_simultaneous_judge.has_value() || second_simultaneous_judge->lane != 2) {
-        std::cerr << "Independent simultaneous judge failed\n";
+    const std::optional<judge_event> simultaneous_judge = judge.get_last_judge();
+    if (!simultaneous_judge.has_value() || simultaneous_judge->lane != 2) {
+        std::cerr << "Last simultaneous judge failed\n";
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
## 概要
- judge_system を 1 フレーム複数イベント対応に変更
- play_scene を複数判定イベント処理に追従
- judge_system_smoke を同時押しケースに更新
- settings_scene のレーン幅スライダー上限調整も同梱

## 確認
- ユーザー環境で judge_system_smoke 通過
- 実プレイで 3 鍵以上の同時押しが取りこぼされないことを確認

Closes #50