### PR TITLE
Windows の高精度入力イベント経路を追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ add_executable(raythm src/main.cpp
         src/audio/audio.h
         src/audio/audio_manager.cpp
         src/audio/audio_manager.h
+        src/platform/windows_input_source.cpp
+        src/platform/windows_input_source.h
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
         src/models/data_models.h
@@ -74,6 +76,8 @@ add_executable(song_loader_smoke
         src/tests/song_loader_smoke.cpp)
 
 add_executable(input_handler_smoke
+        src/platform/windows_input_source.cpp
+        src/platform/windows_input_source.h
         src/gameplay/input_handler.cpp
         src/gameplay/input_handler.h
         src/tests/input_handler_smoke.cpp)
@@ -86,6 +90,8 @@ add_executable(timing_engine_smoke
 
 add_executable(judge_system_smoke
         src/models/data_models.h
+        src/platform/windows_input_source.cpp
+        src/platform/windows_input_source.h
         src/gameplay/input_handler.cpp
         src/gameplay/input_handler.h
         src/gameplay/judge_system.cpp

--- a/src/gameplay/input_handler.cpp
+++ b/src/gameplay/input_handler.cpp
@@ -30,11 +30,19 @@ void input_handler::set_key_count(int key_count) {
 }
 
 void input_handler::update(double timestamp_ms) {
-    std::array<bool, kMaxLanes> next_state = {};
     const std::span<const KeyboardKey> lane_keys = key_config_.get_lane_keys(key_count_);
     events_.clear();
     prev_state_ = curr_state_;
 
+    if (windows_input_source::instance().is_available()) {
+        const std::vector<native_key_event> native_events = windows_input_source::instance().drain_events();
+        if (!native_events.empty()) {
+            apply_native_events(native_events);
+            return;
+        }
+    }
+
+    std::array<bool, kMaxLanes> next_state = {};
     for (int lane = 0; lane < key_count_; ++lane) {
         const KeyboardKey key = lane_keys[static_cast<size_t>(lane)];
         if (IsKeyPressed(key)) {
@@ -99,4 +107,32 @@ bool input_handler::is_lane_just_released(int lane) const {
 
     const size_t index = static_cast<size_t>(lane);
     return !curr_state_[index] && prev_state_[index];
+}
+
+int input_handler::find_lane_for_key(int key) const {
+    const std::span<const KeyboardKey> lane_keys = key_config_.get_lane_keys(key_count_);
+    for (int lane = 0; lane < key_count_; ++lane) {
+        if (static_cast<int>(lane_keys[static_cast<size_t>(lane)]) == key) {
+            return lane;
+        }
+    }
+    return -1;
+}
+
+void input_handler::apply_native_events(std::span<const native_key_event> native_events) {
+    for (const native_key_event& native_event : native_events) {
+        const int lane = find_lane_for_key(native_event.key);
+        if (lane < 0) {
+            continue;
+        }
+
+        const size_t index = static_cast<size_t>(lane);
+        const bool next_pressed = native_event.type == input_event_type::press;
+        if (curr_state_[index] == next_pressed) {
+            continue;
+        }
+
+        curr_state_[index] = next_pressed;
+        events_.push_back({native_event.type, lane, native_event.timestamp_ms});
+    }
 }

--- a/src/gameplay/input_handler.h
+++ b/src/gameplay/input_handler.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "data_models.h"
+#include "platform/windows_input_source.h"
 #include "raylib.h"
 
 struct key_config {
@@ -30,6 +31,9 @@ public:
 
 private:
     static constexpr int kMaxLanes = 6;
+
+    int find_lane_for_key(int key) const;
+    void apply_native_events(std::span<const native_key_event> native_events);
 
     key_config key_config_;
     int key_count_ = 4;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include "settings_io.h"
 #include "theme.h"
 #include "virtual_screen.h"
+#include "platform/windows_input_source.h"
 
 int main() {
     load_settings(g_settings);
@@ -23,6 +24,7 @@ int main() {
         ToggleFullscreen();
     }
 
+    windows_input_source::instance().initialize(GetWindowHandle());
     virtual_screen::init();
 
     scene_manager manager;
@@ -44,6 +46,7 @@ int main() {
     }
 
     virtual_screen::cleanup();
+    windows_input_source::instance().shutdown();
     audio_manager::instance().shutdown();
     CloseWindow();
 }

--- a/src/platform/windows_input_source.cpp
+++ b/src/platform/windows_input_source.cpp
@@ -1,0 +1,294 @@
+#include <algorithm>
+#include <deque>
+#include <mutex>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#endif
+
+#include "windows_input_source.h"
+
+namespace {
+
+constexpr int kKeyNull = 0;
+constexpr int kKeySpace = 32;
+constexpr int kKeyApostrophe = 39;
+constexpr int kKeyComma = 44;
+constexpr int kKeyMinus = 45;
+constexpr int kKeyPeriod = 46;
+constexpr int kKeySlash = 47;
+constexpr int kKeyLeftBracket = 91;
+constexpr int kKeyBackslash = 92;
+constexpr int kKeyRightBracket = 93;
+constexpr int kKeyGrave = 96;
+constexpr int kKeyTab = 258;
+constexpr int kKeyRight = 262;
+constexpr int kKeyLeft = 263;
+constexpr int kKeyDown = 264;
+constexpr int kKeyUp = 265;
+constexpr int kKeyF1 = 290;
+constexpr int kKeyF2 = 291;
+constexpr int kKeyF3 = 292;
+constexpr int kKeyF4 = 293;
+constexpr int kKeyF5 = 294;
+constexpr int kKeyF6 = 295;
+constexpr int kKeyF7 = 296;
+constexpr int kKeyF8 = 297;
+constexpr int kKeyF9 = 298;
+constexpr int kKeyF10 = 299;
+constexpr int kKeyF11 = 300;
+constexpr int kKeyF12 = 301;
+constexpr int kKeyLeftShift = 340;
+constexpr int kKeyLeftControl = 341;
+constexpr int kKeyLeftAlt = 342;
+constexpr int kKeyRightShift = 344;
+constexpr int kKeyRightControl = 345;
+constexpr int kKeyRightAlt = 346;
+
+class windows_input_source_state {
+public:
+    bool initialize(void* native_window_handle) {
+        std::scoped_lock lock(mutex_);
+
+#ifdef _WIN32
+        if (installed_) {
+            return true;
+        }
+
+        if (native_window_handle == nullptr) {
+            return false;
+        }
+
+        LARGE_INTEGER frequency = {};
+        LARGE_INTEGER origin = {};
+        if (QueryPerformanceFrequency(&frequency) == 0 || QueryPerformanceCounter(&origin) == 0) {
+            return false;
+        }
+
+        hwnd_ = static_cast<HWND>(native_window_handle);
+        SetLastError(0);
+        previous_wnd_proc_ = reinterpret_cast<WNDPROC>(
+            SetWindowLongPtrW(hwnd_, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(&windows_input_source_state::wnd_proc)));
+        if (previous_wnd_proc_ == nullptr && GetLastError() != 0) {
+            hwnd_ = nullptr;
+            return false;
+        }
+
+        installed_ = true;
+        qpc_frequency_ = frequency.QuadPart;
+        qpc_origin_ = origin.QuadPart;
+        queued_events_.clear();
+        sequence_ = 0;
+#else
+        (void)native_window_handle;
+#endif
+
+        return true;
+    }
+
+    void shutdown() {
+        std::scoped_lock lock(mutex_);
+
+#ifdef _WIN32
+        if (installed_ && hwnd_ != nullptr) {
+            SetWindowLongPtrW(hwnd_, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(previous_wnd_proc_));
+        }
+
+        installed_ = false;
+        hwnd_ = nullptr;
+        previous_wnd_proc_ = nullptr;
+#endif
+
+        queued_events_.clear();
+        test_mode_ = false;
+    }
+
+    bool is_available() const {
+        std::scoped_lock lock(mutex_);
+        return installed_ || test_mode_;
+    }
+
+    std::vector<native_key_event> drain_events() {
+        std::scoped_lock lock(mutex_);
+        std::vector<native_key_event> drained;
+        drained.reserve(queued_events_.size());
+        while (!queued_events_.empty()) {
+            drained.push_back(queued_events_.front());
+            queued_events_.pop_front();
+        }
+        return drained;
+    }
+
+    void enable_test_mode() {
+        std::scoped_lock lock(mutex_);
+        queued_events_.clear();
+        test_mode_ = true;
+        sequence_ = 0;
+    }
+
+    void push_test_event(native_key_event event) {
+        std::scoped_lock lock(mutex_);
+        test_mode_ = true;
+        if (event.sequence == 0) {
+            event.sequence = ++sequence_;
+        }
+        queued_events_.push_back(event);
+    }
+
+#ifdef _WIN32
+    static LRESULT CALLBACK wnd_proc(HWND hwnd, UINT message, WPARAM w_param, LPARAM l_param) {
+        windows_input_source_state& state = instance();
+        if (state.try_capture_event(message, w_param, l_param)) {
+            return CallWindowProcW(state.previous_wnd_proc_, hwnd, message, w_param, l_param);
+        }
+
+        return CallWindowProcW(state.previous_wnd_proc_, hwnd, message, w_param, l_param);
+    }
+#endif
+
+    static windows_input_source_state& instance() {
+        static windows_input_source_state state;
+        return state;
+    }
+
+private:
+#ifdef _WIN32
+    bool try_capture_event(UINT message, WPARAM w_param, LPARAM l_param) {
+        std::scoped_lock lock(mutex_);
+        if (!installed_) {
+            return false;
+        }
+
+        if (message != WM_KEYDOWN && message != WM_SYSKEYDOWN &&
+            message != WM_KEYUP && message != WM_SYSKEYUP) {
+            return false;
+        }
+
+        const bool pressed = message == WM_KEYDOWN || message == WM_SYSKEYDOWN;
+        if (pressed && (l_param & (1LL << 30)) != 0) {
+            return false;
+        }
+
+        const int key = translate_key(w_param, l_param);
+        if (key == kKeyNull) {
+            return false;
+        }
+
+        LARGE_INTEGER counter = {};
+        if (QueryPerformanceCounter(&counter) == 0 || qpc_frequency_ == 0) {
+            return false;
+        }
+
+        native_key_event event;
+        event.key = key;
+        event.type = pressed ? input_event_type::press : input_event_type::release;
+        event.timestamp_ms =
+            static_cast<double>(counter.QuadPart - qpc_origin_) * 1000.0 / static_cast<double>(qpc_frequency_);
+        event.sequence = ++sequence_;
+        queued_events_.push_back(event);
+        return true;
+    }
+
+    static int translate_key(WPARAM w_param, LPARAM l_param) {
+        UINT virtual_key = static_cast<UINT>(w_param);
+        const UINT scan_code = (static_cast<UINT>(l_param) >> 16) & 0xff;
+        const bool extended = (static_cast<UINT>(l_param) & 0x01000000U) != 0;
+
+        if (virtual_key == VK_SHIFT) {
+            virtual_key = MapVirtualKeyW(scan_code, MAPVK_VSC_TO_VK_EX);
+        } else if (virtual_key == VK_CONTROL) {
+            virtual_key = extended ? VK_RCONTROL : VK_LCONTROL;
+        } else if (virtual_key == VK_MENU) {
+            virtual_key = extended ? VK_RMENU : VK_LMENU;
+        }
+
+        if ((virtual_key >= '0' && virtual_key <= '9') || (virtual_key >= 'A' && virtual_key <= 'Z')) {
+            return static_cast<int>(virtual_key);
+        }
+
+        switch (virtual_key) {
+            case VK_SPACE: return kKeySpace;
+            case VK_TAB: return kKeyTab;
+            case VK_LEFT: return kKeyLeft;
+            case VK_RIGHT: return kKeyRight;
+            case VK_UP: return kKeyUp;
+            case VK_DOWN: return kKeyDown;
+            case VK_OEM_COMMA: return kKeyComma;
+            case VK_OEM_PERIOD: return kKeyPeriod;
+            case VK_OEM_2: return kKeySlash;
+            case VK_OEM_1: return 59;
+            case VK_OEM_7: return kKeyApostrophe;
+            case VK_OEM_4: return kKeyLeftBracket;
+            case VK_OEM_6: return kKeyRightBracket;
+            case VK_OEM_5: return kKeyBackslash;
+            case VK_OEM_MINUS: return kKeyMinus;
+            case VK_OEM_PLUS: return 61;
+            case VK_OEM_3: return kKeyGrave;
+            case VK_F1: return kKeyF1;
+            case VK_F2: return kKeyF2;
+            case VK_F3: return kKeyF3;
+            case VK_F4: return kKeyF4;
+            case VK_F5: return kKeyF5;
+            case VK_F6: return kKeyF6;
+            case VK_F7: return kKeyF7;
+            case VK_F8: return kKeyF8;
+            case VK_F9: return kKeyF9;
+            case VK_F10: return kKeyF10;
+            case VK_F11: return kKeyF11;
+            case VK_F12: return kKeyF12;
+            case VK_LSHIFT: return kKeyLeftShift;
+            case VK_RSHIFT: return kKeyRightShift;
+            case VK_LCONTROL: return kKeyLeftControl;
+            case VK_RCONTROL: return kKeyRightControl;
+            case VK_LMENU: return kKeyLeftAlt;
+            case VK_RMENU: return kKeyRightAlt;
+            default: return kKeyNull;
+        }
+    }
+
+    HWND hwnd_ = nullptr;
+    WNDPROC previous_wnd_proc_ = nullptr;
+    long long qpc_frequency_ = 0;
+    long long qpc_origin_ = 0;
+#endif
+
+    mutable std::mutex mutex_;
+    std::deque<native_key_event> queued_events_;
+    std::uint64_t sequence_ = 0;
+    bool test_mode_ = false;
+    bool installed_ = false;
+};
+
+}  // namespace
+
+windows_input_source& windows_input_source::instance() {
+    static windows_input_source source;
+    return source;
+}
+
+bool windows_input_source::initialize(void* native_window_handle) {
+    return windows_input_source_state::instance().initialize(native_window_handle);
+}
+
+void windows_input_source::shutdown() {
+    windows_input_source_state::instance().shutdown();
+}
+
+bool windows_input_source::is_available() const {
+    return windows_input_source_state::instance().is_available();
+}
+
+std::vector<native_key_event> windows_input_source::drain_events() {
+    return windows_input_source_state::instance().drain_events();
+}
+
+void windows_input_source::enable_test_mode() {
+    windows_input_source_state::instance().enable_test_mode();
+}
+
+void windows_input_source::push_test_event(native_key_event event) {
+    windows_input_source_state::instance().push_test_event(std::move(event));
+}

--- a/src/platform/windows_input_source.h
+++ b/src/platform/windows_input_source.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstdint>
+#include <vector>
+
+#include "data_models.h"
+
+struct native_key_event {
+    int key = 0;
+    input_event_type type = input_event_type::press;
+    double timestamp_ms = 0.0;
+    std::uint64_t sequence = 0;
+};
+
+class windows_input_source final {
+public:
+    static windows_input_source& instance();
+
+    bool initialize(void* native_window_handle);
+    void shutdown();
+    bool is_available() const;
+
+    std::vector<native_key_event> drain_events();
+
+    void enable_test_mode();
+    void push_test_event(native_key_event event);
+
+private:
+    windows_input_source() = default;
+};

--- a/src/tests/input_handler_smoke.cpp
+++ b/src/tests/input_handler_smoke.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "input_handler.h"
+#include "platform/windows_input_source.h"
 
 int main() {
     input_handler handler;
@@ -48,6 +49,42 @@ int main() {
         std::cerr << "6-key mode detection failed\n";
         return EXIT_FAILURE;
     }
+
+    windows_input_source::instance().enable_test_mode();
+    handler = input_handler();
+    handler.set_key_count(4);
+    windows_input_source::instance().push_test_event({KEY_D, input_event_type::press, 10.0, 1});
+    windows_input_source::instance().push_test_event({KEY_F, input_event_type::press, 10.5, 2});
+    windows_input_source::instance().push_test_event({KEY_D, input_event_type::release, 20.0, 3});
+    handler.update(999.0);
+
+    const std::span<const input_event> native_events = handler.events();
+    if (native_events.size() != 3 || native_events[0].lane != 0 || native_events[1].lane != 1 ||
+        native_events[2].type != input_event_type::release || native_events[2].lane != 0) {
+        std::cerr << "Native event ordering failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (native_events[0].timestamp_ms != 10.0 || native_events[1].timestamp_ms != 10.5 ||
+        native_events[2].timestamp_ms != 20.0) {
+        std::cerr << "Native event timestamps failed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (handler.is_lane_held(0) || !handler.is_lane_held(1) || handler.is_lane_just_pressed(0)) {
+        std::cerr << "Native event state tracking failed\n";
+        return EXIT_FAILURE;
+    }
+
+    handler.set_key_count(6);
+    windows_input_source::instance().push_test_event({KEY_L, input_event_type::press, 30.0, 4});
+    handler.update(999.0);
+    if (handler.events().size() != 1 || handler.events()[0].lane != 5 || !handler.is_lane_held(5)) {
+        std::cerr << "Native 6-key mapping failed\n";
+        return EXIT_FAILURE;
+    }
+
+    windows_input_source::instance().shutdown();
 
     std::cout << "input_handler smoke test passed\n";
     return EXIT_SUCCESS;


### PR DESCRIPTION
## 概要
- Win32 のキーイベントを高精度時刻付きで受け取る windows_input_source を追加
- input_handler がネイティブ入力イベントバッファを取り込めるように更新
- native イベント未取得時は既存ポーリングへフォールバックするように調整
- input handler smoke test に 4K/6K マッピングと順序付きイベント確認を追加

## 確認
- ローカルでビルド通過
- 実機で入力検知を確認

Closes #61
Part of #56