### PR TITLE
UI: 親子クリップを安全に扱えるクリップ矩形スタックを導入する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,9 @@ add_executable(raythm src/main.cpp
         src/ui/ui_layout.h
         src/ui/ui_text.h
         src/ui/ui_hit.h
-        src/ui/ui_draw.h)
+        src/ui/ui_draw.h
+        src/ui/ui_clip.cpp
+        src/ui/ui_clip.h)
 
 add_executable(chart_parser_smoke
         src/gameplay/chart_parser.cpp

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -12,6 +12,7 @@
 #include "scene_manager.h"
 #include "song_select_scene.h"
 #include "theme.h"
+#include "ui_clip.h"
 #include "ui_draw.h"
 #include "virtual_screen.h"
 
@@ -659,7 +660,7 @@ void editor_scene::draw_timeline() const {
     const Rectangle track = timeline_scrollbar_track_rect();
 
     DrawRectangleRec(ui::inset(kTimelineRect, 10.0f), t.section);
-    ui::begin_scissor_rect(content);
+    ui::scoped_clip_rect clip_scope(content);
     draw_timeline_grid(min_tick, max_tick);
     draw_timeline_notes();
     if (note_dragging_) {
@@ -683,8 +684,6 @@ void editor_scene::draw_timeline() const {
         DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
         DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
     }
-    EndScissorMode();
-
     ui::draw_scrollbar(track, content_height_pixels(), scroll_offset_pixels(),
                        t.scrollbar_track, t.scrollbar_thumb, 40.0f);
 

--- a/src/scenes/scene_common.cpp
+++ b/src/scenes/scene_common.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 
 #include "theme.h"
+#include "ui_clip.h"
 #include "ui_coord.h"
 
 namespace {
@@ -17,9 +18,8 @@ void draw_text_clipped(const char* text, float x, float y, int font_size, Color 
     const float font_size_f = static_cast<float>(font_size);
     const float spacing = font_size_f / static_cast<float>(font.baseSize);
 
-    ui::begin_scissor_rect(clip_rect);
+    ui::scoped_clip_rect clip_scope(clip_rect);
     DrawTextEx(font, text, {x, y}, font_size_f, spacing, color);
-    EndScissorMode();
 }
 
 }  // namespace

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -15,6 +15,7 @@
 #include "song_loader.h"
 #include "theme.h"
 #include "title_scene.h"
+#include "ui_clip.h"
 #include "ui_draw.h"
 #include "virtual_screen.h"
 
@@ -62,19 +63,6 @@ std::filesystem::path repo_root() {
 
 std::string key_mode_label(int key_count) {
     return key_count == 6 ? "6K" : "4K";
-}
-
-Rectangle intersect_rectangles(Rectangle a, Rectangle b) {
-    const float left = std::max(a.x, b.x);
-    const float top = std::max(a.y, b.y);
-    const float right = std::min(a.x + a.width, b.x + b.width);
-    const float bottom = std::min(a.y + a.height, b.y + b.height);
-    return {
-        left,
-        top,
-        std::max(0.0f, right - left),
-        std::max(0.0f, bottom - top)
-    };
 }
 
 }
@@ -310,10 +298,8 @@ void song_select_scene::draw_song_row(const song_entry& song, float item_y, bool
     const Rectangle row_rect = {kSongListRect.x + 14.0f, item_y - 8.0f, kSongListRect.width - 28.0f, 44.0f};
     const float text_x = kSongListRect.x + 30.0f;
     const float list_text_max_w = kSongListRect.width - 70.0f;
-    const Rectangle title_clip_rect = intersect_rectangles({text_x, item_y, list_text_max_w, 24.0f},
-                                                           kSongListViewRect);
-    const Rectangle artist_clip_rect = intersect_rectangles({text_x, item_y + 22.0f, list_text_max_w, 16.0f},
-                                                            kSongListViewRect);
+    const Rectangle title_clip_rect = {text_x, item_y, list_text_max_w, 24.0f};
+    const Rectangle artist_clip_rect = {text_x, item_y + 22.0f, list_text_max_w, 16.0f};
 
     if (ui::is_hovered(row_rect) || is_selected) {
         const ui::row_state row_state = ui::draw_selectable_row(row_rect, is_selected, 0.0f);
@@ -353,7 +339,7 @@ void song_select_scene::draw_song_list(const std::vector<const chart_option*>& f
     const auto& t = *g_theme;
     ui::draw_text_in_rect("Songs", 28, kSongListTitleRect, t.text, ui::text_align::left);
 
-    ui::begin_scissor_rect(kSongListViewRect);
+    ui::scoped_clip_rect clip_scope(kSongListViewRect);
 
     const double now = GetTime();
     float item_y = kSongListViewRect.y - scroll_y_;
@@ -377,8 +363,6 @@ void song_select_scene::draw_song_list(const std::vector<const chart_option*>& f
         }
         item_y += row_h;
     }
-    EndScissorMode();
-
     ui::draw_scrollbar(kSongListScrollbarTrackRect, compute_content_height(), scroll_y_, t.scrollbar_track, t.scrollbar_thumb);
 }
 

--- a/src/ui/ui_clip.cpp
+++ b/src/ui/ui_clip.cpp
@@ -1,0 +1,102 @@
+#include "ui_clip.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "ui_coord.h"
+
+namespace ui {
+namespace {
+
+Rectangle intersect_rectangles(Rectangle a, Rectangle b) {
+    const float left = std::max(a.x, b.x);
+    const float top = std::max(a.y, b.y);
+    const float right = std::min(a.x + a.width, b.x + b.width);
+    const float bottom = std::min(a.y + a.height, b.y + b.height);
+    return {
+        left,
+        top,
+        std::max(0.0f, right - left),
+        std::max(0.0f, bottom - top)
+    };
+}
+
+std::vector<Rectangle>& clip_rect_stack() {
+    static std::vector<Rectangle> stack;
+    return stack;
+}
+
+void apply_clip_rect(Rectangle rect) {
+    begin_scissor_rect(rect);
+}
+
+}  // namespace
+
+void push_clip_rect(Rectangle rect) {
+    std::vector<Rectangle>& stack = clip_rect_stack();
+    const Rectangle merged = stack.empty() ? rect : intersect_rectangles(stack.back(), rect);
+
+    if (!stack.empty()) {
+        EndScissorMode();
+    }
+
+    stack.push_back(merged);
+    apply_clip_rect(merged);
+}
+
+void pop_clip_rect() {
+    std::vector<Rectangle>& stack = clip_rect_stack();
+    if (stack.empty()) {
+        return;
+    }
+
+    EndScissorMode();
+    stack.pop_back();
+
+    if (!stack.empty()) {
+        apply_clip_rect(stack.back());
+    }
+}
+
+bool has_clip_rect() {
+    return !clip_rect_stack().empty();
+}
+
+Rectangle current_clip_rect() {
+    const std::vector<Rectangle>& stack = clip_rect_stack();
+    if (stack.empty()) {
+        return {0.0f, 0.0f, 0.0f, 0.0f};
+    }
+
+    return stack.back();
+}
+
+scoped_clip_rect::scoped_clip_rect(Rectangle rect) : active_(true) {
+    push_clip_rect(rect);
+}
+
+scoped_clip_rect::~scoped_clip_rect() {
+    if (active_) {
+        pop_clip_rect();
+    }
+}
+
+scoped_clip_rect::scoped_clip_rect(scoped_clip_rect&& other) noexcept
+    : active_(std::exchange(other.active_, false)) {
+}
+
+scoped_clip_rect& scoped_clip_rect::operator=(scoped_clip_rect&& other) noexcept {
+    if (this == &other) {
+        return *this;
+    }
+
+    if (active_) {
+        pop_clip_rect();
+    }
+
+    active_ = std::exchange(other.active_, false);
+    return *this;
+}
+
+}  // namespace ui

--- a/src/ui/ui_clip.h
+++ b/src/ui/ui_clip.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "raylib.h"
+
+namespace ui {
+
+void push_clip_rect(Rectangle rect);
+void pop_clip_rect();
+bool has_clip_rect();
+// クリップが積まれていない場合は空矩形を返す。
+Rectangle current_clip_rect();
+
+class scoped_clip_rect {
+public:
+    explicit scoped_clip_rect(Rectangle rect);
+    ~scoped_clip_rect();
+
+    scoped_clip_rect(const scoped_clip_rect&) = delete;
+    scoped_clip_rect& operator=(const scoped_clip_rect&) = delete;
+
+    scoped_clip_rect(scoped_clip_rect&& other) noexcept;
+    scoped_clip_rect& operator=(scoped_clip_rect&& other) noexcept;
+
+private:
+    bool active_ = false;
+};
+
+}  // namespace ui

--- a/src/ui/ui_coord.h
+++ b/src/ui/ui_coord.h
@@ -60,8 +60,13 @@ inline void draw_rect_span(Rectangle rect, Color color) {
 }
 
 // Rectangle から安全なシザー領域を開始する。
-// floor/ceil で端数を広めに取り、幅・高さは最低 1 を保証する。
+// floor/ceil で端数を広めに取り、空矩形は画面外 1px に逃がして描画を無効化する。
 inline void begin_scissor_rect(Rectangle rect) {
+    if (rect.width <= 0.0f || rect.height <= 0.0f) {
+        BeginScissorMode(GetRenderWidth(), GetRenderHeight(), 1, 1);
+        return;
+    }
+
     const int sx = static_cast<int>(std::floor(rect.x));
     const int sy = static_cast<int>(std::floor(rect.y));
     const int sw = std::max(1, static_cast<int>(std::ceil(rect.x + rect.width) - std::floor(rect.x)));


### PR DESCRIPTION
## 概要
- UI 層に親子クリップを安全に合成するクリップ矩形スタックを追加
- マーキー描画と曲リストのスクロール領域を新しいクリップ基盤へ移行
- エディタのタイムライン描画も同じクリップ管理に寄せて直接 `EndScissorMode` を減らした

## 確認
- ビルド成功、UIの崩れなし。

Closes #85