### PR TITLE
UI描画キューとlayerベースの入力優先順位を導入

### DIFF
--- a/docs/ui-layout-system.md
+++ b/docs/ui-layout-system.md
@@ -1107,3 +1107,18 @@ if (ui::is_clicked(kSettingsButtonRect)) {
 
 `play_scene.cpp` の 3D レンダリング（DrawCube, DrawCubeWires, Camera3D 関連）はレイアウトシステムの対象外。
 HUD（2D オーバーレイ）のみが移行対象。
+
+### draw queue の段階導入
+
+`ui_draw.h` には即時描画 API と併存できる frame-local の draw queue がある。
+`ui::begin_draw_queue()` でフレーム開始時にキューを初期化し、`ui::enqueue_*` で layer 付きコマンドを積み、最後に `ui::flush_draw_queue()` で layer 順に描画する。
+入力優先順位を揃えたいフレームでは `ui::begin_hit_regions()` で登録を初期化し、overlay / modal の矩形を `ui::register_hit_region()` で積んでから `ui::is_clicked(rect, layer)` を使う。
+
+- 最初の移行対象は dropdown / popover / modal のような overlay 系 UI
+- 既存の `draw_*` API はそのまま残し、scene ごとに段階移行する
+- 将来的には hit test 優先順位も同じ layer に揃える想定
+- `editor_scene.cpp` の dropdown と `play_scene.cpp` の pause / failure / result overlay は queue 化済み
+- `editor_scene.cpp` の dropdown と `play_scene.cpp` の pause ボタンは hit region も layer と連動済み
+- `settings_scene.cpp` の slider / selector / tab も layer-aware な hit test API へ移行済み
+- `song_select_scene.cpp` の settings / action button / song list / chart list / scrollbar も layer-aware な hit test API へ移行済み
+- 次段の候補は scene 共通の hit region 構築を helper 化して、overlay を持つ scene の update/draw 重複を減らすこと

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -46,6 +46,19 @@ constexpr float kScrollWheelViewportRatio = 0.36f;
 constexpr float kNoteHeadHeight = 14.0f;
 constexpr int kSnapDivisions[] = {1, 2, 4, 8, 16, 32};
 constexpr const char* kSnapLabels[] = {"1/1", "1/2", "1/4", "1/8", "1/16", "1/32"};
+constexpr Rectangle kHeaderToolsRect = ui::place(kHeaderRect, 360.0f, 34.0f,
+                                                 ui::anchor::center_right, ui::anchor::center_right,
+                                                 {-18.0f, 0.0f});
+constexpr float kDropdownItemHeight = 30.0f;
+constexpr float kDropdownItemSpacing = 4.0f;
+constexpr Rectangle kSnapDropdownRect = kHeaderToolsRect;
+constexpr Rectangle kSnapDropdownMenuRect = {
+    kSnapDropdownRect.x,
+    kSnapDropdownRect.y + kSnapDropdownRect.height + 4.0f,
+    kSnapDropdownRect.width,
+    12.0f + static_cast<float>(std::size(kSnapLabels)) * kDropdownItemHeight +
+        static_cast<float>(std::size(kSnapLabels) - 1) * kDropdownItemSpacing
+};
 
 std::vector<timing_event> sorted_meter_events(const chart_data& data) {
     std::vector<timing_event> meter_events;
@@ -117,6 +130,8 @@ void editor_scene::on_enter() {
 }
 
 void editor_scene::update(float dt) {
+    rebuild_hit_regions();
+
     if (IsKeyPressed(KEY_ESCAPE)) {
         manager_.change_scene(std::make_unique<song_select_scene>(manager_));
         return;
@@ -132,10 +147,19 @@ void editor_scene::update(float dt) {
     apply_scroll_and_zoom(dt);
 }
 
+void editor_scene::rebuild_hit_regions() const {
+    ui::begin_hit_regions();
+    if (snap_dropdown_open_) {
+        ui::register_hit_region(kSnapDropdownMenuRect, ui::draw_layer::overlay);
+    }
+}
+
 void editor_scene::draw() {
     const auto& t = *g_theme;
     const double now = GetTime();
     virtual_screen::begin();
+    rebuild_hit_regions();
+    ui::begin_draw_queue();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
 
@@ -152,9 +176,10 @@ void editor_scene::draw() {
     draw_left_panel();
     draw_timeline();
     draw_right_panel();
-    draw_cursor_hud();
     draw_header_tools();
+    draw_cursor_hud();
 
+    ui::flush_draw_queue();
     virtual_screen::end();
     ClearBackground(BLACK);
     virtual_screen::draw_to_screen();
@@ -455,12 +480,13 @@ void editor_scene::handle_shortcuts() {
 void editor_scene::handle_timeline_interaction() {
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const Rectangle content = timeline_content_rect();
+    const bool timeline_hovered = ui::is_hovered(content, ui::draw_layer::base);
 
     if (IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) {
-        selected_note_index_ = note_at_position(mouse);
+        selected_note_index_ = timeline_hovered ? note_at_position(mouse) : std::nullopt;
     }
 
-    if (!CheckCollisionPointRec(mouse, content)) {
+    if (!timeline_hovered) {
         if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
             note_dragging_ = false;
         }
@@ -660,29 +686,31 @@ void editor_scene::draw_timeline() const {
     const Rectangle track = timeline_scrollbar_track_rect();
 
     DrawRectangleRec(ui::inset(kTimelineRect, 10.0f), t.section);
-    ui::scoped_clip_rect clip_scope(content);
-    draw_timeline_grid(min_tick, max_tick);
-    draw_timeline_notes();
-    if (note_dragging_) {
-        note_data preview;
-        preview.lane = drag_lane_;
-        preview.tick = std::min(drag_start_tick_, drag_current_tick_);
-        preview.end_tick = std::max(drag_start_tick_, drag_current_tick_);
-        preview.type = (preview.end_tick - preview.tick) >= snap_interval() ? note_type::hold : note_type::tap;
-        if (preview.type == note_type::tap) {
-            preview.end_tick = preview.tick;
-        }
+    {
+        ui::scoped_clip_rect clip_scope(content);
+        draw_timeline_grid(min_tick, max_tick);
+        draw_timeline_notes();
+        if (note_dragging_) {
+            note_data preview;
+            preview.lane = drag_lane_;
+            preview.tick = std::min(drag_start_tick_, drag_current_tick_);
+            preview.end_tick = std::max(drag_start_tick_, drag_current_tick_);
+            preview.type = (preview.end_tick - preview.tick) >= snap_interval() ? note_type::hold : note_type::tap;
+            if (preview.type == note_type::tap) {
+                preview.end_tick = preview.tick;
+            }
 
-        const note_draw_info info = note_rects(preview);
-        const Color fill = state_.has_note_overlap(preview) ? with_alpha(t.error, 150) : with_alpha(t.success, 150);
-        const Color outline = state_.has_note_overlap(preview) ? t.error : t.success;
-        if (info.has_body) {
-            DrawRectangleRounded(info.body_rect, 0.4f, 6, fill);
-            DrawRectangleRounded(info.tail_rect, 0.4f, 6, fill);
-            DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
+            const note_draw_info info = note_rects(preview);
+            const Color fill = state_.has_note_overlap(preview) ? with_alpha(t.error, 150) : with_alpha(t.success, 150);
+            const Color outline = state_.has_note_overlap(preview) ? t.error : t.success;
+            if (info.has_body) {
+                DrawRectangleRounded(info.body_rect, 0.4f, 6, fill);
+                DrawRectangleRounded(info.tail_rect, 0.4f, 6, fill);
+                DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
+            }
+            DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
+            DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
         }
-        DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
-        DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
     }
     ui::draw_scrollbar(track, content_height_pixels(), scroll_offset_pixels(),
                        t.scrollbar_track, t.scrollbar_thumb, 40.0f);
@@ -778,21 +806,15 @@ void editor_scene::draw_cursor_hud() const {
 }
 
 void editor_scene::draw_header_tools() {
-    const auto& t = *g_theme;
-    const Rectangle tools_rect = ui::place(kHeaderRect, 360.0f, 34.0f,
-                                           ui::anchor::center_right, ui::anchor::center_right,
-                                           {-18.0f, 0.0f});
-    const Rectangle dropdown_rect = tools_rect;
-    const Rectangle dropdown_menu_rect = {
-        dropdown_rect.x,
-        dropdown_rect.y + dropdown_rect.height + 4.0f,
-        dropdown_rect.width,
-        12.0f + static_cast<float>(std::size(kSnapLabels)) * 30.0f + static_cast<float>(std::size(kSnapLabels) - 1) * 4.0f
-    };
-    const ui::dropdown_state dropdown = ui::draw_dropdown(dropdown_rect, dropdown_menu_rect,
-                                                          "Tools", kSnapLabels[snap_index_],
-                                                          std::span<const char* const>(kSnapLabels, std::size(kSnapLabels)),
-                                                          snap_index_, snap_dropdown_open_, 16, 64.0f);
+    // 描画は queue に寄せるが、ヒットテストはまだ即時計算のままにしている。
+    // 次段で layer と hit test 優先順位を統合すると、modal / pause 系も同じ仕組みに載せられる。
+    const ui::dropdown_state dropdown = ui::enqueue_dropdown(
+        kSnapDropdownRect, kSnapDropdownMenuRect,
+        "Tools", kSnapLabels[snap_index_],
+        std::span<const char* const>(kSnapLabels, std::size(kSnapLabels)),
+        snap_index_, snap_dropdown_open_,
+        ui::draw_layer::base, ui::draw_layer::overlay,
+        16, 64.0f);
     if (dropdown.trigger.clicked) {
         snap_dropdown_open_ = !snap_dropdown_open_;
     }
@@ -800,8 +822,8 @@ void editor_scene::draw_header_tools() {
         snap_index_ = dropdown.clicked_index;
         snap_dropdown_open_ = false;
     } else if (snap_dropdown_open_ && IsMouseButtonReleased(MOUSE_BUTTON_LEFT) &&
-               !ui::is_hovered(dropdown_rect) &&
-               !CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), dropdown_menu_rect)) {
+               !ui::is_hovered(kSnapDropdownRect, ui::draw_layer::base) &&
+               !ui::is_hovered(kSnapDropdownMenuRect, ui::draw_layer::overlay)) {
         snap_dropdown_open_ = false;
     }
 }

--- a/src/scenes/editor_scene.h
+++ b/src/scenes/editor_scene.h
@@ -63,6 +63,7 @@ private:
     std::optional<int> lane_at_position(Vector2 point) const;
     std::optional<size_t> note_at_position(Vector2 point) const;
     note_draw_info note_rects(const note_data& note) const;
+    void rebuild_hit_regions() const;
     void handle_shortcuts();
     void handle_timeline_interaction();
     void apply_scroll_and_zoom(float dt);

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -309,6 +309,7 @@ void play_scene::on_exit() {
 
 // 時刻進行・入力処理・判定更新・シーン遷移を行う。
 void play_scene::update(float dt) {
+    rebuild_hit_regions();
     judge_feedback_timer_ = std::max(0.0f, judge_feedback_timer_ - dt);
 
     if (!initialized_) {
@@ -346,7 +347,7 @@ void play_scene::update(float dt) {
         Rectangle buttons[3];
         ui::vstack(kPauseButtonArea, 42.0f, 16.0f, buttons);
 
-        if (ui::is_clicked(buttons[0])) {
+        if (ui::is_clicked(buttons[0], ui::draw_layer::modal)) {
             paused_ = false;
             if (audio_manager::instance().is_bgm_loaded() && !intro_playing_) {
                 audio_manager::instance().play_bgm(false);
@@ -355,7 +356,7 @@ void play_scene::update(float dt) {
             return;
         }
 
-        if (ui::is_clicked(buttons[1])) {
+        if (ui::is_clicked(buttons[1], ui::draw_layer::modal)) {
             if (song_data_.has_value() && selected_chart_path_.has_value()) {
                 manager_.change_scene(std::make_unique<play_scene>(manager_, *song_data_, *selected_chart_path_, key_count_));
             } else {
@@ -364,7 +365,7 @@ void play_scene::update(float dt) {
             return;
         }
 
-        if (ui::is_clicked(buttons[2])) {
+        if (ui::is_clicked(buttons[2], ui::draw_layer::modal)) {
             manager_.change_scene(std::make_unique<song_select_scene>(manager_));
             return;
         }
@@ -471,6 +472,15 @@ void play_scene::update(float dt) {
     }
 }
 
+void play_scene::rebuild_hit_regions() const {
+    ui::begin_hit_regions();
+    if (paused_) {
+        ui::register_hit_region({0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)},
+                                ui::draw_layer::overlay);
+        ui::register_hit_region(kPausePanelRect, ui::draw_layer::modal);
+    }
+}
+
 // 判定ラインが画面下端から指定比率の位置に来るようカメラを構築する。
 Camera3D play_scene::make_play_camera() const {
     const float angle_rad = std::clamp(camera_angle_degrees_, 5.0f, 90.0f) * DEG2RAD;
@@ -555,6 +565,8 @@ void play_scene::draw() {
 
     // 2D HUD を仮想スクリーンに描画して透過合成
     virtual_screen::begin();
+    rebuild_hit_regions();
+    ui::begin_draw_queue();
     ClearBackground(BLANK);
     draw_hud();
     draw_judge_feedback();
@@ -570,6 +582,7 @@ void play_scene::draw() {
     if (paused_) {
         draw_pause_overlay();
     }
+    ui::flush_draw_queue();
     virtual_screen::end();
 
     virtual_screen::draw_to_screen(true);
@@ -696,47 +709,53 @@ void play_scene::draw_hud() const {
     const result_data result = score_system_.get_result_data();
     Rectangle score_rows[2];
     ui::vstack(kScoreRect, 30.0f, 0.0f, score_rows);
-    ui::draw_text_in_rect(TextFormat("SCORE %07d", result.score), 30,
-                          score_rows[0], g_theme->hud_score, ui::text_align::left);
-    ui::draw_text_in_rect(TextFormat("Accuracy %.2f %%", result.accuracy), 22,
-                          score_rows[1], g_theme->hud_score, ui::text_align::left);
+    ui::enqueue_text_in_rect(TextFormat("SCORE %07d", result.score), 30,
+                             score_rows[0], g_theme->hud_score, ui::text_align::left);
+    ui::enqueue_text_in_rect(TextFormat("Accuracy %.2f %%", result.accuracy), 22,
+                             score_rows[1], g_theme->hud_score, ui::text_align::left);
 
-    ui::draw_text_in_rect(TextFormat("FPS: %d", GetFPS()), 20,
-                          kFpsRect, g_theme->hud_fps, ui::text_align::right);
-    ui::draw_text_in_rect(TextFormat("%.2f", current_ms_ / 1000.0), 30,
-                          kTimeRect, g_theme->hud_time);
-    ui::draw_text_in_rect(TextFormat("INPUT %s (%d)", input_source_text(input_handler_.last_update_source()),
-                                     input_handler_.last_update_event_count()),
-                          20, {48.0f, 92.0f, 360.0f, 24.0f}, g_theme->hud_fps, ui::text_align::left);
+    ui::enqueue_text_in_rect(TextFormat("FPS: %d", GetFPS()), 20,
+                             kFpsRect, g_theme->hud_fps, ui::text_align::right);
+    ui::enqueue_text_in_rect(TextFormat("%.2f", current_ms_ / 1000.0), 30,
+                             kTimeRect, g_theme->hud_time);
+    ui::enqueue_text_in_rect(TextFormat("INPUT %s (%d)", input_source_text(input_handler_.last_update_source()),
+                                        input_handler_.last_update_event_count()),
+                             20, {48.0f, 92.0f, 360.0f, 24.0f}, g_theme->hud_fps, ui::text_align::left);
 
-    ui::draw_text_in_rect("HEALTH", 24, kHealthLabelRect,
-                          g_theme->hud_health_label, ui::text_align::right);
-    ui::draw_progress_bar(kHealthBarRect, gauge_.get_value() / 100.0f,
-                          g_theme->hud_health_bg,
-                          gauge_.get_value() >= 70.0f ? g_theme->health_high : g_theme->health_low,
-                          g_theme->hud_health_border);
+    ui::enqueue_text_in_rect("HEALTH", 24, kHealthLabelRect,
+                             g_theme->hud_health_label, ui::text_align::right);
+    ui::enqueue_draw_command(ui::draw_layer::base, [this]() {
+        ui::draw_progress_bar(kHealthBarRect, gauge_.get_value() / 100.0f,
+                              g_theme->hud_health_bg,
+                              gauge_.get_value() >= 70.0f ? g_theme->health_high : g_theme->health_low,
+                              g_theme->hud_health_border);
+    });
 
     // コンボ数（画面中央に大きく表示）
     if (combo_display_ > 0) {
-        ui::draw_text_in_rect(TextFormat("%03d", combo_display_), 86,
-                              kComboNumberRect, g_theme->hud_combo);
-        ui::draw_text_in_rect("COMBO", 24, kComboLabelRect, g_theme->hud_combo);
+        ui::enqueue_text_in_rect(TextFormat("%03d", combo_display_), 86,
+                                 kComboNumberRect, g_theme->hud_combo);
+        ui::enqueue_text_in_rect("COMBO", 24, kComboLabelRect, g_theme->hud_combo);
     }
 }
 
 void play_scene::draw_pause_overlay() const {
-    ui::draw_fullscreen_overlay(g_theme->pause_overlay);
-    ui::draw_panel(kPausePanelRect);
-    ui::draw_text_in_rect("PAUSED", 42, kPauseTitleRect, g_theme->text);
+    ui::enqueue_fullscreen_overlay(g_theme->pause_overlay, ui::draw_layer::overlay);
+    ui::enqueue_panel(kPausePanelRect, ui::draw_layer::modal);
+    ui::enqueue_text_in_rect("PAUSED", 42, kPauseTitleRect, g_theme->text,
+                             ui::text_align::center, ui::draw_layer::modal);
 
     Rectangle buttons[3];
     ui::vstack(kPauseButtonArea, 42.0f, 16.0f, buttons);
     const char* labels[] = {"RESUME", "RESTART", "SONG SELECT"};
+    // ボタンの hit test は update() 側の即時計算を維持している。
+    // 次段では modal layer と入力優先順位を揃える。
     for (int i = 0; i < 3; ++i) {
-        ui::draw_button(buttons[i], labels[i], 24);
+        ui::enqueue_button(buttons[i], labels[i], 24, ui::draw_layer::modal);
     }
 
-    ui::draw_text_in_rect("ESC: Resume", 20, kPauseHintRect, g_theme->text_muted, ui::text_align::left);
+    ui::enqueue_text_in_rect("ESC: Resume", 20, kPauseHintRect, g_theme->text_muted,
+                             ui::text_align::left, ui::draw_layer::modal);
 }
 
 void play_scene::draw_judge_feedback() const {
@@ -746,29 +765,30 @@ void play_scene::draw_judge_feedback() const {
 
     const Color color = Fade(judge_color(display_judge_->result), std::min(judge_feedback_timer_ / 1.0f, 1.0f));
     const char* text = judge_text(display_judge_->result);
-    ui::draw_text_in_rect(text, 42, kJudgeFeedbackRect, color);
+    ui::enqueue_text_in_rect(text, 42, kJudgeFeedbackRect, color);
 }
 
 void play_scene::draw_intro_overlay() const {
     const float progress = 1.0f - std::clamp(intro_timer_ / kIntroDurationSeconds, 0.0f, 0.7f);
     const unsigned char alpha = static_cast<unsigned char>((1.0f - progress) * 255.0f);
-    ui::draw_fullscreen_overlay({0, 0, 0, alpha});
+    ui::enqueue_fullscreen_overlay({0, 0, 0, alpha}, ui::draw_layer::overlay);
 }
 
 void play_scene::draw_failure_overlay() const {
     const float elapsed = kFailureTransitionDurationSeconds - failure_transition_timer_;
     const float fade_progress = std::clamp(elapsed / kFailureFadeDurationSeconds, 0.0f, 0.7f);
     const unsigned char alpha = static_cast<unsigned char>(fade_progress * 255.0f);
-    ui::draw_fullscreen_overlay({0, 0, 0, alpha});
+    ui::enqueue_fullscreen_overlay({0, 0, 0, alpha}, ui::draw_layer::overlay);
     const char* text = "FAILED...";
-    ui::draw_text_in_rect(text, 44, kFailureTextRect,
-                          Fade(g_theme->hud_failure_text, std::min(fade_progress * 1.15f, 1.0f)));
+    ui::enqueue_text_in_rect(text, 44, kFailureTextRect,
+                             Fade(g_theme->hud_failure_text, std::min(fade_progress * 1.15f, 1.0f)),
+                             ui::text_align::center, ui::draw_layer::modal);
 }
 
 void play_scene::draw_result_transition_overlay() const {
     const float progress = std::clamp(result_transition_timer_ / kResultTransitionDurationSeconds, 0.0f, 1.0f);
     const unsigned char alpha = static_cast<unsigned char>(progress * kResultFadeMaxAlpha * 255.0f);
-    ui::draw_fullscreen_overlay({0, 0, 0, alpha});
+    ui::enqueue_fullscreen_overlay({0, 0, 0, alpha}, ui::draw_layer::overlay);
 }
 
 double play_scene::get_visual_ms() const {

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -44,6 +44,8 @@ private:
     Camera3D make_play_camera() const;
     // カメラの可視範囲からレーンのZ方向の手前端・判定位置・奥端を計算する。
     bool get_lane_view_bounds(const Camera3D& camera, float& lane_start_z, float& judgement_z, float& lane_end_z) const;
+    // 現在フレームの UI layer に対応する hit region を再構築する。
+    void rebuild_hit_regions() const;
     // 描画キューを更新する。inactive から active へのノート移動と、active からの除去を行う。
     void update_draw_queues(float judgement_z, float lane_start_z, float lane_end_z, double visual_ms);
     // 開始前演出を含めた描画用の時刻を返す。

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -20,6 +20,7 @@
 #include "virtual_screen.h"
 
 namespace {
+constexpr ui::draw_layer kSettingsLayer = ui::draw_layer::base;
 constexpr int kPageCount = 4;
 const char* kPageNames[] = {"Gameplay", "Audio", "Video", "Key Config"};
 constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
@@ -128,6 +129,7 @@ void settings_scene::on_enter() {
 }
 
 void settings_scene::update(float dt) {
+    ui::begin_hit_regions();
     error_timer_ = std::max(0.0f, error_timer_ - dt);
 
     // リスニング中はページ切り替え・画面遷移を無効にする
@@ -136,7 +138,7 @@ void settings_scene::update(float dt) {
         return;
     }
 
-    if (ui::is_clicked(kBackRect)) {
+    if (ui::is_clicked(kBackRect, kSettingsLayer)) {
         save_settings(g_settings);
         if (return_target_ == return_target::song_select) {
             manager_.change_scene(std::make_unique<song_select_scene>(manager_));
@@ -149,7 +151,7 @@ void settings_scene::update(float dt) {
     Rectangle tabs[kPageCount];
     build_tab_rects(tabs);
     for (int i = 0; i < kPageCount; ++i) {
-        if (ui::is_clicked(tabs[i])) {
+        if (ui::is_clicked(tabs[i], kSettingsLayer)) {
             current_page_ = static_cast<page>(i);
             key_config_slot_ = -1;
             listening_ = false;
@@ -181,11 +183,11 @@ void settings_scene::update_gameplay() {
     }
 
     if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        if (ui::is_hovered(kGeneralRows[0])) {
+        if (ui::is_hovered(kGeneralRows[0], kSettingsLayer)) {
             active_slider_ = general_slider::note_speed;
-        } else if (ui::is_hovered(kGeneralRows[1])) {
+        } else if (ui::is_hovered(kGeneralRows[1], kSettingsLayer)) {
             active_slider_ = general_slider::camera_angle;
-        } else if (ui::is_hovered(kGeneralRows[2])) {
+        } else if (ui::is_hovered(kGeneralRows[2], kSettingsLayer)) {
             active_slider_ = general_slider::lane_width;
         }
     }
@@ -212,9 +214,9 @@ void settings_scene::update_audio() {
     }
 
     if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        if (ui::is_hovered(kGeneralRows[0])) {
+        if (ui::is_hovered(kGeneralRows[0], kSettingsLayer)) {
             active_slider_ = general_slider::bgm_volume;
-        } else if (ui::is_hovered(kGeneralRows[1])) {
+        } else if (ui::is_hovered(kGeneralRows[1], kSettingsLayer)) {
             active_slider_ = general_slider::se_volume;
         }
     }
@@ -241,7 +243,7 @@ void settings_scene::update_video() {
         active_slider_ = general_slider::none;
     }
 
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && ui::is_hovered(kGeneralRows[0])) {
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && ui::is_hovered(kGeneralRows[0], kSettingsLayer)) {
         active_slider_ = general_slider::frame_rate;
     }
 
@@ -254,10 +256,10 @@ void settings_scene::update_video() {
 
     bool resolution_changed = false;
 
-    if (ui::is_clicked(arrow_left_rect(kGeneralRows[1]))) {
+    if (ui::is_clicked(arrow_left_rect(kGeneralRows[1]), kSettingsLayer)) {
         g_settings.resolution_index = std::max(0, g_settings.resolution_index - 1);
         resolution_changed = true;
-    } else if (ui::is_clicked(arrow_right_rect(kGeneralRows[1]))) {
+    } else if (ui::is_clicked(arrow_right_rect(kGeneralRows[1]), kSettingsLayer)) {
         g_settings.resolution_index = std::min(kResolutionPresetCount - 1, g_settings.resolution_index + 1);
         resolution_changed = true;
     }
@@ -267,15 +269,15 @@ void settings_scene::update_video() {
         SetWindowSize(preset.width, preset.height);
     }
 
-    if (ui::is_clicked(arrow_left_rect(kGeneralRows[2])) ||
-        ui::is_clicked(arrow_right_rect(kGeneralRows[2]))) {
+    if (ui::is_clicked(arrow_left_rect(kGeneralRows[2]), kSettingsLayer) ||
+        ui::is_clicked(arrow_right_rect(kGeneralRows[2]), kSettingsLayer)) {
         g_settings.fullscreen = !g_settings.fullscreen;
         ToggleFullscreen();
     }
 
     // テーマ切り替え
-    if (ui::is_clicked(arrow_left_rect(kGeneralRows[3])) ||
-        ui::is_clicked(arrow_right_rect(kGeneralRows[3]))) {
+    if (ui::is_clicked(arrow_left_rect(kGeneralRows[3]), kSettingsLayer) ||
+        ui::is_clicked(arrow_right_rect(kGeneralRows[3]), kSettingsLayer)) {
         g_settings.dark_mode = !g_settings.dark_mode;
         set_theme(g_settings.dark_mode);
     }
@@ -322,7 +324,7 @@ void settings_scene::update_key_config() {
 
     const Rectangle mode_left = arrow_left_rect(kKeyModeRect);
     const Rectangle mode_right = arrow_right_rect(kKeyModeRect);
-    if (ui::is_clicked(mode_left) || ui::is_clicked(mode_right)) {
+    if (ui::is_clicked(mode_left, kSettingsLayer) || ui::is_clicked(mode_right, kSettingsLayer)) {
         key_config_mode_ = 1 - key_config_mode_;
         key_config_slot_ = -1;
         return;
@@ -330,7 +332,7 @@ void settings_scene::update_key_config() {
 
     for (int i = 0; i < max_keys; ++i) {
         const Rectangle row_rect = key_slot_rect(i);
-        if (ui::is_clicked(row_rect)) {
+        if (ui::is_clicked(row_rect, kSettingsLayer)) {
             if (key_config_slot_ == i) {
                 listening_ = true;
                 key_config_error_.clear();
@@ -428,7 +430,7 @@ void settings_scene::draw_gameplay() {
             ratio = (g_settings.lane_width - 0.6f) / (10.0f - 0.6f);
         }
         ui::draw_slider_relative(kGeneralRows[i], labels[i], values[i].c_str(), clamp01(ratio),
-                                 kSliderLeftInset, kSliderRightInset, 22, kSliderTopOffset);
+                                 kSliderLeftInset, kSliderRightInset, kSettingsLayer, 22, kSliderTopOffset);
     }
 }
 
@@ -443,7 +445,7 @@ void settings_scene::draw_audio() {
         const int i = row;
         const float ratio = row == 0 ? g_settings.bgm_volume : g_settings.se_volume;
         ui::draw_slider_relative(kGeneralRows[i], labels[row], values[row].c_str(), ratio,
-                                 kSliderLeftInset, kSliderRightInset, 22, kSliderTopOffset);
+                                 kSliderLeftInset, kSliderRightInset, kSettingsLayer, 22, kSliderTopOffset);
     }
 }
 
@@ -451,15 +453,15 @@ void settings_scene::draw_video() {
     const std::string fps_label = g_settings.target_fps == 0 ? "Unlimited" : std::to_string(g_settings.target_fps);
     ui::draw_slider_relative(kGeneralRows[0], "Frame Rate", fps_label.c_str(),
                              static_cast<float>(fps_option_index(g_settings.target_fps)) / 3.0f,
-                             kSliderLeftInset, kSliderRightInset, 22, kSliderTopOffset);
-    ui::draw_value_selector(kGeneralRows[1], "Resolution", kResolutionPresets[g_settings.resolution_index].label);
-    ui::draw_value_selector(kGeneralRows[2], "Display", g_settings.fullscreen ? "Fullscreen" : "Windowed");
-    ui::draw_value_selector(kGeneralRows[3], "Theme", g_settings.dark_mode ? "Dark" : "Light");
+                             kSliderLeftInset, kSliderRightInset, kSettingsLayer, 22, kSliderTopOffset);
+    ui::draw_value_selector(kGeneralRows[1], "Resolution", kResolutionPresets[g_settings.resolution_index].label, kSettingsLayer);
+    ui::draw_value_selector(kGeneralRows[2], "Display", g_settings.fullscreen ? "Fullscreen" : "Windowed", kSettingsLayer);
+    ui::draw_value_selector(kGeneralRows[3], "Theme", g_settings.dark_mode ? "Dark" : "Light", kSettingsLayer);
 }
 
 void settings_scene::draw_key_config() {
     const auto& t = *g_theme;
-    ui::draw_value_selector(kKeyModeRect, "Mode", key_config_mode_ == 0 ? "4K" : "6K");
+    ui::draw_value_selector(kKeyModeRect, "Mode", key_config_mode_ == 0 ? "4K" : "6K", kSettingsLayer);
 
     // キースロット表示
     const std::span<const KeyboardKey> keys = key_config_mode_ == 0
@@ -470,7 +472,10 @@ void settings_scene::draw_key_config() {
         const bool selected = key_config_slot_ == i;
         const bool is_listening = selected && listening_;
         const Rectangle row_rect = key_slot_rect(i);
-        const ui::row_state row_state = ui::draw_selectable_row(row_rect, selected);
+        const ui::row_state row_state = ui::draw_row(row_rect,
+                                                     selected ? t.row_selected : t.row,
+                                                     selected ? t.row_active : t.row_hover,
+                                                     selected ? t.border_active : t.border);
         const char* key_label = is_listening ? "Press a key..." : get_key_name(keys[static_cast<size_t>(i)]);
         const ui::rect_pair columns = ui::split_columns(ui::inset(row_state.visual, 18.0f), 160.0f);
         ui::draw_text_in_rect(TextFormat("Lane %d", i + 1), 24, columns.first, t.text, ui::text_align::left);

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -20,6 +20,7 @@
 #include "virtual_screen.h"
 
 namespace {
+constexpr ui::draw_layer kSongSelectLayer = ui::draw_layer::base;
 constexpr float kRowHeight = 60.0f;
 constexpr float kScrollWheelStep = 80.0f;
 constexpr float kScrollLerpSpeed = 12.0f;
@@ -301,7 +302,7 @@ void song_select_scene::draw_song_row(const song_entry& song, float item_y, bool
     const Rectangle title_clip_rect = {text_x, item_y, list_text_max_w, 24.0f};
     const Rectangle artist_clip_rect = {text_x, item_y + 22.0f, list_text_max_w, 16.0f};
 
-    if (ui::is_hovered(row_rect) || is_selected) {
+    if (ui::is_hovered(row_rect, kSongSelectLayer) || is_selected) {
         const ui::row_state row_state = ui::draw_selectable_row(row_rect, is_selected, 0.0f);
         (void)row_state;
     }
@@ -323,7 +324,7 @@ void song_select_scene::draw_chart_rows(const std::vector<const chart_option*>& 
         const chart_option& chart = *filtered[static_cast<size_t>(chart_index)];
         const bool child_selected = chart_index == difficulty_index_;
         const Rectangle child_rect = {child_x, child_y - 6.0f, child_w, 28.0f};
-        if (ui::is_hovered(child_rect) || child_selected) {
+        if (ui::is_hovered(child_rect, kSongSelectLayer) || child_selected) {
             const ui::row_state child_state = ui::draw_selectable_row(child_rect, child_selected, 0.0f);
             (void)child_state;
         }
@@ -381,6 +382,7 @@ float song_select_scene::compute_content_height() const {
 }
 
 void song_select_scene::update(float dt) {
+    ui::begin_hit_regions();
     update_preview(dt);
 
     if (IsKeyPressed(KEY_ESCAPE)) {
@@ -391,7 +393,7 @@ void song_select_scene::update(float dt) {
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const float wheel = GetMouseWheelMove();
     if (IsKeyPressed(KEY_F1) ||
-        ui::is_clicked(kSettingsButtonRect)) {
+        ui::is_clicked(kSettingsButtonRect, kSongSelectLayer)) {
         manager_.change_scene(std::make_unique<settings_scene>(manager_, settings_scene::return_target::song_select));
         return;
     }
@@ -404,6 +406,7 @@ void song_select_scene::update(float dt) {
     }
 
     const int previous_song_index = selected_song_index_;
+    const bool song_list_hovered = ui::is_hovered(kSongListViewRect, kSongSelectLayer);
 
     // キー入力で曲選択
     if (IsKeyPressed(KEY_UP) || IsKeyPressed(KEY_W)) {
@@ -416,14 +419,15 @@ void song_select_scene::update(float dt) {
 
     const float content_height = compute_content_height();
     const ui::scrollbar_interaction scrollbar = ui::update_vertical_scrollbar(
-        kSongListScrollbarTrackRect, content_height, scroll_y_target_, scrollbar_dragging_, scrollbar_drag_offset_);
+        kSongListScrollbarTrackRect, content_height, scroll_y_target_, scrollbar_dragging_, scrollbar_drag_offset_,
+        kSongSelectLayer);
     scroll_y_target_ = scrollbar.scroll_offset;
     if (scrollbar.changed || scrollbar.dragging) {
         scroll_y_ = scroll_y_target_;
     }
 
     // マウスホイールでスムーズスクロール
-    if (!scrollbar.dragging && CheckCollisionPointRec(mouse, kSongListViewRect) && wheel != 0.0f) {
+    if (!scrollbar.dragging && song_list_hovered && wheel != 0.0f) {
         scroll_y_target_ -= wheel * kScrollWheelStep;
     }
 
@@ -466,27 +470,27 @@ void song_select_scene::update(float dt) {
         }
     }
 
-    if (ui::is_clicked(kPlayButtonRect) && !filtered.empty()) {
+    if (ui::is_clicked(kPlayButtonRect, kSongSelectLayer) && !filtered.empty()) {
         manager_.change_scene(std::make_unique<play_scene>(manager_, selected_song()->song,
                                                            filtered[static_cast<size_t>(difficulty_index_)]->path,
                                                            filtered[static_cast<size_t>(difficulty_index_)]->meta.key_count));
         return;
     }
 
-    if (ui::is_clicked(kEditButtonRect) && !filtered.empty()) {
+    if (ui::is_clicked(kEditButtonRect, kSongSelectLayer) && !filtered.empty()) {
         manager_.change_scene(std::make_unique<editor_scene>(manager_, selected_song()->song,
                                                              filtered[static_cast<size_t>(difficulty_index_)]->path));
         return;
     }
 
-    if (ui::is_clicked(kNewChartButtonRect)) {
+    if (ui::is_clicked(kNewChartButtonRect, kSongSelectLayer)) {
         const int key_count = filtered.empty() ? 4 : filtered[static_cast<size_t>(difficulty_index_)]->meta.key_count;
         manager_.change_scene(std::make_unique<editor_scene>(manager_, selected_song()->song, key_count));
         return;
     }
 
     // リスト内クリック: スクロールオフセットを考慮して当たり判定
-    if (CheckCollisionPointRec(mouse, kSongListViewRect) && IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+    if (song_list_hovered && IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
         float item_y = kSongListViewRect.y - scroll_y_;
         for (int i = 0; i < static_cast<int>(songs_.size()); ++i) {
             float row_h = kRowHeight;
@@ -498,7 +502,7 @@ void song_select_scene::update(float dt) {
                 for (int chart_index = 0; chart_index < static_cast<int>(filtered.size()); ++chart_index) {
                     const Rectangle child_rect = {kSongListRect.x + 46.0f, child_y - 6.0f, kSongListRect.width - 92.0f, 28.0f};
                     if (child_rect.y >= kSongListViewRect.y && child_rect.y + child_rect.height <= kSongListViewRect.y + kSongListViewRect.height &&
-                        CheckCollisionPointRec(mouse, child_rect)) {
+                        ui::is_hovered(child_rect, kSongSelectLayer)) {
                         if (difficulty_index_ == chart_index) {
                             // 選択中の難易度を再クリックでプレイ開始
                             manager_.change_scene(std::make_unique<play_scene>(manager_, selected_song()->song,
@@ -515,7 +519,7 @@ void song_select_scene::update(float dt) {
 
             const Rectangle row_rect = {kSongListRect.x + 14.0f, item_y - 8.0f, kSongListRect.width - 28.0f, 44.0f};
             if (row_rect.y >= kSongListViewRect.y && row_rect.y + row_rect.height <= kSongListViewRect.y + kSongListViewRect.height &&
-                CheckCollisionPointRec(mouse, row_rect)) {
+                ui::is_hovered(row_rect, kSongSelectLayer)) {
                 if (selected_song_index_ != i) {
                     selected_song_index_ = i;
                     difficulty_index_ = 0;

--- a/src/ui/ui_draw.h
+++ b/src/ui/ui_draw.h
@@ -1,6 +1,12 @@
 #pragma once
 
 #include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <span>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "raylib.h"
 #include "ui_coord.h"
@@ -13,6 +19,73 @@
 // 繰り返し使用される UI 描画パターンのユーティリティ。
 // theme.h の g_theme を参照するため、テーマ設定後に使用すること。
 namespace ui {
+
+struct draw_command {
+    int layer = 0;
+    std::uint64_t order = 0;
+    std::function<void()> draw;
+};
+
+inline std::vector<draw_command>& draw_queue() {
+    static std::vector<draw_command> queue;
+    return queue;
+}
+
+inline std::uint64_t& draw_queue_order() {
+    static std::uint64_t order = 0;
+    return order;
+}
+
+// 即時描画と併存する frame-local な UI 描画キュー。
+// overlay から段階導入し、将来的には hit test 優先順位も同じ layer に揃える前提。
+inline void begin_draw_queue() {
+    draw_queue().clear();
+    draw_queue_order() = 0;
+}
+
+inline void enqueue_draw_command(draw_layer layer, std::function<void()> draw) {
+    draw_queue().push_back({static_cast<int>(layer), draw_queue_order()++, std::move(draw)});
+}
+
+template <typename Fn>
+inline void enqueue_draw_command(draw_layer layer, Fn&& draw) {
+    enqueue_draw_command(layer, std::function<void()>(std::forward<Fn>(draw)));
+}
+
+inline void flush_draw_queue() {
+    auto& queue = draw_queue();
+    std::stable_sort(queue.begin(), queue.end(), [](const draw_command& left, const draw_command& right) {
+        if (left.layer != right.layer) {
+            return left.layer < right.layer;
+        }
+        return left.order < right.order;
+    });
+
+    for (const draw_command& command : queue) {
+        command.draw();
+    }
+    queue.clear();
+}
+
+namespace detail {
+
+inline void draw_button_visual(Rectangle rect, bool hovered, bool pressed, const char* label,
+                               int font_size, Color bg, Color bg_hover, Color text_color,
+                               float border_width) {
+    const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
+    DrawRectangleRec(visual, lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f));
+    DrawRectangleLinesEx(visual, border_width, g_theme->border);
+    draw_text_in_rect(label, font_size, visual, text_color);
+}
+
+inline void draw_row_visual(Rectangle rect, bool hovered, bool pressed, Color bg, Color bg_hover,
+                            Color border_color, float border_width) {
+    const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
+    DrawRectangleRec(visual, lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f));
+    DrawRectangleLinesEx(visual, border_width, border_color);
+}
+
+}  // namespace detail
 
 // ── ボタン ──────────────────────────────────────────────
 
@@ -60,11 +133,8 @@ inline button_state draw_button(Rectangle rect, const char* label, int font_size
     const bool hovered = is_hovered(rect);
     const bool pressed = is_pressed(rect);
     const bool clicked = is_clicked(rect);
-    const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
-
-    DrawRectangleRec(visual, lerp_color(g_theme->row, g_theme->row_hover, hovered ? 1.0f : 0.0f));
-    DrawRectangleLinesEx(visual, border_width, g_theme->border);
-    draw_text_in_rect(label, font_size, visual, g_theme->text);
+    detail::draw_button_visual(rect, hovered, pressed, label, font_size,
+                               g_theme->row, g_theme->row_hover, g_theme->text, border_width);
 
     return {hovered, pressed, clicked};
 }
@@ -76,11 +146,8 @@ inline button_state draw_button_colored(Rectangle rect, const char* label, int f
     const bool hovered = is_hovered(rect);
     const bool pressed = is_pressed(rect);
     const bool clicked = is_clicked(rect);
-    const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
-
-    DrawRectangleRec(visual, lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f));
-    DrawRectangleLinesEx(visual, border_width, g_theme->border);
-    draw_text_in_rect(label, font_size, visual, text_color);
+    detail::draw_button_visual(rect, hovered, pressed, label, font_size,
+                               bg, bg_hover, text_color, border_width);
 
     return {hovered, pressed, clicked};
 }
@@ -93,8 +160,7 @@ inline row_state draw_row(Rectangle rect, Color bg, Color bg_hover, Color border
     const bool clicked = is_clicked(rect);
     const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
 
-    DrawRectangleRec(visual, lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f));
-    DrawRectangleLinesEx(visual, border_width, border_color);
+    detail::draw_row_visual(rect, hovered, pressed, bg, bg_hover, border_color, border_width);
     return {hovered, pressed, clicked, visual};
 }
 
@@ -107,6 +173,37 @@ inline row_state draw_selectable_row(Rectangle rect, bool selected,
                     border_width);
 }
 
+inline button_state enqueue_button(Rectangle rect, const char* label, int font_size,
+                                   draw_layer layer = draw_layer::base,
+                                   float border_width = 2.0f) {
+    const bool hovered = is_hovered(rect, layer);
+    const bool pressed = is_pressed(rect, layer);
+    const bool clicked = is_clicked(rect, layer);
+    const std::string label_copy = label != nullptr ? label : "";
+
+    enqueue_draw_command(layer, [rect, hovered, pressed, label_copy, font_size, border_width]() {
+        detail::draw_button_visual(rect, hovered, pressed, label_copy.c_str(), font_size,
+                                   g_theme->row, g_theme->row_hover, g_theme->text, border_width);
+    });
+
+    return {hovered, pressed, clicked};
+}
+
+inline row_state enqueue_row(Rectangle rect, Color bg, Color bg_hover, Color border_color,
+                             draw_layer layer = draw_layer::base,
+                             float border_width = 2.0f) {
+    const bool hovered = is_hovered(rect, layer);
+    const bool pressed = is_pressed(rect, layer);
+    const bool clicked = is_clicked(rect, layer);
+    const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
+
+    enqueue_draw_command(layer, [rect, hovered, pressed, bg, bg_hover, border_color, border_width]() {
+        detail::draw_row_visual(rect, hovered, pressed, bg, bg_hover, border_color, border_width);
+    });
+
+    return {hovered, pressed, clicked, visual};
+}
+
 // ── パネル ──────────────────────────────────────────────
 
 // メインパネル（panel 背景 + border ボーダー、2px）。
@@ -115,10 +212,31 @@ inline void draw_panel(Rectangle rect) {
     DrawRectangleLinesEx(rect, 2.0f, g_theme->border);
 }
 
+inline void enqueue_panel(Rectangle rect, draw_layer layer = draw_layer::base) {
+    enqueue_draw_command(layer, [rect]() {
+        draw_panel(rect);
+    });
+}
+
 // セクションパネル（section 背景 + border_light ボーダー、1.5px）。
 inline void draw_section(Rectangle rect) {
     DrawRectangleRec(rect, g_theme->section);
     DrawRectangleLinesEx(rect, 1.5f, g_theme->border_light);
+}
+
+inline void enqueue_section(Rectangle rect, draw_layer layer = draw_layer::base) {
+    enqueue_draw_command(layer, [rect]() {
+        draw_section(rect);
+    });
+}
+
+inline void enqueue_text_in_rect(const char* text, int font_size, Rectangle rect, Color color,
+                                 text_align align = text_align::center,
+                                 draw_layer layer = draw_layer::base) {
+    const std::string text_copy = text != nullptr ? text : "";
+    enqueue_draw_command(layer, [text_copy, font_size, rect, color, align]() {
+        draw_text_in_rect(text_copy.c_str(), font_size, rect, color, align);
+    });
 }
 
 // ── ラベル付き値 ────────────────────────────────────────
@@ -171,6 +289,51 @@ inline selector_state draw_value_selector(Rectangle rect, const char* label, con
     return {row, left, right};
 }
 
+inline selector_state draw_value_selector(Rectangle rect, const char* label, const char* value,
+                                          draw_layer layer,
+                                          int font_size = 24, float button_size = 34.0f,
+                                          float label_width = 200.0f, float content_padding = 18.0f) {
+    const bool row_hovered = is_hovered(rect, layer);
+    const bool row_pressed = is_pressed(rect, layer);
+    const bool row_clicked = is_clicked(rect, layer);
+    const Rectangle visual = row_pressed ? inset(rect, 1.5f) : rect;
+    detail::draw_row_visual(rect, row_hovered, row_pressed, g_theme->row, g_theme->row_hover, g_theme->border, 2.0f);
+    const row_state row = {row_hovered, row_pressed, row_clicked, visual};
+
+    const Rectangle content = inset(row.visual, edge_insets::symmetric(0.0f, content_padding));
+    const rect_pair columns = split_columns(content, label_width);
+    const Rectangle button_pair_area = place(columns.second, button_size * 2.0f + 10.0f, button_size,
+                                             anchor::center_right, anchor::center_right);
+    Rectangle buttons[2];
+    hstack(button_pair_area, button_size, 10.0f, buttons);
+
+    const Rectangle value_rect = {
+        columns.second.x,
+        columns.second.y,
+        button_pair_area.x - columns.second.x - 16.0f,
+        columns.second.height
+    };
+
+    draw_text_in_rect(label, font_size, columns.first, g_theme->text, text_align::left);
+    draw_text_in_rect(value, font_size, value_rect, g_theme->text_dim, text_align::right);
+
+    const bool left_hovered = is_hovered(buttons[0], layer);
+    const bool left_pressed = is_pressed(buttons[0], layer);
+    const bool left_clicked = is_clicked(buttons[0], layer);
+    detail::draw_button_visual(buttons[0], left_hovered, left_pressed, "<", font_size,
+                               g_theme->row, g_theme->row_hover, g_theme->text, 2.0f);
+
+    const bool right_hovered = is_hovered(buttons[1], layer);
+    const bool right_pressed = is_pressed(buttons[1], layer);
+    const bool right_clicked = is_clicked(buttons[1], layer);
+    detail::draw_button_visual(buttons[1], right_hovered, right_pressed, ">", font_size,
+                               g_theme->row, g_theme->row_hover, g_theme->text, 2.0f);
+
+    const button_state left = {left_hovered, left_pressed, left_clicked};
+    const button_state right = {right_hovered, right_pressed, right_clicked};
+    return {row, left, right};
+}
+
 inline dropdown_state draw_dropdown(Rectangle trigger_rect, Rectangle menu_rect,
                                     const char* label, const char* value,
                                     std::span<const char* const> options,
@@ -210,6 +373,102 @@ inline dropdown_state draw_dropdown(Rectangle trigger_rect, Rectangle menu_rect,
             }
             item_rect.y += item_height + item_spacing;
         }
+    }
+
+    return {trigger, clicked_index};
+}
+
+inline dropdown_state enqueue_dropdown(Rectangle trigger_rect, Rectangle menu_rect,
+                                       const char* label, const char* value,
+                                       std::span<const char* const> options,
+                                       int selected_index, bool open,
+                                       draw_layer trigger_layer = draw_layer::base,
+                                       draw_layer menu_layer = draw_layer::overlay,
+                                       int font_size = 18, float label_width = 72.0f,
+                                       float content_padding = 12.0f,
+                                       float item_height = 30.0f, float item_spacing = 4.0f) {
+    if (open) {
+        register_hit_region(menu_rect, menu_layer);
+    }
+
+    const bool trigger_pressed = is_pressed(trigger_rect, trigger_layer);
+    const row_state trigger = {
+        is_hovered(trigger_rect, trigger_layer),
+        trigger_pressed,
+        is_clicked(trigger_rect, trigger_layer),
+        trigger_pressed ? inset(trigger_rect, 1.5f) : trigger_rect
+    };
+
+    std::vector<std::string> option_copies;
+    option_copies.reserve(options.size());
+    for (const char* option : options) {
+        option_copies.emplace_back(option != nullptr ? option : "");
+    }
+    const std::string label_copy = label != nullptr ? label : "";
+    const std::string value_copy = value != nullptr ? value : "";
+
+    enqueue_draw_command(trigger_layer, [trigger_rect, trigger, label_copy, value_copy, font_size,
+                                         label_width, content_padding, open]() {
+        const Rectangle trigger_content = inset(trigger.visual, edge_insets::symmetric(0.0f, content_padding));
+        const rect_pair trigger_columns = split_columns(trigger_content, label_width);
+        const Rectangle trigger_arrow_rect = place(trigger_columns.second, 18.0f, trigger_columns.second.height,
+                                                   anchor::center_right, anchor::center_right);
+        const Rectangle trigger_value_rect = {
+            trigger_columns.second.x,
+            trigger_columns.second.y,
+            std::max(0.0f, trigger_arrow_rect.x - trigger_columns.second.x - 8.0f),
+            trigger_columns.second.height
+        };
+
+        detail::draw_row_visual(trigger_rect, trigger.hovered, trigger.pressed,
+                                open ? g_theme->row_selected : g_theme->row,
+                                open ? g_theme->row_selected_hover : g_theme->row_hover,
+                                open ? g_theme->border_active : g_theme->border,
+                                2.0f);
+        draw_text_in_rect(label_copy.c_str(), font_size, trigger_columns.first, g_theme->text, text_align::left);
+        draw_text_in_rect(value_copy.c_str(), font_size, trigger_value_rect, g_theme->text_dim, text_align::right);
+        draw_text_in_rect(open ? "^" : "v", font_size, trigger_arrow_rect, g_theme->text_dim);
+    });
+
+    int clicked_index = -1;
+    if (open) {
+        Rectangle item_rect = {menu_rect.x + 6.0f, menu_rect.y + 6.0f, menu_rect.width - 12.0f, item_height};
+        std::vector<row_state> item_states;
+        item_states.reserve(option_copies.size());
+
+        for (int i = 0; i < static_cast<int>(option_copies.size()); ++i) {
+            const bool item_pressed = is_pressed(item_rect, menu_layer);
+            const row_state option_row = {
+                is_hovered(item_rect, menu_layer),
+                item_pressed,
+                is_clicked(item_rect, menu_layer),
+                item_pressed ? inset(item_rect, 1.5f) : item_rect
+            };
+            item_states.push_back(option_row);
+            if (option_row.clicked) {
+                clicked_index = i;
+            }
+            item_rect.y += item_height + item_spacing;
+        }
+
+        enqueue_draw_command(menu_layer, [menu_rect, item_height, item_spacing, font_size, selected_index,
+                                          option_copies = std::move(option_copies),
+                                          item_states = std::move(item_states)]() {
+            draw_section(menu_rect);
+            Rectangle draw_item_rect = {menu_rect.x + 6.0f, menu_rect.y + 6.0f, menu_rect.width - 12.0f, item_height};
+            for (int i = 0; i < static_cast<int>(option_copies.size()); ++i) {
+                const row_state& option_row = item_states[static_cast<size_t>(i)];
+                detail::draw_row_visual(draw_item_rect, option_row.hovered, option_row.pressed,
+                                        i == selected_index ? g_theme->row_selected : g_theme->row,
+                                        i == selected_index ? g_theme->row_active : g_theme->row_hover,
+                                        i == selected_index ? g_theme->border_active : g_theme->border,
+                                        1.5f);
+                draw_text_in_rect(option_copies[static_cast<size_t>(i)].c_str(), font_size,
+                                  inset(option_row.visual, edge_insets::symmetric(0.0f, 12.0f)),
+                                  i == selected_index ? g_theme->text : g_theme->text_dim, text_align::left);
+                draw_item_rect.y += item_height + item_spacing;
+            }
+        });
     }
 
     return {trigger, clicked_index};
@@ -297,6 +556,33 @@ inline float draw_slider(Rectangle row_rect, const char* label, const char* valu
     return -1.0f;
 }
 
+inline float draw_slider(Rectangle row_rect, const char* label, const char* value_text,
+                         float ratio, float track_left, float track_width, draw_layer layer,
+                         int font_size = 22, float track_top_offset = 26.0f) {
+    DrawRectangleRec(row_rect, g_theme->row);
+    DrawRectangleLinesEx(row_rect, 2.0f, g_theme->border);
+
+    const Rectangle label_rect = {row_rect.x + 18.0f, row_rect.y, 200.0f, row_rect.height};
+    draw_text_in_rect(label, font_size, label_rect, g_theme->text, text_align::left);
+
+    const Rectangle track = {track_left, row_rect.y + track_top_offset, track_width, 6.0f};
+    const float clamped = std::clamp(ratio, 0.0f, 1.0f);
+    DrawRectangleRec(track, g_theme->slider_track);
+    draw_rect_f(track.x, track.y, track.width * clamped, track.height, g_theme->slider_fill);
+
+    const float knob_x = track.x + track.width * clamped;
+    draw_rect_f(knob_x - 6.0f, track.y - 8.0f, 12.0f, 22.0f, g_theme->slider_knob);
+
+    const Rectangle value_rect = {track.x, row_rect.y, track.width, track_top_offset};
+    draw_text_in_rect(value_text, font_size, value_rect, g_theme->text_dim, text_align::right);
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && is_hovered(row_rect, layer)) {
+        const Vector2 mouse = virtual_screen::get_virtual_mouse();
+        return std::clamp((mouse.x - track.x) / track.width, 0.0f, 1.0f);
+    }
+    return -1.0f;
+}
+
 // スライダー行を描画する。track_left_inset / track_right_inset は row_rect 基準の相対指定。
 inline float draw_slider_relative(Rectangle row_rect, const char* label, const char* value_text,
                                   float ratio, float track_left_inset, float track_right_inset,
@@ -317,6 +603,36 @@ inline float draw_slider_relative(Rectangle row_rect, const char* label, const c
     draw_text_in_rect(value_text, font_size, layout.value_rect, g_theme->text_dim, text_align::right);
 
     if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), row_rect)) {
+        const Vector2 mouse = virtual_screen::get_virtual_mouse();
+        return std::clamp((mouse.x - layout.track_rect.x) / layout.track_rect.width, 0.0f, 1.0f);
+    }
+    return -1.0f;
+}
+
+inline float draw_slider_relative(Rectangle row_rect, const char* label, const char* value_text,
+                                  float ratio, float track_left_inset, float track_right_inset,
+                                  draw_layer layer,
+                                  int font_size = 22, float track_top_offset = 26.0f,
+                                  float label_width = 200.0f, float content_padding = 18.0f) {
+    const bool hovered = is_hovered(row_rect, layer);
+    const bool pressed = is_pressed(row_rect, layer);
+    const Rectangle visual = pressed ? inset(row_rect, 1.5f) : row_rect;
+    detail::draw_row_visual(row_rect, hovered, pressed, g_theme->row, g_theme->row_hover, g_theme->border, 2.0f);
+    const row_state row = {hovered, pressed, is_clicked(row_rect, layer), visual};
+    const slider_layout layout = make_slider_layout(row.visual, track_left_inset, track_right_inset,
+                                                    label_width, content_padding, track_top_offset);
+    const float clamped = std::clamp(ratio, 0.0f, 1.0f);
+
+    draw_text_in_rect(label, font_size, layout.label_rect, g_theme->text, text_align::left);
+    DrawRectangleRec(layout.track_rect, g_theme->slider_track);
+    draw_rect_f(layout.track_rect.x, layout.track_rect.y,
+                layout.track_rect.width * clamped, layout.track_rect.height, g_theme->slider_fill);
+
+    const float knob_x = layout.track_rect.x + layout.track_rect.width * clamped;
+    draw_rect_f(knob_x - 6.0f, layout.track_rect.y - 8.0f, 12.0f, 22.0f, g_theme->slider_knob);
+    draw_text_in_rect(value_text, font_size, layout.value_rect, g_theme->text_dim, text_align::right);
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && is_hovered(row_rect, layer)) {
         const Vector2 mouse = virtual_screen::get_virtual_mouse();
         return std::clamp((mouse.x - layout.track_rect.x) / layout.track_rect.width, 0.0f, 1.0f);
     }
@@ -374,11 +690,57 @@ inline scrollbar_interaction update_vertical_scrollbar(Rectangle track_rect, flo
     return {next_offset, changed, dragging};
 }
 
+inline scrollbar_interaction update_vertical_scrollbar(Rectangle track_rect, float content_height, float scroll_offset,
+                                                       bool& dragging, float& drag_offset, draw_layer layer,
+                                                       float min_thumb_height = 36.0f) {
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        dragging = false;
+    }
+
+    const scroll_metrics metrics = vertical_scroll_metrics(track_rect, content_height, scroll_offset, min_thumb_height);
+    if (metrics.max_scroll <= 0.0f) {
+        return {0.0f, false, false};
+    }
+
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    float next_offset = std::clamp(scroll_offset, 0.0f, metrics.max_scroll);
+    bool changed = false;
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && is_hovered(track_rect, layer)) {
+        if (CheckCollisionPointRec(mouse, metrics.thumb_rect)) {
+            dragging = true;
+            drag_offset = mouse.y - metrics.thumb_rect.y;
+        } else {
+            const float thumb_half = metrics.thumb_rect.height * 0.5f;
+            const float available = std::max(1.0f, track_rect.height - metrics.thumb_rect.height);
+            const float thumb_top = std::clamp(mouse.y - thumb_half - track_rect.y, 0.0f, available);
+            next_offset = metrics.max_scroll * (thumb_top / available);
+            changed = true;
+        }
+    }
+
+    if (dragging && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        const float available = std::max(1.0f, track_rect.height - metrics.thumb_rect.height);
+        const float thumb_top = std::clamp(mouse.y - drag_offset - track_rect.y, 0.0f, available);
+        next_offset = metrics.max_scroll * (thumb_top / available);
+        changed = true;
+    }
+
+    next_offset = std::clamp(next_offset, 0.0f, metrics.max_scroll);
+    return {next_offset, changed, dragging};
+}
+
 // ── オーバーレイ ────────────────────────────────────────
 
 // 画面全体を覆う半透明オーバーレイ。ポーズ画面やフェードイン/アウトに使用する。
 inline void draw_fullscreen_overlay(Color color) {
     DrawRectangle(0, 0, 1280, 720, color);
+}
+
+inline void enqueue_fullscreen_overlay(Color color, draw_layer layer = draw_layer::overlay) {
+    enqueue_draw_command(layer, [color]() {
+        draw_fullscreen_overlay(color);
+    });
 }
 
 }  // namespace ui

--- a/src/ui/ui_hit.h
+++ b/src/ui/ui_hit.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "raylib.h"
 #include "virtual_screen.h"
 
@@ -7,19 +9,63 @@
 // virtual_screen の仮想マウス座標を使用して判定する。
 namespace ui {
 
+enum class draw_layer : int {
+    base = 0,
+    overlay = 100,
+    modal = 200,
+    debug = 300,
+};
+
+struct hit_region {
+    Rectangle rect = {};
+    int layer = 0;
+};
+
+inline std::vector<hit_region>& hit_regions() {
+    static std::vector<hit_region> regions;
+    return regions;
+}
+
+inline void begin_hit_regions() {
+    hit_regions().clear();
+}
+
+inline void register_hit_region(Rectangle rect, draw_layer layer) {
+    hit_regions().push_back({rect, static_cast<int>(layer)});
+}
+
+inline bool is_blocked_by_higher_layer(Rectangle rect, draw_layer layer) {
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    if (!CheckCollisionPointRec(mouse, rect)) {
+        return false;
+    }
+
+    const int requested_layer = static_cast<int>(layer);
+    for (const hit_region& region : hit_regions()) {
+        if (region.layer <= requested_layer) {
+            continue;
+        }
+        if (CheckCollisionPointRec(mouse, region.rect)) {
+            return true;
+        }
+    }
+    return false;
+}
+
 // 仮想マウスが rect 内にあるか。
-inline bool is_hovered(Rectangle rect) {
-    return CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), rect);
+inline bool is_hovered(Rectangle rect, draw_layer layer = draw_layer::base) {
+    return CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), rect) &&
+           !is_blocked_by_higher_layer(rect, layer);
 }
 
 // ホバー中かつマウスボタン押下中か。
-inline bool is_pressed(Rectangle rect) {
-    return is_hovered(rect) && IsMouseButtonDown(MOUSE_BUTTON_LEFT);
+inline bool is_pressed(Rectangle rect, draw_layer layer = draw_layer::base) {
+    return is_hovered(rect, layer) && IsMouseButtonDown(MOUSE_BUTTON_LEFT);
 }
 
 // ホバー中かつマウスボタンを離した瞬間か（クリック判定）。
-inline bool is_clicked(Rectangle rect) {
-    return is_hovered(rect) && IsMouseButtonReleased(MOUSE_BUTTON_LEFT);
+inline bool is_clicked(Rectangle rect, draw_layer layer = draw_layer::base) {
+    return is_hovered(rect, layer) && IsMouseButtonReleased(MOUSE_BUTTON_LEFT);
 }
 
 }  // namespace ui


### PR DESCRIPTION
## 概要
- `ui_draw.h` に frame-local な draw queue と layer 付き enqueue API を追加
- `editor_scene` の dropdown と `play_scene` の pause / transition overlay を queue ベース描画へ移行
- `ui_hit.h` に hit region 登録を追加し、dropdown / pause / settings / song select の入力判定を layer-aware に統一
- `docs/ui-layout-system.md` に段階移行方針と適用済みシーンを追記

## 確認
- build はユーザー環境で実施
- editor dropdown 上のクリックで timeline にノーツが追加されないことを確認済み
- ChartEditor の scrollbar 表示が戻っていることを確認済み
- pause / settings / song select の各 UI が期待通り動作することを確認済み

Closes #86