### PR TITLE
音声時間を基準時計として参照できるようにする

### DIFF
--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -96,6 +96,26 @@ double audio_manager::get_bgm_length_seconds() const {
     return get_voice_length_seconds(bgm_handle_);
 }
 
+audio_clock_snapshot audio_manager::get_bgm_clock() const {
+    return get_voice_clock(bgm_handle_);
+}
+
+double audio_manager::get_output_latency_seconds() const {
+    BASS_INFO info = {};
+    if (!initialized_ || BASS_GetInfo(&info) == FALSE) {
+        return 0.0;
+    }
+    return static_cast<double>(info.latency) / 1000.0;
+}
+
+double audio_manager::get_output_buffer_seconds() const {
+    BASS_INFO info = {};
+    if (!initialized_ || BASS_GetInfo(&info) == FALSE) {
+        return 0.0;
+    }
+    return static_cast<double>(info.minbuf) / 1000.0;
+}
+
 bool audio_manager::load_preview(const std::string& file_path) {
     if (!ensure_initialized()) {
         return false;
@@ -247,6 +267,22 @@ double audio_manager::get_voice_length_seconds(unsigned long handle) {
 
     const QWORD length = BASS_ChannelGetLength(handle, BASS_POS_BYTE);
     return BASS_ChannelBytes2Seconds(handle, length);
+}
+
+audio_clock_snapshot audio_manager::get_voice_clock(unsigned long handle) {
+    audio_clock_snapshot snapshot;
+    snapshot.loaded = is_voice_loaded(handle);
+    snapshot.playing = is_voice_playing(handle);
+    snapshot.stream_position_seconds = get_voice_position_seconds(handle);
+
+    BASS_INFO info = {};
+    if (BASS_GetInfo(&info) != FALSE) {
+        snapshot.device_latency_seconds = static_cast<double>(info.latency) / 1000.0;
+        snapshot.device_buffer_seconds = static_cast<double>(info.minbuf) / 1000.0;
+    }
+
+    snapshot.audio_time_seconds = snapshot.stream_position_seconds + snapshot.device_latency_seconds;
+    return snapshot;
 }
 
 void audio_manager::play_voice(unsigned long handle, bool restart) {

--- a/src/audio/audio_manager.h
+++ b/src/audio/audio_manager.h
@@ -5,6 +5,15 @@
 
 class audio;
 
+struct audio_clock_snapshot {
+    bool loaded = false;
+    bool playing = false;
+    double stream_position_seconds = 0.0;
+    double audio_time_seconds = 0.0;
+    double device_latency_seconds = 0.0;
+    double device_buffer_seconds = 0.0;
+};
+
 class audio_manager final {
 public:
     static audio_manager& instance();
@@ -26,6 +35,9 @@ public:
     bool is_bgm_playing() const;
     double get_bgm_position_seconds() const;
     double get_bgm_length_seconds() const;
+    audio_clock_snapshot get_bgm_clock() const;
+    double get_output_latency_seconds() const;
+    double get_output_buffer_seconds() const;
 
     bool load_preview(const std::string& file_path);
     void play_preview(bool restart = true);
@@ -61,6 +73,7 @@ private:
     static bool is_voice_playing(unsigned long handle);
     static double get_voice_position_seconds(unsigned long handle);
     static double get_voice_length_seconds(unsigned long handle);
+    static audio_clock_snapshot get_voice_clock(unsigned long handle);
     static void play_voice(unsigned long handle, bool restart);
     static void pause_voice(unsigned long handle);
     static void stop_voice(unsigned long handle);

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -397,9 +397,10 @@ void play_scene::update(float dt) {
         return;
     }
 
-    // 時刻をオーディオ位置から取得（オーディオ無しなら dt で進行）
-    current_ms_ = audio_manager::instance().is_bgm_loaded()
-                      ? audio_manager::instance().get_bgm_position_seconds() * 1000.0
+    // プレイ中の基準時計は audio_manager から取得する。
+    const audio_clock_snapshot bgm_clock = audio_manager::instance().get_bgm_clock();
+    current_ms_ = bgm_clock.loaded
+                      ? bgm_clock.audio_time_seconds * 1000.0
                       : current_ms_ + dt * 1000.0;
     input_handler_.update(current_ms_);
     judge_system_.update(current_ms_, input_handler_);

--- a/src/tests/audio_manager_smoke.cpp
+++ b/src/tests/audio_manager_smoke.cpp
@@ -28,8 +28,28 @@ int main() {
         std::cerr << "BGM load failed\n";
         return 1;
     }
+    const audio_clock_snapshot initial_clock = manager.get_bgm_clock();
+    if (!initial_clock.loaded || initial_clock.stream_position_seconds < 0.0 ||
+        initial_clock.audio_time_seconds < initial_clock.stream_position_seconds) {
+        std::cerr << "Initial BGM clock snapshot is invalid\n";
+        return 1;
+    }
+
     manager.set_bgm_volume(0.2f);
     manager.play_bgm();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    const audio_clock_snapshot playing_clock = manager.get_bgm_clock();
+    if (!playing_clock.loaded || !playing_clock.playing ||
+        playing_clock.stream_position_seconds <= initial_clock.stream_position_seconds) {
+        std::cerr << "BGM clock did not advance during playback\n";
+        return 1;
+    }
+
+    if (manager.get_output_latency_seconds() < 0.0 || manager.get_output_buffer_seconds() < 0.0) {
+        std::cerr << "Output timing information is invalid\n";
+        return 1;
+    }
 
     if (!manager.load_preview(audio_path.string())) {
         std::cerr << "Preview load failed\n";


### PR DESCRIPTION
## 概要
- udio_manager に BGM の基準時計スナップショット API を追加
- 再生位置に加えて出力 latency / buffer の補助情報を取得できるように変更
- play_scene がプレイ中の基準時刻を audio clock から参照するよう更新
- udio_manager_smoke に時計 API の基本確認を追加

## 確認
- feature-clock にてビルド通過

Closes #62
Part of #56