### PR TITLE
譜面エディタ: エディタ状態管理とUndo/Redoコマンド基盤を実装

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,9 @@ add_executable(raythm src/main.cpp
         src/audio/audio.h
         src/audio/audio_manager.cpp
         src/audio/audio_manager.h
+        src/editor/editor_command.h
+        src/editor/editor_state.cpp
+        src/editor/editor_state.h
         src/platform/windows_input_source.cpp
         src/platform/windows_input_source.h
         src/gameplay/chart_parser.cpp
@@ -77,6 +80,15 @@ add_executable(chart_serializer_smoke
         src/tests/chart_serializer_smoke.cpp
         src/models/data_models.h)
 
+add_executable(editor_state_smoke
+        src/editor/editor_command.h
+        src/editor/editor_state.cpp
+        src/editor/editor_state.h
+        src/models/data_models.h
+        src/gameplay/timing_engine.cpp
+        src/gameplay/timing_engine.h
+        src/tests/editor_state_smoke.cpp)
+
 add_executable(song_loader_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
@@ -128,6 +140,7 @@ set(RAYTHM_INCLUDE_DIRS
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_SOURCE_DIR}/src/audio
         ${CMAKE_SOURCE_DIR}/src/core
+        ${CMAKE_SOURCE_DIR}/src/editor
         ${CMAKE_SOURCE_DIR}/src/gameplay
         ${CMAKE_SOURCE_DIR}/src/models
         ${CMAKE_SOURCE_DIR}/src/scenes
@@ -139,6 +152,7 @@ set(RAYTHM_INCLUDE_DIRS
 target_include_directories(raythm PRIVATE ${CMAKE_SOURCE_DIR}/libs/bass ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(chart_parser_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(chart_serializer_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(editor_state_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(song_loader_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(input_handler_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(timing_engine_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})

--- a/src/editor/editor_command.h
+++ b/src/editor/editor_command.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstddef>
+#include <memory>
+#include <vector>
+
+class editor_command {
+public:
+    virtual ~editor_command() = default;
+
+    virtual void execute() = 0;
+    virtual void undo() = 0;
+};
+
+class command_history {
+public:
+    void push(std::unique_ptr<editor_command> command) {
+        if (!command) {
+            return;
+        }
+
+        if (cursor_ < commands_.size()) {
+            commands_.erase(commands_.begin() + static_cast<std::ptrdiff_t>(cursor_), commands_.end());
+        }
+
+        command->execute();
+        commands_.push_back(std::move(command));
+        cursor_ = commands_.size();
+    }
+
+    bool undo() {
+        if (!can_undo()) {
+            return false;
+        }
+
+        --cursor_;
+        commands_[cursor_]->undo();
+        return true;
+    }
+
+    bool redo() {
+        if (!can_redo()) {
+            return false;
+        }
+
+        commands_[cursor_]->execute();
+        ++cursor_;
+        return true;
+    }
+
+    bool can_undo() const {
+        return cursor_ > 0;
+    }
+
+    bool can_redo() const {
+        return cursor_ < commands_.size();
+    }
+
+    void clear() {
+        commands_.clear();
+        cursor_ = 0;
+    }
+
+    size_t current_index() const {
+        return cursor_;
+    }
+
+private:
+    std::vector<std::unique_ptr<editor_command>> commands_;
+    size_t cursor_ = 0;
+};

--- a/src/editor/editor_state.cpp
+++ b/src/editor/editor_state.cpp
@@ -1,0 +1,299 @@
+#include "editor_state.h"
+
+#include <memory>
+#include <utility>
+
+namespace {
+class add_note_command final : public editor_command {
+public:
+    add_note_command(chart_data& chart, note_data note) : chart_(chart), note_(std::move(note)) {}
+
+    void execute() override {
+        chart_.notes.push_back(note_);
+    }
+
+    void undo() override {
+        chart_.notes.pop_back();
+    }
+
+private:
+    chart_data& chart_;
+    note_data note_;
+};
+
+class remove_note_command final : public editor_command {
+public:
+    remove_note_command(chart_data& chart, size_t index) : chart_(chart), index_(index), removed_(chart.notes[index]) {}
+
+    void execute() override {
+        chart_.notes.erase(chart_.notes.begin() + static_cast<std::ptrdiff_t>(index_));
+    }
+
+    void undo() override {
+        chart_.notes.insert(chart_.notes.begin() + static_cast<std::ptrdiff_t>(index_), removed_);
+    }
+
+private:
+    chart_data& chart_;
+    size_t index_ = 0;
+    note_data removed_;
+};
+
+class modify_note_command final : public editor_command {
+public:
+    modify_note_command(chart_data& chart, size_t index, note_data updated)
+        : chart_(chart), index_(index), before_(chart.notes[index]), after_(std::move(updated)) {}
+
+    void execute() override {
+        chart_.notes[index_] = after_;
+    }
+
+    void undo() override {
+        chart_.notes[index_] = before_;
+    }
+
+private:
+    chart_data& chart_;
+    size_t index_ = 0;
+    note_data before_;
+    note_data after_;
+};
+
+class add_timing_event_command final : public editor_command {
+public:
+    add_timing_event_command(chart_data& chart, timing_engine& engine, timing_event event)
+        : chart_(chart), engine_(engine), event_(std::move(event)) {}
+
+    void execute() override {
+        chart_.timing_events.push_back(event_);
+        rebuild();
+    }
+
+    void undo() override {
+        chart_.timing_events.pop_back();
+        rebuild();
+    }
+
+private:
+    void rebuild() {
+        engine_.init(chart_.timing_events, chart_.meta.resolution);
+    }
+
+    chart_data& chart_;
+    timing_engine& engine_;
+    timing_event event_;
+};
+
+class remove_timing_event_command final : public editor_command {
+public:
+    remove_timing_event_command(chart_data& chart, timing_engine& engine, size_t index)
+        : chart_(chart), engine_(engine), index_(index), removed_(chart.timing_events[index]) {}
+
+    void execute() override {
+        chart_.timing_events.erase(chart_.timing_events.begin() + static_cast<std::ptrdiff_t>(index_));
+        rebuild();
+    }
+
+    void undo() override {
+        chart_.timing_events.insert(chart_.timing_events.begin() + static_cast<std::ptrdiff_t>(index_), removed_);
+        rebuild();
+    }
+
+private:
+    void rebuild() {
+        engine_.init(chart_.timing_events, chart_.meta.resolution);
+    }
+
+    chart_data& chart_;
+    timing_engine& engine_;
+    size_t index_ = 0;
+    timing_event removed_;
+};
+
+class modify_timing_event_command final : public editor_command {
+public:
+    modify_timing_event_command(chart_data& chart, timing_engine& engine, size_t index, timing_event updated)
+        : chart_(chart), engine_(engine), index_(index), before_(chart.timing_events[index]), after_(std::move(updated)) {}
+
+    void execute() override {
+        chart_.timing_events[index_] = after_;
+        rebuild();
+    }
+
+    void undo() override {
+        chart_.timing_events[index_] = before_;
+        rebuild();
+    }
+
+private:
+    void rebuild() {
+        engine_.init(chart_.timing_events, chart_.meta.resolution);
+    }
+
+    chart_data& chart_;
+    timing_engine& engine_;
+    size_t index_ = 0;
+    timing_event before_;
+    timing_event after_;
+};
+
+class modify_metadata_command final : public editor_command {
+public:
+    modify_metadata_command(chart_data& chart, timing_engine& engine, chart_meta updated)
+        : chart_(chart), engine_(engine), before_(chart.meta), after_(std::move(updated)) {}
+
+    void execute() override {
+        chart_.meta = after_;
+        rebuild();
+    }
+
+    void undo() override {
+        chart_.meta = before_;
+        rebuild();
+    }
+
+private:
+    void rebuild() {
+        engine_.init(chart_.timing_events, chart_.meta.resolution);
+    }
+
+    chart_data& chart_;
+    timing_engine& engine_;
+    chart_meta before_;
+    chart_meta after_;
+};
+}
+
+editor_state::editor_state() {
+    chart_.meta.resolution = 480;
+    rebuild_timing_engine();
+}
+
+editor_state::editor_state(chart_data data, std::string file_path) {
+    load(std::move(data), std::move(file_path));
+}
+
+void editor_state::load(chart_data data, std::string file_path) {
+    chart_ = std::move(data);
+    file_path_ = std::move(file_path);
+    history_.clear();
+    saved_history_index_ = 0;
+    dirty_ = false;
+    rebuild_timing_engine();
+}
+
+void editor_state::mark_saved(std::string file_path) {
+    if (!file_path.empty()) {
+        file_path_ = std::move(file_path);
+    }
+
+    saved_history_index_ = history_.current_index();
+    sync_dirty_flag();
+}
+
+bool editor_state::undo() {
+    const bool changed = history_.undo();
+    if (changed) {
+        sync_dirty_flag();
+    }
+    return changed;
+}
+
+bool editor_state::redo() {
+    const bool changed = history_.redo();
+    if (changed) {
+        sync_dirty_flag();
+    }
+    return changed;
+}
+
+bool editor_state::can_undo() const {
+    return history_.can_undo();
+}
+
+bool editor_state::can_redo() const {
+    return history_.can_redo();
+}
+
+void editor_state::add_note(note_data note) {
+    history_.push(std::make_unique<add_note_command>(chart_, std::move(note)));
+    sync_dirty_flag();
+}
+
+bool editor_state::remove_note(size_t index) {
+    if (index >= chart_.notes.size()) {
+        return false;
+    }
+
+    history_.push(std::make_unique<remove_note_command>(chart_, index));
+    sync_dirty_flag();
+    return true;
+}
+
+bool editor_state::modify_note(size_t index, note_data note) {
+    if (index >= chart_.notes.size()) {
+        return false;
+    }
+
+    history_.push(std::make_unique<modify_note_command>(chart_, index, std::move(note)));
+    sync_dirty_flag();
+    return true;
+}
+
+void editor_state::add_timing_event(timing_event event) {
+    history_.push(std::make_unique<add_timing_event_command>(chart_, timing_engine_, std::move(event)));
+    sync_dirty_flag();
+}
+
+bool editor_state::remove_timing_event(size_t index) {
+    if (index >= chart_.timing_events.size()) {
+        return false;
+    }
+
+    history_.push(std::make_unique<remove_timing_event_command>(chart_, timing_engine_, index));
+    sync_dirty_flag();
+    return true;
+}
+
+bool editor_state::modify_timing_event(size_t index, timing_event event) {
+    if (index >= chart_.timing_events.size()) {
+        return false;
+    }
+
+    history_.push(std::make_unique<modify_timing_event_command>(chart_, timing_engine_, index, std::move(event)));
+    sync_dirty_flag();
+    return true;
+}
+
+void editor_state::modify_metadata(chart_meta meta) {
+    history_.push(std::make_unique<modify_metadata_command>(chart_, timing_engine_, std::move(meta)));
+    sync_dirty_flag();
+}
+
+const chart_data& editor_state::data() const {
+    return chart_;
+}
+
+const timing_engine& editor_state::engine() const {
+    return timing_engine_;
+}
+
+bool editor_state::is_dirty() const {
+    return dirty_;
+}
+
+const std::string& editor_state::file_path() const {
+    return file_path_;
+}
+
+void editor_state::set_file_path(std::string file_path) {
+    file_path_ = std::move(file_path);
+}
+
+void editor_state::rebuild_timing_engine() {
+    timing_engine_.init(chart_.timing_events, chart_.meta.resolution);
+}
+
+void editor_state::sync_dirty_flag() {
+    dirty_ = history_.current_index() != saved_history_index_;
+}

--- a/src/editor/editor_state.h
+++ b/src/editor/editor_state.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+
+#include "editor_command.h"
+#include "timing_engine.h"
+
+class editor_state {
+public:
+    editor_state();
+    explicit editor_state(chart_data data, std::string file_path = "");
+
+    void load(chart_data data, std::string file_path = "");
+    void mark_saved(std::string file_path = "");
+
+    bool undo();
+    bool redo();
+    bool can_undo() const;
+    bool can_redo() const;
+
+    void add_note(note_data note);
+    bool remove_note(size_t index);
+    bool modify_note(size_t index, note_data note);
+
+    void add_timing_event(timing_event event);
+    bool remove_timing_event(size_t index);
+    bool modify_timing_event(size_t index, timing_event event);
+
+    void modify_metadata(chart_meta meta);
+
+    const chart_data& data() const;
+
+    const timing_engine& engine() const;
+
+    bool is_dirty() const;
+    const std::string& file_path() const;
+    void set_file_path(std::string file_path);
+
+private:
+    void rebuild_timing_engine();
+    void sync_dirty_flag();
+
+    chart_data chart_;
+    command_history history_;
+    timing_engine timing_engine_;
+    bool dirty_ = false;
+    std::string file_path_;
+    size_t saved_history_index_ = 0;
+};

--- a/src/tests/editor_state_smoke.cpp
+++ b/src/tests/editor_state_smoke.cpp
@@ -1,0 +1,168 @@
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "editor_state.h"
+
+namespace {
+bool nearly_equal(double left, double right) {
+    return std::fabs(left - right) < 0.001;
+}
+
+chart_data make_chart() {
+    chart_data data;
+    data.meta.chart_id = "editor-state-smoke";
+    data.meta.key_count = 4;
+    data.meta.difficulty = "Normal";
+    data.meta.level = 5;
+    data.meta.chart_author = "Codex";
+    data.meta.format_version = 1;
+    data.meta.resolution = 480;
+    data.timing_events = {
+        {timing_event_type::bpm, 0, 120.0f, 4, 4},
+        {timing_event_type::meter, 0, 0.0f, 4, 4},
+    };
+    data.notes = {
+        {note_type::tap, 0, 0, 0},
+        {note_type::hold, 480, 2, 960},
+    };
+    return data;
+}
+}
+
+int main() {
+    editor_state state(make_chart(), "assets/charts/editor_state.chart");
+
+    if (state.is_dirty()) {
+        std::cerr << "freshly loaded state should not be dirty\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!nearly_equal(state.engine().tick_to_ms(480), 500.0)) {
+        std::cerr << "initial timing engine state is invalid\n";
+        return EXIT_FAILURE;
+    }
+
+    state.add_note({note_type::tap, 240, 1, 240});
+    if (state.data().notes.size() != 3 || !state.can_undo() || state.can_redo() || !state.is_dirty()) {
+        std::cerr << "add_note did not update history correctly\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.modify_note(0, {note_type::tap, 120, 3, 120})) {
+        std::cerr << "modify_note should succeed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (state.modify_note(99, {note_type::tap, 999, 0, 999})) {
+        std::cerr << "modify_note should fail for an invalid index\n";
+        return EXIT_FAILURE;
+    }
+
+    if (state.data().notes[0].tick != 120 || state.data().notes[0].lane != 3) {
+        std::cerr << "modify_note did not update note data\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.remove_note(1) || state.data().notes.size() != 2) {
+        std::cerr << "remove_note did not remove the selected note\n";
+        return EXIT_FAILURE;
+    }
+
+    state.add_timing_event({timing_event_type::bpm, 480, 240.0f, 4, 4});
+    if (!nearly_equal(state.engine().tick_to_ms(960), 750.0)) {
+        std::cerr << "timing engine was not rebuilt after add_timing_event\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.modify_timing_event(0, {timing_event_type::bpm, 0, 150.0f, 4, 4})) {
+        std::cerr << "modify_timing_event should succeed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (state.remove_timing_event(99)) {
+        std::cerr << "remove_timing_event should fail for an invalid index\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!nearly_equal(state.engine().tick_to_ms(480), 400.0)) {
+        std::cerr << "timing engine was not rebuilt after modify_timing_event\n";
+        return EXIT_FAILURE;
+    }
+
+    chart_meta updated_meta = state.data().meta;
+    updated_meta.resolution = 960;
+    updated_meta.level = 7;
+    state.modify_metadata(updated_meta);
+    if (state.data().meta.resolution != 960 || state.data().meta.level != 7) {
+        std::cerr << "modify_metadata did not update metadata\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!nearly_equal(state.engine().tick_to_ms(480), 200.0)) {
+        std::cerr << "timing engine was not rebuilt after metadata change\n";
+        return EXIT_FAILURE;
+    }
+
+    state.mark_saved("assets/charts/editor_state_saved.chart");
+    if (state.is_dirty() || state.file_path() != "assets/charts/editor_state_saved.chart") {
+        std::cerr << "mark_saved did not update save state\n";
+        return EXIT_FAILURE;
+    }
+
+    state.add_note({note_type::tap, 720, 0, 720});
+    if (!state.undo()) {
+        std::cerr << "undo should succeed after additional edit\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.can_redo()) {
+        std::cerr << "redo should be available after undo\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.redo()) {
+        std::cerr << "redo should succeed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.undo()) {
+        std::cerr << "undo should succeed\n";
+        return EXIT_FAILURE;
+    }
+
+    if (state.data().notes.size() != 2) {
+        std::cerr << "undo did not revert last note addition\n";
+        return EXIT_FAILURE;
+    }
+
+    if (state.is_dirty()) {
+        std::cerr << "state should return to clean after undoing back to the saved point\n";
+        return EXIT_FAILURE;
+    }
+
+    state.add_note({note_type::tap, 840, 1, 840});
+    if (state.can_redo()) {
+        std::cerr << "redo stack should be cleared by a new command after undo\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.is_dirty()) {
+        std::cerr << "state should become dirty after adding a replacement command\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!state.undo()) {
+        std::cerr << "undo should succeed for the replacement command\n";
+        return EXIT_FAILURE;
+    }
+
+    if (state.is_dirty()) {
+        std::cerr << "state should return to clean after undoing to the saved point\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "editor_state smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- editor_state と command_history を追加し、ノート・タイミング・メタデータ編集をコマンド化
- undo/redo、dirty flag、ファイルパス管理を editor_state に実装
- timing イベントや resolution 変更時に timing_engine を再構築するスモークテストを追加

## 確認
- editor_state_smoke がローカルで通過（ユーザー確認）

Closes #69