### PR TITLE
raylib 描画境界の座標変換を共通化

### DIFF
--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -561,8 +561,8 @@ void editor_scene::draw_left_panel() {
     const Rectangle header_rect = ui::place(content, content.width, 54.0f, ui::anchor::top_left, ui::anchor::top_left);
     ui::draw_header_block(header_rect, "Chart", has_file ? "Existing chart" : "New chart", 28, 18, 4.0f);
     const Rectangle song_title_rect = {header_rect.x, header_rect.y + 58.0f, header_rect.width, 24.0f};
-    draw_marquee_text(song_.meta.title.c_str(), static_cast<int>(song_title_rect.x),
-                      static_cast<int>(song_title_rect.y + 2.0f), 18, t.text_secondary, song_title_rect.width, now);
+    draw_marquee_text(song_.meta.title.c_str(), song_title_rect.x,
+                      song_title_rect.y + 2.0f, 18, t.text_secondary, song_title_rect.width, now);
 
     const Rectangle meta_box = {content.x, content.y + 100.0f, content.width, 142.0f};
     ui::draw_section(meta_box);
@@ -659,8 +659,7 @@ void editor_scene::draw_timeline() const {
     const Rectangle track = timeline_scrollbar_track_rect();
 
     DrawRectangleRec(ui::inset(kTimelineRect, 10.0f), t.section);
-    BeginScissorMode(static_cast<int>(content.x), static_cast<int>(content.y),
-                     static_cast<int>(content.width), static_cast<int>(content.height));
+    ui::begin_scissor_rect(content);
     draw_timeline_grid(min_tick, max_tick);
     draw_timeline_notes();
     if (note_dragging_) {
@@ -710,23 +709,19 @@ void editor_scene::draw_timeline_grid(int min_tick, int max_tick) const {
     const int first_snap_tick = std::max(0, (min_tick / interval) * interval);
     for (int tick = first_snap_tick; tick <= max_tick; tick += interval) {
         const float y = tick_to_timeline_y(tick);
-        DrawLine(static_cast<int>(content.x), static_cast<int>(y),
-                 static_cast<int>(content.x + content.width), static_cast<int>(y),
-                 with_alpha(t.border_light, 80));
+        ui::draw_line_f(content.x, y, content.x + content.width, y, with_alpha(t.border_light, 80));
     }
 
     for (const grid_line& line : visible_grid_lines(min_tick, max_tick)) {
         const float y = tick_to_timeline_y(line.tick);
         const Color color = line.major ? with_alpha(t.border_active, 255) : with_alpha(t.border_light, 220);
-        DrawLine(static_cast<int>(content.x), static_cast<int>(y),
-                 static_cast<int>(content.x + content.width), static_cast<int>(y), color);
+        ui::draw_line_f(content.x, y, content.x + content.width, y, color);
         if (line.major) {
-            DrawLine(static_cast<int>(content.x), static_cast<int>(y + 1.0f),
-                     static_cast<int>(content.x + content.width), static_cast<int>(y + 1.0f),
-                     with_alpha(t.border_active, 180));
+            ui::draw_line_f(content.x, y + 1.0f, content.x + content.width, y + 1.0f,
+                            with_alpha(t.border_active, 180));
         }
-        DrawText(TextFormat("%d:%d", line.measure, line.beat), static_cast<int>(content.x + 8.0f), static_cast<int>(y - 10.0f),
-                 line.major ? 16 : 14, line.major ? t.text : t.text_secondary);
+        ui::draw_text_f(TextFormat("%d:%d", line.measure, line.beat), content.x + 8.0f, y - 10.0f,
+                        line.major ? 16 : 14, line.major ? t.text : t.text_secondary);
     }
 }
 
@@ -779,8 +774,8 @@ void editor_scene::draw_cursor_hud() const {
                                          {12.0f, -12.0f});
     DrawRectangleRec(hud_rect, with_alpha(t.panel, 240));
     DrawRectangleLinesEx(hud_rect, 1.5f, t.border);
-    DrawText(TextFormat("bar %d:%d   beat %.2f   snap %d", measure, beat_in_measure, beat, snapped_tick),
-             static_cast<int>(hud_rect.x + 12.0f), static_cast<int>(hud_rect.y + 8.0f), 18, t.text);
+    ui::draw_text_f(TextFormat("bar %d:%d   beat %.2f   snap %d", measure, beat_in_measure, beat, snapped_tick),
+                    hud_rect.x + 12.0f, hud_rect.y + 8.0f, 18, t.text);
 }
 
 void editor_scene::draw_header_tools() {

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -102,15 +102,16 @@ void result_scene::draw() {
     const float song_info_max_w = kSongInfoRect.width - 32.0f;
     const double now = GetTime();
     {
-        const int sy = static_cast<int>(kSongInfoRect.y + (kSongInfoRect.height - 82) * 0.5f);
-        const int lx = static_cast<int>(kSongInfoRect.x + 16);
+        const float sy = kSongInfoRect.y + (kSongInfoRect.height - 82.0f) * 0.5f;
+        const float lx = kSongInfoRect.x + 16.0f;
         draw_marquee_text(song_.meta.title.c_str(), lx, sy, 32, t.text, song_info_max_w, now);
         draw_marquee_text(song_.meta.artist.c_str(), lx, sy + 38, 22, t.text_dim, song_info_max_w, now);
         const char* chart_label = TextFormat("%s %s Lv.%d", key_mode_label(chart_.key_count),
                                              chart_.difficulty.c_str(), chart_.level);
         const int chart_label_w = MeasureText(chart_label, 20);
-        DrawText(chart_label, lx, sy + 66, 20, t.accent);
-        DrawText(chart_.chart_author.c_str(), lx + chart_label_w + 16, sy + 66, 20, t.text_muted);
+        ui::draw_text_f(chart_label, lx, sy + 66.0f, 20, t.accent);
+        ui::draw_text_f(chart_.chart_author.c_str(), lx + static_cast<float>(chart_label_w) + 16.0f,
+                        sy + 66.0f, 20, t.text_muted);
     }
 
     // ランク表示
@@ -128,9 +129,7 @@ void result_scene::draw() {
 
     // FAILED 表示
     if (result_.failed) {
-        DrawText("FAILED",
-                 static_cast<int>(kRankRect.x + kRankRect.width + 20),
-                 static_cast<int>(kRankRect.y + 20), 40, t.error);
+        ui::draw_text_f("FAILED", kRankRect.x + kRankRect.width + 20.0f, kRankRect.y + 20.0f, 40, t.error);
     }
 
     // スコア・精度（フレーム中央に配置）

--- a/src/scenes/scene_common.cpp
+++ b/src/scenes/scene_common.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "theme.h"
+#include "ui_coord.h"
 
 namespace {
 
@@ -15,12 +16,8 @@ void draw_text_clipped(const char* text, float x, float y, int font_size, Color 
     const Font font = GetFontDefault();
     const float font_size_f = static_cast<float>(font_size);
     const float spacing = font_size_f / static_cast<float>(font.baseSize);
-    const int scissor_x = static_cast<int>(std::floor(clip_rect.x));
-    const int scissor_y = static_cast<int>(std::floor(clip_rect.y));
-    const int scissor_width = std::max(1, static_cast<int>(std::ceil(clip_rect.x + clip_rect.width) - std::floor(clip_rect.x)));
-    const int scissor_height = std::max(1, static_cast<int>(std::ceil(clip_rect.y + clip_rect.height) - std::floor(clip_rect.y)));
 
-    BeginScissorMode(scissor_x, scissor_y, scissor_width, scissor_height);
+    ui::begin_scissor_rect(clip_rect);
     DrawTextEx(font, text, {x, y}, font_size_f, spacing, color);
     EndScissorMode();
 }
@@ -34,8 +31,8 @@ void draw_scene_frame(const char* title, const char* subtitle, Color accent) {
     DrawRectangleRounded({80.0f, 80.0f, 1120.0f, 560.0f}, 0.04f, 8, g_theme->panel);
     DrawRectangleRoundedLinesEx({80.0f, 80.0f, 1120.0f, 560.0f}, 0.04f, 8, 3.0f, accent);
 
-    DrawText(title, 130, 130, 44, accent);
-    DrawText(subtitle, 130, 190, 24, g_theme->text_secondary);
+    ui::draw_text_f(title, 130.0f, 130.0f, 44, accent);
+    ui::draw_text_f(subtitle, 130.0f, 190.0f, 24, g_theme->text_secondary);
 }
 
 void draw_marquee_text(const char* text, Rectangle clip_rect, int font_size, Color color, double time) {
@@ -78,7 +75,7 @@ void draw_marquee_text(const char* text, Rectangle clip_rect, int font_size, Col
     draw_text_clipped(text, draw_x - offset, draw_y, font_size, color, clip_rect);
 }
 
-void draw_marquee_text(const char* text, int x, int y, int font_size, Color color, float max_width, double time) {
-    draw_marquee_text(text, {static_cast<float>(x), static_cast<float>(y), max_width, static_cast<float>(font_size)},
+void draw_marquee_text(const char* text, float x, float y, int font_size, Color color, float max_width, double time) {
+    draw_marquee_text(text, {x, y, max_width, static_cast<float>(font_size)},
                       font_size, color, time);
 }

--- a/src/scenes/scene_common.h
+++ b/src/scenes/scene_common.h
@@ -16,4 +16,4 @@ void draw_marquee_text(const char* text, Rectangle clip_rect, int font_size, Col
 // テキストが max_width に収まらない場合、自動的に左右にスクロールするマーキー表示を行う。
 // 収まる場合はそのまま描画する。time にはアニメーションの基準時刻（GetTime() 等）を渡す。
 // Rectangle ベース API への後方互換ラッパー。
-void draw_marquee_text(const char* text, int x, int y, int font_size, Color color, float max_width, double time);
+void draw_marquee_text(const char* text, float x, float y, int font_size, Color color, float max_width, double time);

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -364,7 +364,7 @@ void settings_scene::draw() {
         }
     }
 
-    draw_marquee_text("Click tabs to switch pages", static_cast<int>(kSidebarHintRect.x), static_cast<int>(kSidebarHintRect.y),
+    draw_marquee_text("Click tabs to switch pages", kSidebarHintRect.x, kSidebarHintRect.y,
                       20, t.text_muted, kSidebarHintRect.width, GetTime());
     ui::draw_button(kBackRect, "BACK", 22);
 

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -282,18 +282,18 @@ void song_select_scene::draw_song_details(const song_entry& song, const chart_op
     const float detail_x = kJacketRect.x + kJacketRect.width + 20.0f;
     const float detail_max_width = kLeftPanelRect.x + kLeftPanelRect.width - detail_x - 16.0f;
     const double now = GetTime();
-    draw_marquee_text(song.song.meta.title.c_str(), static_cast<int>(detail_x + content_offset_x), static_cast<int>(kJacketRect.y + 4.0f), 40,
+    draw_marquee_text(song.song.meta.title.c_str(), detail_x + content_offset_x, kJacketRect.y + 4.0f, 40,
                       with_alpha(t.text, content_alpha), detail_max_width, now);
-    draw_marquee_text(song.song.meta.artist.c_str(), static_cast<int>(detail_x + content_offset_x), static_cast<int>(kJacketRect.y + 56.0f), 28,
+    draw_marquee_text(song.song.meta.artist.c_str(), detail_x + content_offset_x, kJacketRect.y + 56.0f, 28,
                       with_alpha(t.text_secondary, content_alpha), detail_max_width, now);
-    DrawText(TextFormat("BPM %.0f", song.song.meta.base_bpm), static_cast<int>(detail_x + content_offset_x),
-             static_cast<int>(kJacketRect.y + 100.0f), 24, with_alpha(t.text_muted, content_alpha));
+    ui::draw_text_f(TextFormat("BPM %.0f", song.song.meta.base_bpm), detail_x + content_offset_x,
+                    kJacketRect.y + 100.0f, 24, with_alpha(t.text_muted, content_alpha));
     if (selected_chart != nullptr) {
-        DrawText(TextFormat("%s %s Lv.%d", key_mode_label(selected_chart->meta.key_count).c_str(),
-                            selected_chart->meta.difficulty.c_str(), selected_chart->meta.level),
-                 static_cast<int>(detail_x + content_offset_x), static_cast<int>(kJacketRect.y + 150.0f), 28, with_alpha(t.text, content_alpha));
-        DrawText(selected_chart->meta.chart_author.c_str(), static_cast<int>(detail_x + content_offset_x),
-                 static_cast<int>(kJacketRect.y + 186.0f), 20, with_alpha(t.text_muted, content_alpha));
+        ui::draw_text_f(TextFormat("%s %s Lv.%d", key_mode_label(selected_chart->meta.key_count).c_str(),
+                                   selected_chart->meta.difficulty.c_str(), selected_chart->meta.level),
+                        detail_x + content_offset_x, kJacketRect.y + 150.0f, 28, with_alpha(t.text, content_alpha));
+        ui::draw_text_f(selected_chart->meta.chart_author.c_str(), detail_x + content_offset_x,
+                        kJacketRect.y + 186.0f, 20, with_alpha(t.text_muted, content_alpha));
     }
 
     ui::draw_section(kActionPanelRect);
@@ -307,13 +307,12 @@ void song_select_scene::draw_song_details(const song_entry& song, const chart_op
 
 void song_select_scene::draw_song_row(const song_entry& song, float item_y, bool is_selected, double now) const {
     const auto& t = *g_theme;
-    const int iy = static_cast<int>(item_y);
     const Rectangle row_rect = {kSongListRect.x + 14.0f, item_y - 8.0f, kSongListRect.width - 28.0f, 44.0f};
-    const int text_x = static_cast<int>(kSongListRect.x + 30.0f);
+    const float text_x = kSongListRect.x + 30.0f;
     const float list_text_max_w = kSongListRect.width - 70.0f;
-    const Rectangle title_clip_rect = intersect_rectangles({static_cast<float>(text_x), static_cast<float>(iy), list_text_max_w, 24.0f},
+    const Rectangle title_clip_rect = intersect_rectangles({text_x, item_y, list_text_max_w, 24.0f},
                                                            kSongListViewRect);
-    const Rectangle artist_clip_rect = intersect_rectangles({static_cast<float>(text_x), static_cast<float>(iy + 22), list_text_max_w, 16.0f},
+    const Rectangle artist_clip_rect = intersect_rectangles({text_x, item_y + 22.0f, list_text_max_w, 16.0f},
                                                             kSongListViewRect);
 
     if (ui::is_hovered(row_rect) || is_selected) {
@@ -331,8 +330,8 @@ void song_select_scene::draw_chart_rows(const std::vector<const chart_option*>& 
     const auto& t = *g_theme;
     const float child_x = kSongListRect.x + 46.0f;
     const float child_w = kSongListRect.width - 92.0f;
-    const int child_text_x = static_cast<int>(kSongListRect.x + 58.0f);
-    const int author_x = static_cast<int>(kSongListRect.x + kSongListRect.width - 120.0f);
+    const float child_text_x = kSongListRect.x + 58.0f;
+    const float author_x = kSongListRect.x + kSongListRect.width - 120.0f;
     float child_y = item_y + 46.0f;
     for (int chart_index = 0; chart_index < static_cast<int>(filtered.size()); ++chart_index) {
         const chart_option& chart = *filtered[static_cast<size_t>(chart_index)];
@@ -342,11 +341,10 @@ void song_select_scene::draw_chart_rows(const std::vector<const chart_option*>& 
             const ui::row_state child_state = ui::draw_selectable_row(child_rect, child_selected, 0.0f);
             (void)child_state;
         }
-        DrawText(TextFormat("%s %s Lv.%d", key_mode_label(chart.meta.key_count).c_str(), chart.meta.difficulty.c_str(),
-                            chart.meta.level),
-                 child_text_x, static_cast<int>(child_y), 18,
-                 child_selected ? t.text : t.text_secondary);
-        DrawText(chart.meta.chart_author.c_str(), author_x, static_cast<int>(child_y) + 1, 14, t.text_muted);
+        ui::draw_text_f(TextFormat("%s %s Lv.%d", key_mode_label(chart.meta.key_count).c_str(), chart.meta.difficulty.c_str(),
+                                   chart.meta.level),
+                        child_text_x, child_y, 18, child_selected ? t.text : t.text_secondary);
+        ui::draw_text_f(chart.meta.chart_author.c_str(), author_x, child_y + 1.0f, 14, t.text_muted);
         child_y += 30.0f;
     }
 }
@@ -355,8 +353,7 @@ void song_select_scene::draw_song_list(const std::vector<const chart_option*>& f
     const auto& t = *g_theme;
     ui::draw_text_in_rect("Songs", 28, kSongListTitleRect, t.text, ui::text_align::left);
 
-    BeginScissorMode(static_cast<int>(kSongListViewRect.x), static_cast<int>(kSongListViewRect.y),
-                     static_cast<int>(kSongListViewRect.width), static_cast<int>(kSongListViewRect.height));
+    ui::begin_scissor_rect(kSongListViewRect);
 
     const double now = GetTime();
     float item_y = kSongListViewRect.y - scroll_y_;

--- a/src/ui/ui_coord.h
+++ b/src/ui/ui_coord.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+
+#include "raylib.h"
+
+// 描画境界の座標変換ヘルパー。
+// float → int の static_cast を一元管理し、呼び出し側の記述を簡潔にする。
+namespace ui {
+
+// 整数座標ペア。
+struct ipoint {
+    int x;
+    int y;
+};
+
+// float を int へ切り捨て変換する（描画位置座標用）。
+inline int to_i(float v) {
+    return static_cast<int>(v);
+}
+
+// float を int へ四捨五入変換する。
+inline int round_to_i(float v) {
+    return static_cast<int>(std::lround(v));
+}
+
+// Vector2 を ipoint へ変換する。
+inline ipoint to_point(Vector2 v) {
+    return {static_cast<int>(v.x), static_cast<int>(v.y)};
+}
+
+// float 座標で DrawText を呼び出す。
+inline void draw_text_f(const char* text, float x, float y, int font_size, Color color) {
+    DrawText(text, to_i(x), to_i(y), font_size, color);
+}
+
+// float 座標で DrawLine を呼び出す。
+inline void draw_line_f(float x1, float y1, float x2, float y2, Color color) {
+    DrawLine(to_i(x1), to_i(y1), to_i(x2), to_i(y2), color);
+}
+
+// float 座標で DrawRectangle を呼び出す。
+inline void draw_rect_f(float x, float y, float w, float h, Color color) {
+    DrawRectangle(to_i(x), to_i(y), to_i(w), to_i(h), color);
+}
+
+// Rectangle で DrawRectangle を呼び出す。
+inline void draw_rect_f(Rectangle rect, Color color) {
+    DrawRectangle(to_i(rect.x), to_i(rect.y), to_i(rect.width), to_i(rect.height), color);
+}
+
+// 位置は floor、右端と下端は ceil で広めに取りたい矩形描画用。
+inline void draw_rect_span(Rectangle rect, Color color) {
+    const int x = static_cast<int>(std::floor(rect.x));
+    const int y = static_cast<int>(std::floor(rect.y));
+    const int w = std::max(1, static_cast<int>(std::ceil(rect.x + rect.width) - std::floor(rect.x)));
+    const int h = std::max(1, static_cast<int>(std::ceil(rect.y + rect.height) - std::floor(rect.y)));
+    DrawRectangle(x, y, w, h, color);
+}
+
+// Rectangle から安全なシザー領域を開始する。
+// floor/ceil で端数を広めに取り、幅・高さは最低 1 を保証する。
+inline void begin_scissor_rect(Rectangle rect) {
+    const int sx = static_cast<int>(std::floor(rect.x));
+    const int sy = static_cast<int>(std::floor(rect.y));
+    const int sw = std::max(1, static_cast<int>(std::ceil(rect.x + rect.width) - std::floor(rect.x)));
+    const int sh = std::max(1, static_cast<int>(std::ceil(rect.y + rect.height) - std::floor(rect.y)));
+    BeginScissorMode(sx, sy, sw, sh);
+}
+
+}  // namespace ui

--- a/src/ui/ui_draw.h
+++ b/src/ui/ui_draw.h
@@ -3,6 +3,7 @@
 #include <algorithm>
 
 #include "raylib.h"
+#include "ui_coord.h"
 #include "scene_common.h"
 #include "theme.h"
 #include "ui_hit.h"
@@ -140,7 +141,7 @@ inline void draw_label_value_marquee(Rectangle rect, const char* label, const ch
     const Rectangle value_rect = {rect.x + label_width, rect.y,
                                   rect.width - label_width, rect.height};
     draw_text_in_rect(label, font_size, label_rect, label_color, text_align::left);
-    draw_marquee_text(value, static_cast<int>(value_rect.x), static_cast<int>(value_rect.y + 4.0f), font_size,
+    draw_marquee_text(value, value_rect.x, value_rect.y + 4.0f, font_size,
                       value_color, value_rect.width, time);
 }
 
@@ -235,8 +236,7 @@ inline void draw_progress_bar(Rectangle rect, float ratio,
     if (ratio > 0.0f) {
         const Rectangle fill_area = inset(rect, bar_inset);
         const float fill_w = fill_area.width * std::clamp(ratio, 0.0f, 1.0f);
-        DrawRectangle(static_cast<int>(fill_area.x), static_cast<int>(fill_area.y),
-                      static_cast<int>(fill_w), static_cast<int>(fill_area.height), fill);
+        draw_rect_f(fill_area.x, fill_area.y, fill_w, fill_area.height, fill);
     }
 }
 
@@ -277,13 +277,11 @@ inline float draw_slider(Rectangle row_rect, const char* label, const char* valu
     const Rectangle track = {track_left, row_rect.y + track_top_offset, track_width, 6.0f};
     const float clamped = std::clamp(ratio, 0.0f, 1.0f);
     DrawRectangleRec(track, g_theme->slider_track);
-    DrawRectangle(static_cast<int>(track.x), static_cast<int>(track.y),
-                  static_cast<int>(track.width * clamped), static_cast<int>(track.height),
-                  g_theme->slider_fill);
+    draw_rect_f(track.x, track.y, track.width * clamped, track.height, g_theme->slider_fill);
 
     // つまみ
-    const int knob_x = static_cast<int>(track.x + track.width * clamped);
-    DrawRectangle(knob_x - 6, static_cast<int>(track.y - 8.0f), 12, 22, g_theme->slider_knob);
+    const float knob_x = track.x + track.width * clamped;
+    draw_rect_f(knob_x - 6.0f, track.y - 8.0f, 12.0f, 22.0f, g_theme->slider_knob);
 
     // 値テキスト（右上）
     const Rectangle value_rect = {track.x, row_rect.y, track.width, track_top_offset};
@@ -311,12 +309,11 @@ inline float draw_slider_relative(Rectangle row_rect, const char* label, const c
 
     draw_text_in_rect(label, font_size, layout.label_rect, g_theme->text, text_align::left);
     DrawRectangleRec(layout.track_rect, g_theme->slider_track);
-    DrawRectangle(static_cast<int>(layout.track_rect.x), static_cast<int>(layout.track_rect.y),
-                  static_cast<int>(layout.track_rect.width * clamped), static_cast<int>(layout.track_rect.height),
-                  g_theme->slider_fill);
+    draw_rect_f(layout.track_rect.x, layout.track_rect.y,
+                layout.track_rect.width * clamped, layout.track_rect.height, g_theme->slider_fill);
 
-    const int knob_x = static_cast<int>(layout.track_rect.x + layout.track_rect.width * clamped);
-    DrawRectangle(knob_x - 6, static_cast<int>(layout.track_rect.y - 8.0f), 12, 22, g_theme->slider_knob);
+    const float knob_x = layout.track_rect.x + layout.track_rect.width * clamped;
+    draw_rect_f(knob_x - 6.0f, layout.track_rect.y - 8.0f, 12.0f, 22.0f, g_theme->slider_knob);
     draw_text_in_rect(value_text, font_size, layout.value_rect, g_theme->text_dim, text_align::right);
 
     if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), row_rect)) {

--- a/src/ui/ui_text.h
+++ b/src/ui/ui_text.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "raylib.h"
+#include "ui_coord.h"
 #include "ui_layout.h"
 
 // テキスト配置ユーティリティ。
@@ -32,7 +33,7 @@ inline Vector2 text_position(const char* text, int font_size, Rectangle rect,
 inline void draw_text_in_rect(const char* text, int font_size, Rectangle rect,
                               Color color, text_align align = text_align::center) {
     const Vector2 pos = text_position(text, font_size, rect, align);
-    DrawText(text, static_cast<int>(pos.x), static_cast<int>(pos.y), font_size, color);
+    draw_text_f(text, pos.x, pos.y, font_size, color);
 }
 
 }  // namespace ui


### PR DESCRIPTION
## 概要
- `src/ui/ui_coord.h` を追加し、描画境界の float -> int 変換を共通化
- `ui_text` / `ui_draw` と各 scene の描画コードから座標変換の `static_cast<int>` を削減
- scissor 開始とマーキーテキスト描画も共通ヘルパー経由に整理

## 確認
- ユーザー環境で build / run 実施
- UI 崩れがないことを確認済み

Closes #87