### PR TITLE
譜面エディタ: chart_serializerを実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ add_executable(raythm src/main.cpp
         src/platform/windows_input_source.h
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
+        src/gameplay/chart_serializer.cpp
+        src/gameplay/chart_serializer.h
         src/models/data_models.h
         src/gameplay/input_handler.cpp
         src/gameplay/input_handler.h
@@ -65,6 +67,14 @@ add_executable(chart_parser_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
         src/tests/chart_parser_smoke.cpp
+        src/models/data_models.h)
+
+add_executable(chart_serializer_smoke
+        src/gameplay/chart_parser.cpp
+        src/gameplay/chart_parser.h
+        src/gameplay/chart_serializer.cpp
+        src/gameplay/chart_serializer.h
+        src/tests/chart_serializer_smoke.cpp
         src/models/data_models.h)
 
 add_executable(song_loader_smoke
@@ -128,6 +138,7 @@ set(RAYTHM_INCLUDE_DIRS
 # BASSライブラリ
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(chart_parser_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(chart_serializer_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(song_loader_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(input_handler_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(timing_engine_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})

--- a/src/gameplay/chart_serializer.cpp
+++ b/src/gameplay/chart_serializer.cpp
@@ -1,0 +1,91 @@
+#include "chart_serializer.h"
+
+#include <algorithm>
+#include <array>
+#include <fstream>
+#include <iomanip>
+#include <limits>
+#include <sstream>
+#include <vector>
+
+namespace {
+std::string format_float(float value) {
+    std::ostringstream stream;
+    stream << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
+    return stream.str();
+}
+
+const char* timing_type_name(timing_event_type type) {
+    switch (type) {
+        case timing_event_type::bpm:
+            return "bpm";
+        case timing_event_type::meter:
+            return "meter";
+    }
+
+    return "";
+}
+
+const char* note_type_name(note_type type) {
+    switch (type) {
+        case note_type::tap:
+            return "tap";
+        case note_type::hold:
+            return "hold";
+    }
+
+    return "";
+}
+}
+
+bool chart_serializer::serialize(const chart_data& data, const std::string& file_path) {
+    std::ofstream output(file_path, std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "[Metadata]\n";
+    output << "chartId=" << data.meta.chart_id << '\n';
+    output << "keyCount=" << data.meta.key_count << '\n';
+    output << "difficulty=" << data.meta.difficulty << '\n';
+    output << "level=" << data.meta.level << '\n';
+    output << "chartAuthor=" << data.meta.chart_author << '\n';
+    output << "formatVersion=" << data.meta.format_version << '\n';
+    output << "resolution=" << data.meta.resolution << "\n\n";
+
+    std::vector<timing_event> sorted_timing = data.timing_events;
+    std::stable_sort(sorted_timing.begin(), sorted_timing.end(), [](const timing_event& left, const timing_event& right) {
+        return left.tick < right.tick;
+    });
+
+    output << "[Timing]\n";
+    for (const timing_event& event : sorted_timing) {
+        output << timing_type_name(event.type) << ',' << event.tick << ',';
+        if (event.type == timing_event_type::bpm) {
+            output << format_float(event.bpm);
+        } else {
+            output << event.numerator << '/' << event.denominator;
+        }
+        output << '\n';
+    }
+    output << '\n';
+
+    std::vector<note_data> sorted_notes = data.notes;
+    std::sort(sorted_notes.begin(), sorted_notes.end(), [](const note_data& left, const note_data& right) {
+        if (left.tick != right.tick) {
+            return left.tick < right.tick;
+        }
+        return left.lane < right.lane;
+    });
+
+    output << "[Notes]\n";
+    for (const note_data& note : sorted_notes) {
+        output << note_type_name(note.type) << ',' << note.tick << ',' << note.lane;
+        if (note.type == note_type::hold) {
+            output << ',' << note.end_tick;
+        }
+        output << '\n';
+    }
+
+    return output.good();
+}

--- a/src/gameplay/chart_serializer.h
+++ b/src/gameplay/chart_serializer.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+
+#include "data_models.h"
+
+class chart_serializer {
+public:
+    static bool serialize(const chart_data& data, const std::string& file_path);
+};

--- a/src/tests/chart_serializer_smoke.cpp
+++ b/src/tests/chart_serializer_smoke.cpp
@@ -1,0 +1,156 @@
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iterator>
+#include <iostream>
+#include <string>
+
+#include "chart_parser.h"
+#include "chart_serializer.h"
+
+namespace {
+bool almost_equal(float left, float right) {
+    return std::fabs(left - right) < 0.0001f;
+}
+
+bool equal_chart_meta(const chart_meta& left, const chart_meta& right) {
+    return left.chart_id == right.chart_id &&
+           left.key_count == right.key_count &&
+           left.difficulty == right.difficulty &&
+           left.level == right.level &&
+           left.chart_author == right.chart_author &&
+           left.format_version == right.format_version &&
+           left.resolution == right.resolution;
+}
+
+bool equal_timing_event(const timing_event& left, const timing_event& right) {
+    return left.type == right.type &&
+           left.tick == right.tick &&
+           almost_equal(left.bpm, right.bpm) &&
+           left.numerator == right.numerator &&
+           left.denominator == right.denominator;
+}
+
+bool equal_note(const note_data& left, const note_data& right) {
+    return left.type == right.type &&
+           left.tick == right.tick &&
+           left.lane == right.lane &&
+           left.end_tick == right.end_tick;
+}
+
+bool equal_chart_data(const chart_data& left, const chart_data& right) {
+    if (!equal_chart_meta(left.meta, right.meta) ||
+        left.timing_events.size() != right.timing_events.size() ||
+        left.notes.size() != right.notes.size()) {
+        return false;
+    }
+
+    for (size_t i = 0; i < left.timing_events.size(); ++i) {
+        if (!equal_timing_event(left.timing_events[i], right.timing_events[i])) {
+            return false;
+        }
+    }
+
+    for (size_t i = 0; i < left.notes.size(); ++i) {
+        if (!equal_note(left.notes[i], right.notes[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+chart_data normalized_chart(chart_data data) {
+    std::stable_sort(data.timing_events.begin(), data.timing_events.end(), [](const timing_event& left, const timing_event& right) {
+        return left.tick < right.tick;
+    });
+
+    std::sort(data.notes.begin(), data.notes.end(), [](const note_data& left, const note_data& right) {
+        if (left.tick != right.tick) {
+            return left.tick < right.tick;
+        }
+        return left.lane < right.lane;
+    });
+
+    return data;
+}
+
+std::string read_text_file(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+bool expect_contains_in_order(const std::string& content, const std::string& first, const std::string& second) {
+    const size_t first_pos = content.find(first);
+    const size_t second_pos = content.find(second);
+    return first_pos != std::string::npos && second_pos != std::string::npos && first_pos < second_pos;
+}
+}
+
+int main() {
+    const std::filesystem::path output_path =
+        std::filesystem::temp_directory_path() / "raythm_chart_serializer_smoke.chart";
+
+    chart_data source;
+    source.meta.chart_id = "serializer-smoke";
+    source.meta.key_count = 4;
+    source.meta.difficulty = "Hyper";
+    source.meta.level = 9;
+    source.meta.chart_author = "Codex";
+    source.meta.format_version = 1;
+    source.meta.resolution = 480;
+
+    source.timing_events = {
+        {.type = timing_event_type::bpm, .tick = 960, .bpm = 180.5f, .numerator = 4, .denominator = 4},
+        {.type = timing_event_type::meter, .tick = 0, .bpm = 0.0f, .numerator = 4, .denominator = 4},
+        {.type = timing_event_type::bpm, .tick = 0, .bpm = 150.0f, .numerator = 4, .denominator = 4},
+    };
+
+    source.notes = {
+        {.type = note_type::tap, .tick = 960, .lane = 3, .end_tick = 960},
+        {.type = note_type::hold, .tick = 480, .lane = 2, .end_tick = 840},
+        {.type = note_type::tap, .tick = 480, .lane = 0, .end_tick = 480},
+        {.type = note_type::tap, .tick = 0, .lane = 1, .end_tick = 0},
+    };
+
+    const bool serialized = chart_serializer::serialize(source, output_path.string());
+    if (!serialized) {
+        std::cerr << "Failed to serialize chart to " << output_path << '\n';
+        return EXIT_FAILURE;
+    }
+
+    const std::string content = read_text_file(output_path);
+    bool ok = true;
+
+    ok = expect_contains_in_order(content, "meter,0,4/4", "bpm,960,180.5") && ok;
+    ok = expect_contains_in_order(content, "tap,480,0", "hold,480,2,840") && ok;
+
+    const chart_parse_result reparsed = chart_parser::parse(output_path.string());
+    if (!reparsed.success || !reparsed.data.has_value()) {
+        std::cerr << "Failed to parse serialized chart\n";
+        for (const std::string& error : reparsed.errors) {
+            std::cerr << "  " << error << '\n';
+        }
+        std::remove(output_path.string().c_str());
+        return EXIT_FAILURE;
+    }
+
+    const chart_data expected = normalized_chart(source);
+    if (!equal_chart_data(expected, *reparsed.data)) {
+        std::cerr << "Round-trip chart data mismatch\n";
+        ok = false;
+    }
+
+    std::remove(output_path.string().c_str());
+
+    if (!ok) {
+        std::cerr << "chart_serializer smoke test failed\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "chart_serializer smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- chart_data を .chart ファイルへ書き出す chart_serializer を追加
- Timing と Notes の出力順を要件どおりにソート
- parse -> serialize -> re-parse の往復スモークテストを追加

## 確認
- chart_serializer_smoke がローカルで通過（ユーザー確認）

Closes #68