### PR TITLE
譜面エディタの editor_scene の責務を分割

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,14 @@ add_executable(raythm src/main.cpp
         src/audio/audio_manager.cpp
         src/audio/audio_manager.h
         src/editor/editor_command.h
+        src/editor/editor_meter_map.cpp
+        src/editor/editor_meter_map.h
         src/editor/editor_state.cpp
         src/editor/editor_state.h
+        src/editor/editor_timeline_view.cpp
+        src/editor/editor_timeline_view.h
+        src/editor/editor_timing_panel.cpp
+        src/editor/editor_timing_panel.h
         src/platform/windows_input_source.cpp
         src/platform/windows_input_source.h
         src/gameplay/chart_parser.cpp
@@ -86,6 +92,8 @@ add_executable(chart_serializer_smoke
 
 add_executable(editor_state_smoke
         src/editor/editor_command.h
+        src/editor/editor_meter_map.cpp
+        src/editor/editor_meter_map.h
         src/editor/editor_state.cpp
         src/editor/editor_state.h
         src/models/data_models.h

--- a/src/editor/editor_meter_map.cpp
+++ b/src/editor/editor_meter_map.cpp
@@ -1,0 +1,174 @@
+#include "editor_meter_map.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace {
+std::vector<timing_event> sorted_meter_events(const chart_data& data) {
+    std::vector<timing_event> meter_events;
+    for (const timing_event& event : data.timing_events) {
+        if (event.type == timing_event_type::meter) {
+            meter_events.push_back(event);
+        }
+    }
+
+    std::sort(meter_events.begin(), meter_events.end(), [](const timing_event& left, const timing_event& right) {
+        return left.tick < right.tick;
+    });
+
+    return meter_events;
+}
+}
+
+void editor_meter_map::rebuild(const chart_data& data) {
+    meter_segments_.clear();
+    resolution_ = std::max(1, data.meta.resolution);
+
+    const std::vector<timing_event> events = sorted_meter_events(data);
+    if (events.empty() || events.front().tick != 0) {
+        meter_segments_.push_back({0, 4, 4, 0, 0});
+    }
+
+    for (const timing_event& event : events) {
+        if (!meter_segments_.empty() && meter_segments_.back().start_tick == event.tick) {
+            meter_segments_.back().numerator = event.numerator;
+            meter_segments_.back().denominator = event.denominator;
+            continue;
+        }
+
+        meter_segment segment;
+        segment.start_tick = event.tick;
+        segment.numerator = event.numerator;
+        segment.denominator = event.denominator;
+
+        if (meter_segments_.empty()) {
+            segment.beat_index_offset = 0;
+            segment.measure_index_offset = 0;
+        } else {
+            const meter_segment& previous = meter_segments_.back();
+            const int beat_ticks = resolution_ * 4 / std::max(previous.denominator, 1);
+            const int measure_ticks = beat_ticks * std::max(previous.numerator, 1);
+            const int beat_count = std::max(0, (segment.start_tick - previous.start_tick) / std::max(1, beat_ticks));
+            const int measure_count = std::max(0, (segment.start_tick - previous.start_tick) / std::max(1, measure_ticks));
+            segment.beat_index_offset = previous.beat_index_offset + beat_count;
+            segment.measure_index_offset = previous.measure_index_offset + measure_count;
+        }
+
+        meter_segments_.push_back(segment);
+    }
+}
+
+std::vector<editor_meter_map::grid_line> editor_meter_map::visible_grid_lines(int min_tick, int max_tick) const {
+    std::vector<grid_line> lines;
+    if (max_tick < min_tick) {
+        return lines;
+    }
+
+    for (size_t i = 0; i < meter_segments_.size(); ++i) {
+        const meter_segment& segment = meter_segments_[i];
+        const int next_tick = i + 1 < meter_segments_.size() ? meter_segments_[i + 1].start_tick : max_tick + resolution_ * 16;
+        const int beat_ticks = std::max(1, resolution_ * 4 / std::max(segment.denominator, 1));
+        const int start_tick = std::max(min_tick, segment.start_tick);
+        const int end_tick = std::min(max_tick, next_tick - (i + 1 < meter_segments_.size() ? 1 : 0));
+        int tick = segment.start_tick;
+        if (tick < start_tick) {
+            const int delta = start_tick - tick;
+            tick += (delta / beat_ticks) * beat_ticks;
+            while (tick < start_tick) {
+                tick += beat_ticks;
+            }
+        }
+
+        for (; tick <= end_tick; tick += beat_ticks) {
+            const int relative_tick = tick - segment.start_tick;
+            const int local_beat_index = relative_tick / beat_ticks;
+            const int beat = local_beat_index % std::max(segment.numerator, 1) + 1;
+            const int measure = segment.measure_index_offset + local_beat_index / std::max(segment.numerator, 1) + 1;
+            lines.push_back({tick, beat == 1, measure, beat});
+        }
+    }
+
+    return lines;
+}
+
+double editor_meter_map::beat_number_at_tick(int tick) const {
+    const meter_segment* segment = segment_at_tick(tick);
+    if (segment == nullptr) {
+        return 1.0;
+    }
+
+    const int beat_ticks = std::max(1, resolution_ * 4 / std::max(segment->denominator, 1));
+    const double local_beats = static_cast<double>(tick - segment->start_tick) / static_cast<double>(beat_ticks);
+    return static_cast<double>(segment->beat_index_offset) + local_beats + 1.0;
+}
+
+editor_meter_map::bar_beat_position editor_meter_map::bar_beat_at_tick(int tick) const {
+    const meter_segment* segment = segment_at_tick(tick);
+    if (segment == nullptr) {
+        return {};
+    }
+
+    const int numerator = std::max(segment->numerator, 1);
+    const int beat_ticks = std::max(1, resolution_ * 4 / std::max(segment->denominator, 1));
+    const int local_beat_index = std::max(0, static_cast<int>(std::llround(
+        static_cast<double>(tick - segment->start_tick) / static_cast<double>(beat_ticks))));
+    return {
+        segment->measure_index_offset + local_beat_index / numerator + 1,
+        local_beat_index % numerator + 1
+    };
+}
+
+std::optional<int> editor_meter_map::tick_from_bar_beat(int measure, int beat) const {
+    if (measure <= 0 || beat <= 0 || meter_segments_.empty()) {
+        return std::nullopt;
+    }
+
+    for (size_t i = 0; i < meter_segments_.size(); ++i) {
+        const meter_segment& segment = meter_segments_[i];
+        const int first_measure = segment.measure_index_offset + 1;
+        const int next_measure = i + 1 < meter_segments_.size()
+            ? meter_segments_[i + 1].measure_index_offset + 1
+            : std::numeric_limits<int>::max();
+        if (measure < first_measure || measure >= next_measure) {
+            continue;
+        }
+
+        const int numerator = std::max(segment.numerator, 1);
+        if (beat > numerator) {
+            return std::nullopt;
+        }
+
+        const int beat_ticks = std::max(1, resolution_ * 4 / std::max(segment.denominator, 1));
+        const int measure_ticks = beat_ticks * numerator;
+        return segment.start_tick + (measure - first_measure) * measure_ticks + (beat - 1) * beat_ticks;
+    }
+
+    const meter_segment& segment = meter_segments_.back();
+    const int first_measure = segment.measure_index_offset + 1;
+    const int numerator = std::max(segment.numerator, 1);
+    if (measure < first_measure || beat > numerator) {
+        return std::nullopt;
+    }
+
+    const int beat_ticks = std::max(1, resolution_ * 4 / std::max(segment.denominator, 1));
+    const int measure_ticks = beat_ticks * numerator;
+    return segment.start_tick + (measure - first_measure) * measure_ticks + (beat - 1) * beat_ticks;
+}
+
+std::string editor_meter_map::bar_beat_label(int tick) const {
+    const bar_beat_position position = bar_beat_at_tick(tick);
+    return std::to_string(position.measure) + ":" + std::to_string(position.beat);
+}
+
+const editor_meter_map::meter_segment* editor_meter_map::segment_at_tick(int tick) const {
+    if (meter_segments_.empty()) {
+        return nullptr;
+    }
+
+    const auto it = std::upper_bound(meter_segments_.begin(), meter_segments_.end(), tick,
+                                     [](int value, const meter_segment& segment) {
+                                         return value < segment.start_tick;
+                                     });
+    return it == meter_segments_.begin() ? &meter_segments_.front() : &*std::prev(it);
+}

--- a/src/editor/editor_meter_map.h
+++ b/src/editor/editor_meter_map.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "data_models.h"
+
+class editor_meter_map {
+public:
+    struct grid_line {
+        int tick = 0;
+        bool major = false;
+        int measure = 1;
+        int beat = 1;
+    };
+
+    struct bar_beat_position {
+        int measure = 1;
+        int beat = 1;
+    };
+
+    void rebuild(const chart_data& data);
+
+    std::vector<grid_line> visible_grid_lines(int min_tick, int max_tick) const;
+    double beat_number_at_tick(int tick) const;
+    bar_beat_position bar_beat_at_tick(int tick) const;
+    std::optional<int> tick_from_bar_beat(int measure, int beat) const;
+    std::string bar_beat_label(int tick) const;
+
+private:
+    struct meter_segment {
+        int start_tick = 0;
+        int numerator = 4;
+        int denominator = 4;
+        int beat_index_offset = 0;
+        int measure_index_offset = 0;
+    };
+
+    const meter_segment* segment_at_tick(int tick) const;
+
+    std::vector<meter_segment> meter_segments_;
+    int resolution_ = 480;
+};

--- a/src/editor/editor_timeline_view.cpp
+++ b/src/editor/editor_timeline_view.cpp
@@ -1,0 +1,152 @@
+#include "editor_timeline_view.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "theme.h"
+#include "ui_clip.h"
+#include "ui_draw.h"
+
+Rectangle editor_timeline_metrics::content_rect() const {
+    return {
+        panel_rect.x + padding,
+        panel_rect.y + padding,
+        panel_rect.width - padding * 2.0f - scrollbar_gap - scrollbar_width,
+        panel_rect.height - padding * 2.0f
+    };
+}
+
+Rectangle editor_timeline_metrics::scrollbar_track_rect() const {
+    const Rectangle content = content_rect();
+    return {
+        content.x + content.width + scrollbar_gap,
+        content.y,
+        scrollbar_width,
+        content.height
+    };
+}
+
+float editor_timeline_metrics::visible_tick_span() const {
+    return content_rect().height * ticks_per_pixel;
+}
+
+float editor_timeline_metrics::tick_to_y(int tick) const {
+    const Rectangle content = content_rect();
+    return content.y + (static_cast<float>(tick) - bottom_tick) / ticks_per_pixel;
+}
+
+int editor_timeline_metrics::y_to_tick(float y) const {
+    const Rectangle content = content_rect();
+    return static_cast<int>(std::lround(bottom_tick + (y - content.y) * ticks_per_pixel));
+}
+
+float editor_timeline_metrics::lane_width() const {
+    const int clamped_key_count = std::max(1, key_count);
+    const float content_width = content_rect().width;
+    return (content_width - lane_gap * static_cast<float>(clamped_key_count - 1)) / static_cast<float>(clamped_key_count);
+}
+
+Rectangle editor_timeline_metrics::lane_rect(int lane) const {
+    const Rectangle content = content_rect();
+    const float width = lane_width();
+    return {
+        content.x + lane * (width + lane_gap),
+        content.y,
+        width,
+        content.height
+    };
+}
+
+editor_timeline_note_draw_info editor_timeline_metrics::note_rects(const editor_timeline_note& note) const {
+    const Rectangle lane = lane_rect(note.lane);
+    const float start_y = tick_to_y(note.tick);
+    editor_timeline_note_draw_info info;
+    info.head_rect = {lane.x + 6.0f, start_y - note_head_height * 0.5f, lane.width - 12.0f, note_head_height};
+
+    if (note.type == editor_timeline_note_type::hold) {
+        const float end_y = tick_to_y(note.end_tick);
+        const float top = std::min(start_y, end_y);
+        const float height = std::fabs(end_y - start_y);
+        info.body_rect = {lane.x + lane.width * 0.3f, top, lane.width * 0.4f, std::max(height, 6.0f)};
+        info.tail_rect = {lane.x + 10.0f, end_y - 5.0f, lane.width - 20.0f, 10.0f};
+        info.has_body = true;
+    }
+
+    return info;
+}
+
+void editor_timeline_view::draw(const editor_timeline_view_model& model) {
+    const auto& t = *g_theme;
+    const Rectangle content = model.metrics.content_rect();
+    const Rectangle track = model.metrics.scrollbar_track_rect();
+
+    DrawRectangleRec(ui::inset(model.metrics.panel_rect, 10.0f), t.section);
+    {
+        ui::scoped_clip_rect clip_scope(content);
+
+        for (int lane = 0; lane < std::max(1, model.metrics.key_count); ++lane) {
+            const Rectangle rect = model.metrics.lane_rect(lane);
+            DrawRectangleRec(rect, lane % 2 == 0 ? with_alpha(t.row, 20) : with_alpha(t.section, 20));
+            DrawRectangleLinesEx(rect, 1.0f, with_alpha(t.border_light, 180));
+            ui::draw_text_in_rect(TextFormat("L%d", lane + 1), 16,
+                                  {rect.x, model.metrics.panel_rect.y + 4.0f, rect.width, 20.0f},
+                                  t.text_hint);
+        }
+
+        const int first_snap_tick = std::max(0, (model.min_tick / model.snap_interval) * model.snap_interval);
+        for (int tick = first_snap_tick; tick <= model.max_tick; tick += model.snap_interval) {
+            const float y = model.metrics.tick_to_y(tick);
+            ui::draw_line_f(content.x, y, content.x + content.width, y, t.editor_grid_snap);
+        }
+
+        for (const editor_meter_map::grid_line& line : model.grid_lines) {
+            const float y = model.metrics.tick_to_y(line.tick);
+            const Color color = line.major ? t.editor_grid_major : t.editor_grid_minor;
+            ui::draw_line_f(content.x, y, content.x + content.width, y, color);
+            if (line.major) {
+                ui::draw_line_f(content.x, y + 1.0f, content.x + content.width, y + 1.0f, t.editor_grid_major_glow);
+            }
+            ui::draw_text_f(TextFormat("%d:%d", line.measure, line.beat), content.x + 8.0f, y - 10.0f,
+                            line.major ? 16 : 14, line.major ? t.text : t.text_secondary);
+        }
+
+        for (size_t i = 0; i < model.notes.size(); ++i) {
+            const editor_timeline_note& note = model.notes[i];
+            if (note.lane < 0 || note.lane >= model.metrics.key_count) {
+                continue;
+            }
+
+            const editor_timeline_note_draw_info info = model.metrics.note_rects(note);
+            const bool selected = model.selected_note_index.has_value() && *model.selected_note_index == i;
+            const Color head_fill = selected ? t.row_active : t.note_color;
+            const Color outline = selected ? t.border_active : t.note_outline;
+            const Color hold_fill = selected ? with_alpha(t.row_active, 200) : with_alpha(t.accent, 170);
+
+            if (info.has_body) {
+                DrawRectangleRounded(info.body_rect, 0.4f, 6, hold_fill);
+                DrawRectangleRounded(info.tail_rect, 0.4f, 6, selected ? with_alpha(t.row_active, 230) : with_alpha(t.accent, 220));
+                DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
+            }
+
+            DrawRectangleRounded(info.head_rect, 0.3f, 6, head_fill);
+            DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
+        }
+
+        if (model.preview_note.has_value()) {
+            const editor_timeline_note_draw_info info = model.metrics.note_rects(*model.preview_note);
+            const Color fill = model.preview_has_overlap ? with_alpha(t.error, 150) : with_alpha(t.success, 150);
+            const Color outline = model.preview_has_overlap ? t.error : t.success;
+            if (info.has_body) {
+                DrawRectangleRounded(info.body_rect, 0.4f, 6, fill);
+                DrawRectangleRounded(info.tail_rect, 0.4f, 6, fill);
+                DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
+            }
+            DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
+            DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
+        }
+    }
+
+    ui::draw_scrollbar(track, model.content_height_pixels, model.scroll_offset_pixels,
+                       t.scrollbar_track, t.scrollbar_thumb, 40.0f);
+    DrawRectangleLinesEx(model.metrics.panel_rect, 2.0f, t.border);
+}

--- a/src/editor/editor_timeline_view.h
+++ b/src/editor/editor_timeline_view.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "editor_meter_map.h"
+#include "raylib.h"
+
+enum class editor_timeline_note_type {
+    tap,
+    hold
+};
+
+struct editor_timeline_note {
+    editor_timeline_note_type type = editor_timeline_note_type::tap;
+    int tick = 0;
+    int lane = 0;
+    int end_tick = 0;
+};
+
+struct editor_timeline_note_draw_info {
+    Rectangle head_rect = {};
+    Rectangle body_rect = {};
+    Rectangle tail_rect = {};
+    bool has_body = false;
+};
+
+struct editor_timeline_metrics {
+    Rectangle panel_rect = {};
+    float padding = 18.0f;
+    float scrollbar_gap = 10.0f;
+    float scrollbar_width = 10.0f;
+    float lane_gap = 6.0f;
+    float note_head_height = 14.0f;
+    float bottom_tick = 0.0f;
+    float ticks_per_pixel = 2.0f;
+    int key_count = 4;
+
+    Rectangle content_rect() const;
+    Rectangle scrollbar_track_rect() const;
+    float visible_tick_span() const;
+    float tick_to_y(int tick) const;
+    int y_to_tick(float y) const;
+    float lane_width() const;
+    Rectangle lane_rect(int lane) const;
+    editor_timeline_note_draw_info note_rects(const editor_timeline_note& note) const;
+};
+
+struct editor_timeline_view_model {
+    editor_timeline_metrics metrics;
+    std::vector<editor_meter_map::grid_line> grid_lines;
+    std::vector<editor_timeline_note> notes;
+    std::optional<size_t> selected_note_index;
+    std::optional<editor_timeline_note> preview_note;
+    bool preview_has_overlap = false;
+    int min_tick = 0;
+    int max_tick = 0;
+    int snap_interval = 1;
+    float content_height_pixels = 0.0f;
+    float scroll_offset_pixels = 0.0f;
+};
+
+class editor_timeline_view {
+public:
+    static void draw(const editor_timeline_view_model& model);
+};

--- a/src/editor/editor_timing_panel.cpp
+++ b/src/editor/editor_timing_panel.cpp
@@ -1,0 +1,208 @@
+#include "editor_timing_panel.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "theme.h"
+#include "ui_clip.h"
+#include "ui_draw.h"
+
+namespace {
+const char* timing_event_type_label(timing_event_type type) {
+    return type == timing_event_type::bpm ? "BPM" : "Meter";
+}
+}
+
+editor_timing_panel_result editor_timing_panel::draw(const editor_timing_panel_model& model, editor_timing_panel_state& state) {
+    const auto& t = *g_theme;
+    editor_timing_panel_result result;
+
+    const Rectangle timing_box = {model.content_rect.x, model.content_rect.y, model.content_rect.width, 262.0f};
+    const Rectangle editor_box = {model.content_rect.x, timing_box.y + timing_box.height + 12.0f, model.content_rect.width, 238.0f};
+
+    auto draw_input_row = [&](Rectangle rect, const char* label, const std::string& value,
+                              editor_timing_input_field field, float label_width = 84.0f) {
+        const bool selected = state.active_input_field == field;
+        const bool picking_bar = state.bar_pick_mode &&
+                                 (field == editor_timing_input_field::bpm_measure || field == editor_timing_input_field::meter_measure);
+        const ui::row_state row = ui::draw_row(
+            rect,
+            selected ? t.row_selected : t.row,
+            selected ? t.row_selected_hover : t.row_hover,
+            selected ? t.border_active : t.border,
+            1.5f);
+        if (row.clicked) {
+            state.active_input_field = field;
+            state.bar_pick_mode = field == editor_timing_input_field::bpm_measure ||
+                                  field == editor_timing_input_field::meter_measure;
+            state.input_error.clear();
+            result.clicked_input_row = true;
+        }
+
+        const Rectangle content_rect = ui::inset(row.visual, ui::edge_insets::symmetric(0.0f, 12.0f));
+        const Rectangle label_rect = {content_rect.x, content_rect.y, label_width, content_rect.height};
+        const Rectangle input_rect = {
+            content_rect.x + label_width,
+            content_rect.y + 4.0f,
+            content_rect.width - label_width,
+            content_rect.height - 8.0f
+        };
+
+        DrawRectangleRec(input_rect, selected ? with_alpha(t.panel, 255) : with_alpha(t.section, 255));
+        DrawRectangleLinesEx(input_rect, 1.5f, picking_bar ? t.accent : (selected ? t.border_active : t.border_light));
+        ui::draw_text_in_rect(label, 16, label_rect, selected ? t.text : t.text_secondary, ui::text_align::left);
+
+        std::string display_value = value;
+        if (display_value.empty()) {
+            display_value = picking_bar ? "Click Timeline" : "Enter value";
+        }
+        if (picking_bar) {
+            display_value = "Click Timeline";
+        }
+        if (selected && !picking_bar && (GetTime() * 2.0 - std::floor(GetTime() * 2.0)) < 0.5) {
+            display_value += "_";
+        }
+
+        ui::draw_text_in_rect(display_value.c_str(), 16,
+                              ui::inset(input_rect, ui::edge_insets::symmetric(0.0f, 10.0f)),
+                              value.empty() && !selected ? t.text_hint : (picking_bar ? t.accent : t.text),
+                              ui::text_align::left);
+    };
+
+    ui::draw_section(timing_box);
+    ui::draw_text_in_rect("Timing Events", 22,
+                          {timing_box.x + 12.0f, timing_box.y + 10.0f, timing_box.width - 24.0f, 28.0f},
+                          t.text, ui::text_align::left);
+
+    const Rectangle timing_list_view_rect = {
+        timing_box.x + 10.0f,
+        timing_box.y + 42.0f,
+        timing_box.width - 32.0f,
+        timing_box.height - 88.0f
+    };
+    const Rectangle timing_list_scrollbar_rect = {
+        timing_list_view_rect.x + timing_list_view_rect.width + 6.0f,
+        timing_list_view_rect.y,
+        6.0f,
+        timing_list_view_rect.height
+    };
+    const float timing_row_height = 30.0f;
+    const float timing_row_gap = 4.0f;
+    const float timing_list_content_height = model.items.empty()
+        ? timing_list_view_rect.height
+        : static_cast<float>(model.items.size()) * timing_row_height +
+              static_cast<float>(std::max<int>(0, static_cast<int>(model.items.size()) - 1)) * timing_row_gap;
+    const float timing_list_max_scroll = std::max(0.0f, timing_list_content_height - timing_list_view_rect.height);
+    state.list_scroll_offset = std::clamp(state.list_scroll_offset, 0.0f, timing_list_max_scroll);
+
+    const ui::scrollbar_interaction timing_scrollbar = ui::update_vertical_scrollbar(
+        timing_list_scrollbar_rect, timing_list_content_height, state.list_scroll_offset,
+        state.list_scrollbar_dragging, state.list_scrollbar_drag_offset, 28.0f);
+    if (timing_scrollbar.changed || timing_scrollbar.dragging) {
+        state.list_scroll_offset = timing_scrollbar.scroll_offset;
+    }
+
+    if (CheckCollisionPointRec(model.mouse, timing_list_view_rect) && GetMouseWheelMove() != 0.0f) {
+        state.list_scroll_offset = std::clamp(
+            state.list_scroll_offset - GetMouseWheelMove() * 42.0f,
+            0.0f, timing_list_max_scroll);
+    }
+
+    {
+        ui::scoped_clip_rect clip_scope(timing_list_view_rect);
+        float row_y = timing_list_view_rect.y - state.list_scroll_offset;
+        for (const editor_timing_panel_item& item : model.items) {
+            const Rectangle row_rect = {timing_list_view_rect.x, row_y, timing_list_view_rect.width, timing_row_height};
+            const ui::row_state row = ui::draw_selectable_row(row_rect, item.selected, 1.5f);
+            if (row.clicked) {
+                result.selected_event_index = item.event_index;
+            }
+
+            ui::draw_label_value(ui::inset(row.visual, ui::edge_insets::symmetric(0.0f, 10.0f)),
+                                 item.label.c_str(), item.value.c_str(), 15,
+                                 item.selected ? t.text : t.text_secondary,
+                                 item.selected ? t.text : t.text_muted, 118.0f);
+            row_y += timing_row_height + timing_row_gap;
+        }
+    }
+    ui::draw_scrollbar(timing_list_scrollbar_rect, timing_list_content_height, state.list_scroll_offset,
+                       t.scrollbar_track, t.scrollbar_thumb, 28.0f);
+
+    const float timing_button_gap = 8.0f;
+    const float timing_button_width = (timing_box.width - 24.0f - timing_button_gap * 2.0f) / 3.0f;
+    const Rectangle add_bpm_rect = {
+        timing_box.x + 12.0f,
+        timing_box.y + timing_box.height - 42.0f,
+        timing_button_width,
+        28.0f
+    };
+    const Rectangle add_meter_rect = {
+        add_bpm_rect.x + timing_button_width + timing_button_gap,
+        add_bpm_rect.y,
+        timing_button_width,
+        28.0f
+    };
+    const Rectangle delete_rect = {
+        add_meter_rect.x + timing_button_width + timing_button_gap,
+        add_bpm_rect.y,
+        timing_button_width,
+        28.0f
+    };
+    if (ui::draw_button(add_bpm_rect, "BPM", 14).clicked) {
+        result.add_bpm = true;
+    }
+    if (ui::draw_button(add_meter_rect, "Meter", 14).clicked) {
+        result.add_meter = true;
+    }
+    const ui::button_state delete_button = ui::draw_button_colored(
+        delete_rect, "Delete", 14,
+        model.delete_enabled ? t.row : t.section,
+        model.delete_enabled ? t.row_hover : t.section,
+        model.delete_enabled ? t.text : t.text_hint, 1.5f);
+    if (model.delete_enabled && delete_button.clicked) {
+        result.delete_selected = true;
+    }
+
+    ui::draw_section(editor_box);
+    ui::draw_text_in_rect("Event Editor", 22,
+                          {editor_box.x + 12.0f, editor_box.y + 10.0f, editor_box.width - 24.0f, 28.0f},
+                          t.text, ui::text_align::left);
+
+    if (model.selected_event.has_value()) {
+        const timing_event& event = *model.selected_event;
+        ui::draw_label_value({editor_box.x + 12.0f, editor_box.y + 44.0f, editor_box.width - 24.0f, 22.0f},
+                             "Type", timing_event_type_label(event.type), 16,
+                             t.text_secondary, t.text, 76.0f);
+        if (event.type == timing_event_type::bpm) {
+            draw_input_row({editor_box.x + 12.0f, editor_box.y + 74.0f, editor_box.width - 24.0f, 32.0f},
+                           "Bar", state.inputs.bpm_bar, editor_timing_input_field::bpm_measure);
+            draw_input_row({editor_box.x + 12.0f, editor_box.y + 112.0f, editor_box.width - 24.0f, 32.0f},
+                           "BPM", state.inputs.bpm_value, editor_timing_input_field::bpm_value);
+        } else {
+            draw_input_row({editor_box.x + 12.0f, editor_box.y + 74.0f, editor_box.width - 24.0f, 32.0f},
+                           "Bar", state.inputs.meter_bar, editor_timing_input_field::meter_measure);
+            draw_input_row({editor_box.x + 12.0f, editor_box.y + 112.0f, (editor_box.width - 32.0f) * 0.5f, 32.0f},
+                           "Num", state.inputs.meter_numerator, editor_timing_input_field::meter_numerator, 40.0f);
+            draw_input_row({editor_box.x + 20.0f + (editor_box.width - 32.0f) * 0.5f, editor_box.y + 112.0f,
+                            (editor_box.width - 32.0f) * 0.5f, 32.0f},
+                           "Den", state.inputs.meter_denominator, editor_timing_input_field::meter_denominator, 40.0f);
+        }
+
+        if (!state.input_error.empty()) {
+            ui::draw_text_in_rect(state.input_error.c_str(), 16,
+                                  {editor_box.x + 12.0f, editor_box.y + 182.0f, editor_box.width - 24.0f, 36.0f},
+                                  t.error, ui::text_align::left);
+        }
+
+        if (ui::draw_button({editor_box.x + editor_box.width - 92.0f, editor_box.y + editor_box.height - 42.0f,
+                             80.0f, 28.0f}, "Apply", 14).clicked) {
+            result.apply_selected = true;
+        }
+    } else {
+        ui::draw_text_in_rect("Select a timing event from the list.", 18,
+                              {editor_box.x + 12.0f, editor_box.y + 54.0f, editor_box.width - 24.0f, 24.0f},
+                              t.text_hint, ui::text_align::left);
+    }
+
+    return result;
+}

--- a/src/editor/editor_timing_panel.h
+++ b/src/editor/editor_timing_panel.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "data_models.h"
+#include "raylib.h"
+
+enum class editor_timing_input_field {
+    none,
+    bpm_measure,
+    bpm_value,
+    meter_measure,
+    meter_numerator,
+    meter_denominator,
+};
+
+struct editor_timing_event_editor_inputs {
+    std::string bpm_bar;
+    std::string bpm_value;
+    std::string meter_bar;
+    std::string meter_numerator;
+    std::string meter_denominator;
+};
+
+struct editor_timing_panel_state {
+    std::optional<size_t> selected_event_index;
+    editor_timing_input_field active_input_field = editor_timing_input_field::none;
+    editor_timing_event_editor_inputs inputs;
+    std::string input_error;
+    bool bar_pick_mode = false;
+    float list_scroll_offset = 0.0f;
+    bool list_scrollbar_dragging = false;
+    float list_scrollbar_drag_offset = 0.0f;
+};
+
+struct editor_timing_panel_item {
+    size_t event_index = 0;
+    std::string label;
+    std::string value;
+    bool selected = false;
+};
+
+struct editor_timing_panel_model {
+    Rectangle content_rect = {};
+    Vector2 mouse = {};
+    std::vector<editor_timing_panel_item> items;
+    std::optional<timing_event> selected_event;
+    bool delete_enabled = false;
+};
+
+struct editor_timing_panel_result {
+    bool clicked_input_row = false;
+    bool add_bpm = false;
+    bool add_meter = false;
+    bool delete_selected = false;
+    bool apply_selected = false;
+    std::optional<size_t> selected_event_index;
+};
+
+class editor_timing_panel {
+public:
+    static editor_timing_panel_result draw(const editor_timing_panel_model& model, editor_timing_panel_state& state);
+};

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <filesystem>
 #include <iterator>
-#include <limits>
 #include <memory>
 
 #include "audio.h"
@@ -61,23 +60,17 @@ constexpr Rectangle kSnapDropdownMenuRect = {
         static_cast<float>(std::size(kSnapLabels) - 1) * kDropdownItemSpacing
 };
 
-std::vector<timing_event> sorted_meter_events(const chart_data& data) {
-    std::vector<timing_event> meter_events;
-    for (const timing_event& event : data.timing_events) {
-        if (event.type == timing_event_type::meter) {
-            meter_events.push_back(event);
-        }
-    }
-
-    std::sort(meter_events.begin(), meter_events.end(), [](const timing_event& left, const timing_event& right) {
-        return left.tick < right.tick;
-    });
-
-    return meter_events;
-}
-
 const char* note_type_label(note_type type) {
     return type == note_type::hold ? "Hold" : "Tap";
+}
+
+editor_timeline_note make_timeline_note(const note_data& note) {
+    return {
+        note.type == note_type::hold ? editor_timeline_note_type::hold : editor_timeline_note_type::tap,
+        note.tick,
+        note.lane,
+        note.end_tick
+    };
 }
 
 const char* timing_event_type_label(timing_event_type type) {
@@ -95,17 +88,17 @@ bool timing_event_sort_less(const timing_event& left, size_t left_index,
     return left_index < right_index;
 }
 
-bool accepts_decimal(editor_scene::timing_input_field field) {
-    return field == editor_scene::timing_input_field::bpm_value;
+bool accepts_decimal(editor_timing_input_field field) {
+    return field == editor_timing_input_field::bpm_value;
 }
 
-bool accepts_bar_beat(editor_scene::timing_input_field field) {
-    return field == editor_scene::timing_input_field::bpm_measure ||
-           field == editor_scene::timing_input_field::meter_measure;
+bool accepts_bar_beat(editor_timing_input_field field) {
+    return field == editor_timing_input_field::bpm_measure ||
+           field == editor_timing_input_field::meter_measure;
 }
 
-bool accepts_character(editor_scene::timing_input_field field, int codepoint, const std::string& value) {
-    if (field == editor_scene::timing_input_field::none) {
+bool accepts_character(editor_timing_input_field field, int codepoint, const std::string& value) {
+    if (field == editor_timing_input_field::none) {
         return false;
     }
     if (codepoint >= '0' && codepoint <= '9') {
@@ -154,7 +147,7 @@ bool try_parse_float(const std::string& text, float& out_value) {
     }
 }
 
-bool try_parse_bar_beat(const std::string& text, editor_scene::bar_beat_position& out_value) {
+bool try_parse_bar_beat(const std::string& text, editor_meter_map::bar_beat_position& out_value) {
     if (text.empty()) {
         return false;
     }
@@ -214,18 +207,15 @@ void editor_scene::on_enter() {
     snap_index_ = 4;
     snap_dropdown_open_ = false;
     selected_note_index_.reset();
-    selected_timing_event_index_ = state_.data().timing_events.empty() ? std::nullopt : std::optional<size_t>(0);
-    active_timing_input_field_ = timing_input_field::none;
-    timing_input_error_.clear();
-    timing_bar_pick_mode_ = false;
-    timing_list_scroll_offset_ = 0.0f;
-    timing_list_scrollbar_dragging_ = false;
-    timing_list_scrollbar_drag_offset_ = 0.0f;
-    note_dragging_ = false;
-    drag_lane_ = 0;
-    drag_start_tick_ = 0;
-    drag_current_tick_ = 0;
-    rebuild_meter_segments();
+    timing_panel_.selected_event_index = state_.data().timing_events.empty() ? std::nullopt : std::optional<size_t>(0);
+    timing_panel_.active_input_field = editor_timing_input_field::none;
+    timing_panel_.input_error.clear();
+    timing_panel_.bar_pick_mode = false;
+    timing_panel_.list_scroll_offset = 0.0f;
+    timing_panel_.list_scrollbar_dragging = false;
+    timing_panel_.list_scrollbar_drag_offset = 0.0f;
+    timeline_drag_ = {};
+    meter_map_.rebuild(state_.data());
     load_timing_event_inputs();
 
     const std::filesystem::path audio_path = std::filesystem::path(song_.directory) / song_.meta.audio_file;
@@ -312,75 +302,21 @@ chart_data editor_scene::make_new_chart_data() const {
     return data;
 }
 
-void editor_scene::rebuild_meter_segments() {
-    meter_segments_.clear();
-
-    const std::vector<timing_event> events = sorted_meter_events(state_.data());
-    if (events.empty() || events.front().tick != 0) {
-        meter_segments_.push_back({0, 4, 4, 0, 0});
+std::optional<note_data> editor_scene::dragged_note() const {
+    if (!timeline_drag_.active) {
+        return std::nullopt;
     }
 
-    for (const timing_event& event : events) {
-        if (!meter_segments_.empty() && meter_segments_.back().start_tick == event.tick) {
-            meter_segments_.back().numerator = event.numerator;
-            meter_segments_.back().denominator = event.denominator;
-            continue;
-        }
-
-        meter_segment segment;
-        segment.start_tick = event.tick;
-        segment.numerator = event.numerator;
-        segment.denominator = event.denominator;
-
-        if (meter_segments_.empty()) {
-            segment.beat_index_offset = 0;
-            segment.measure_index_offset = 0;
-        } else {
-            const meter_segment& previous = meter_segments_.back();
-            const int beat_ticks = state_.data().meta.resolution * 4 / previous.denominator;
-            const int measure_ticks = beat_ticks * std::max(previous.numerator, 1);
-            const int beat_count = std::max(0, (segment.start_tick - previous.start_tick) / std::max(1, beat_ticks));
-            const int measure_count = std::max(0, (segment.start_tick - previous.start_tick) / std::max(1, measure_ticks));
-            segment.beat_index_offset = previous.beat_index_offset + beat_count;
-            segment.measure_index_offset = previous.measure_index_offset + measure_count;
-        }
-
-        meter_segments_.push_back(segment);
-    }
-}
-
-std::vector<editor_scene::grid_line> editor_scene::visible_grid_lines(int min_tick, int max_tick) const {
-    std::vector<grid_line> lines;
-    if (max_tick < min_tick) {
-        return lines;
+    note_data note;
+    note.lane = timeline_drag_.lane;
+    note.tick = std::min(timeline_drag_.start_tick, timeline_drag_.current_tick);
+    note.end_tick = std::max(timeline_drag_.start_tick, timeline_drag_.current_tick);
+    note.type = (note.end_tick - note.tick) >= snap_interval() ? note_type::hold : note_type::tap;
+    if (note.type == note_type::tap) {
+        note.end_tick = note.tick;
     }
 
-    for (size_t i = 0; i < meter_segments_.size(); ++i) {
-        const meter_segment& segment = meter_segments_[i];
-        const int next_tick = i + 1 < meter_segments_.size() ? meter_segments_[i + 1].start_tick : max_tick + state_.data().meta.resolution * 16;
-        const int beat_ticks = std::max(1, state_.data().meta.resolution * 4 / std::max(segment.denominator, 1));
-        const int measure_ticks = beat_ticks * std::max(segment.numerator, 1);
-        const int start_tick = std::max(min_tick, segment.start_tick);
-        const int end_tick = std::min(max_tick, next_tick - (i + 1 < meter_segments_.size() ? 1 : 0));
-        int tick = segment.start_tick;
-        if (tick < start_tick) {
-            const int delta = start_tick - tick;
-            tick += (delta / beat_ticks) * beat_ticks;
-            while (tick < start_tick) {
-                tick += beat_ticks;
-            }
-        }
-
-        for (; tick <= end_tick; tick += beat_ticks) {
-            const int relative_tick = tick - segment.start_tick;
-            const int local_beat_index = relative_tick / beat_ticks;
-            const int beat = local_beat_index % std::max(segment.numerator, 1) + 1;
-            const int measure = segment.measure_index_offset + local_beat_index / std::max(segment.numerator, 1) + 1;
-            lines.push_back({tick, beat == 1, measure, beat});
-        }
-    }
-
-    return lines;
+    return note;
 }
 
 std::vector<size_t> editor_scene::sorted_timing_event_indices() const {
@@ -398,27 +334,22 @@ std::vector<size_t> editor_scene::sorted_timing_event_indices() const {
     return indices;
 }
 
-Rectangle editor_scene::timeline_content_rect() const {
+editor_timeline_metrics editor_scene::timeline_metrics() const {
     return {
-        kTimelineRect.x + kTimelinePadding,
-        kTimelineRect.y + kTimelinePadding,
-        kTimelineRect.width - kTimelinePadding * 2.0f - kScrollbarGap - kScrollbarWidth,
-        kTimelineRect.height - kTimelinePadding * 2.0f
-    };
-}
-
-Rectangle editor_scene::timeline_scrollbar_track_rect() const {
-    const Rectangle content = timeline_content_rect();
-    return {
-        content.x + content.width + kScrollbarGap,
-        content.y,
+        kTimelineRect,
+        kTimelinePadding,
+        kScrollbarGap,
         kScrollbarWidth,
-        content.height
+        kLaneGap,
+        kNoteHeadHeight,
+        bottom_tick_,
+        ticks_per_pixel_,
+        state_.data().meta.key_count
     };
 }
 
 float editor_scene::visible_tick_span() const {
-    return timeline_content_rect().height * ticks_per_pixel_;
+    return timeline_metrics().visible_tick_span();
 }
 
 float editor_scene::content_tick_span() const {
@@ -446,110 +377,6 @@ float editor_scene::max_bottom_tick() const {
     return std::max(-kStartPaddingTicks, content_tick_span() - visible_tick_span());
 }
 
-float editor_scene::tick_to_timeline_y(int tick) const {
-    const Rectangle content = timeline_content_rect();
-    return content.y + (static_cast<float>(tick) - bottom_tick_) / ticks_per_pixel_;
-}
-
-int editor_scene::timeline_y_to_tick(float y) const {
-    const Rectangle content = timeline_content_rect();
-    return static_cast<int>(std::lround(bottom_tick_ + (y - content.y) * ticks_per_pixel_));
-}
-
-float editor_scene::lane_width() const {
-    const int key_count = std::max(1, state_.data().meta.key_count);
-    const float content_width = timeline_content_rect().width;
-    return (content_width - kLaneGap * static_cast<float>(key_count - 1)) / static_cast<float>(key_count);
-}
-
-Rectangle editor_scene::lane_rect(int lane) const {
-    const Rectangle content = timeline_content_rect();
-    const float width = lane_width();
-    return {
-        content.x + lane * (width + kLaneGap),
-        content.y,
-        width,
-        content.height
-    };
-}
-
-double editor_scene::beat_number_at_tick(int tick) const {
-    if (meter_segments_.empty()) {
-        return 1.0;
-    }
-
-    const auto it = std::upper_bound(meter_segments_.begin(), meter_segments_.end(), tick,
-                                     [](int value, const meter_segment& segment) {
-                                         return value < segment.start_tick;
-                                     });
-    const meter_segment& segment = it == meter_segments_.begin() ? meter_segments_.front() : *std::prev(it);
-    const int beat_ticks = std::max(1, state_.data().meta.resolution * 4 / std::max(segment.denominator, 1));
-    const double local_beats = static_cast<double>(tick - segment.start_tick) / static_cast<double>(beat_ticks);
-    return static_cast<double>(segment.beat_index_offset) + local_beats + 1.0;
-}
-
-editor_scene::bar_beat_position editor_scene::bar_beat_at_tick(int tick) const {
-    if (meter_segments_.empty()) {
-        return {};
-    }
-
-    const auto it = std::upper_bound(meter_segments_.begin(), meter_segments_.end(), tick,
-                                     [](int value, const meter_segment& segment) {
-                                         return value < segment.start_tick;
-                                     });
-    const meter_segment& segment = it == meter_segments_.begin() ? meter_segments_.front() : *std::prev(it);
-    const int numerator = std::max(segment.numerator, 1);
-    const int beat_ticks = std::max(1, state_.data().meta.resolution * 4 / std::max(segment.denominator, 1));
-    const int local_beat_index = std::max(0, static_cast<int>(std::llround(
-        static_cast<double>(tick - segment.start_tick) / static_cast<double>(beat_ticks))));
-    return {
-        segment.measure_index_offset + local_beat_index / numerator + 1,
-        local_beat_index % numerator + 1
-    };
-}
-
-std::optional<int> editor_scene::tick_from_bar_beat(int measure, int beat) const {
-    if (measure <= 0 || beat <= 0 || meter_segments_.empty()) {
-        return std::nullopt;
-    }
-
-    for (size_t i = 0; i < meter_segments_.size(); ++i) {
-        const meter_segment& segment = meter_segments_[i];
-        const int first_measure = segment.measure_index_offset + 1;
-        const int next_measure = i + 1 < meter_segments_.size()
-            ? meter_segments_[i + 1].measure_index_offset + 1
-            : std::numeric_limits<int>::max();
-        if (measure < first_measure || measure >= next_measure) {
-            continue;
-        }
-
-        const int numerator = std::max(segment.numerator, 1);
-        if (beat > numerator) {
-            return std::nullopt;
-        }
-
-        const int beat_ticks = std::max(1, state_.data().meta.resolution * 4 / std::max(segment.denominator, 1));
-        const int measure_ticks = beat_ticks * numerator;
-        return segment.start_tick + (measure - first_measure) * measure_ticks + (beat - 1) * beat_ticks;
-    }
-
-    const meter_segment& segment = meter_segments_.back();
-    const int first_measure = segment.measure_index_offset + 1;
-    const int numerator = std::max(segment.numerator, 1);
-    if (measure < first_measure || beat > numerator) {
-        return std::nullopt;
-    }
-
-    const int beat_ticks = std::max(1, state_.data().meta.resolution * 4 / std::max(segment.denominator, 1));
-    const int measure_ticks = beat_ticks * numerator;
-    return segment.start_tick + (measure - first_measure) * measure_ticks + (beat - 1) * beat_ticks;
-}
-
-std::string editor_scene::bar_beat_label(int tick) const {
-    const bar_beat_position position = bar_beat_at_tick(tick);
-    return std::to_string(position.measure) + ":" + std::to_string(position.beat);
-}
-
 int editor_scene::snap_division() const {
     return kSnapDivisions[std::clamp(snap_index_, 0, static_cast<int>(std::size(kSnapDivisions)) - 1)];
 }
@@ -563,20 +390,22 @@ int editor_scene::snap_tick(int raw_tick) const {
 }
 
 int editor_scene::default_timing_event_tick() const {
-    if (selected_timing_event_index_.has_value() && *selected_timing_event_index_ < state_.data().timing_events.size()) {
-        return snap_tick(state_.data().timing_events[*selected_timing_event_index_].tick + snap_interval());
+    if (timing_panel_.selected_event_index.has_value() &&
+        *timing_panel_.selected_event_index < state_.data().timing_events.size()) {
+        return snap_tick(state_.data().timing_events[*timing_panel_.selected_event_index].tick + snap_interval());
     }
     return std::max(snap_interval(), snap_tick(static_cast<int>(bottom_tick_ + visible_tick_span() * 0.5f)));
 }
 
 std::optional<int> editor_scene::lane_at_position(Vector2 point) const {
-    const Rectangle content = timeline_content_rect();
+    const editor_timeline_metrics metrics = timeline_metrics();
+    const Rectangle content = metrics.content_rect();
     if (!CheckCollisionPointRec(point, content)) {
         return std::nullopt;
     }
 
     for (int lane = 0; lane < state_.data().meta.key_count; ++lane) {
-        if (CheckCollisionPointRec(point, lane_rect(lane))) {
+        if (CheckCollisionPointRec(point, metrics.lane_rect(lane))) {
             return lane;
         }
     }
@@ -584,26 +413,9 @@ std::optional<int> editor_scene::lane_at_position(Vector2 point) const {
     return std::nullopt;
 }
 
-editor_scene::note_draw_info editor_scene::note_rects(const note_data& note) const {
-    const Rectangle lane = lane_rect(note.lane);
-    const float start_y = tick_to_timeline_y(note.tick);
-    note_draw_info info;
-    info.head_rect = {lane.x + 6.0f, start_y - kNoteHeadHeight * 0.5f, lane.width - 12.0f, kNoteHeadHeight};
-
-    if (note.type == note_type::hold) {
-        const float end_y = tick_to_timeline_y(note.end_tick);
-        const float top = std::min(start_y, end_y);
-        const float height = std::fabs(end_y - start_y);
-        info.body_rect = {lane.x + lane.width * 0.3f, top, lane.width * 0.4f, std::max(height, 6.0f)};
-        info.tail_rect = {lane.x + 10.0f, end_y - 5.0f, lane.width - 20.0f, 10.0f};
-        info.has_body = true;
-    }
-
-    return info;
-}
-
 std::optional<size_t> editor_scene::note_at_position(Vector2 point) const {
-    const Rectangle content = timeline_content_rect();
+    const editor_timeline_metrics metrics = timeline_metrics();
+    const Rectangle content = metrics.content_rect();
     if (!CheckCollisionPointRec(point, content)) {
         return std::nullopt;
     }
@@ -615,7 +427,7 @@ std::optional<size_t> editor_scene::note_at_position(Vector2 point) const {
             continue;
         }
 
-        const note_draw_info info = note_rects(note);
+        const editor_timeline_note_draw_info info = metrics.note_rects(make_timeline_note(note));
         if (CheckCollisionPointRec(point, info.head_rect) ||
             (info.has_body && (CheckCollisionPointRec(point, info.body_rect) || CheckCollisionPointRec(point, info.tail_rect)))) {
             return index;
@@ -634,21 +446,21 @@ void editor_scene::handle_shortcuts() {
         }
         selected_note_index_.reset();
         sync_timing_event_selection();
-        rebuild_meter_segments();
+        meter_map_.rebuild(state_.data());
         load_timing_event_inputs();
-        timing_input_error_.clear();
+        timing_panel_.input_error.clear();
     }
 
     if ((IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)) && IsKeyPressed(KEY_Y)) {
         state_.redo();
         selected_note_index_.reset();
         sync_timing_event_selection();
-        rebuild_meter_segments();
+        meter_map_.rebuild(state_.data());
         load_timing_event_inputs();
-        timing_input_error_.clear();
+        timing_panel_.input_error.clear();
     }
 
-    if (active_timing_input_field_ == timing_input_field::none &&
+    if (timing_panel_.active_input_field == editor_timing_input_field::none &&
         IsKeyPressed(KEY_DELETE) && selected_note_index_.has_value()) {
         const size_t selected_index = *selected_note_index_;
         if (state_.remove_note(selected_index)) {
@@ -663,23 +475,23 @@ void editor_scene::handle_shortcuts() {
 
 void editor_scene::handle_text_input() {
     std::string* active_input = nullptr;
-    switch (active_timing_input_field_) {
-        case timing_input_field::bpm_measure:
-            active_input = &timing_tick_input_;
+    switch (timing_panel_.active_input_field) {
+        case editor_timing_input_field::bpm_measure:
+            active_input = &timing_panel_.inputs.bpm_bar;
             break;
-        case timing_input_field::bpm_value:
-            active_input = &timing_bpm_input_;
+        case editor_timing_input_field::bpm_value:
+            active_input = &timing_panel_.inputs.bpm_value;
             break;
-        case timing_input_field::meter_measure:
-            active_input = &timing_measure_input_;
+        case editor_timing_input_field::meter_measure:
+            active_input = &timing_panel_.inputs.meter_bar;
             break;
-        case timing_input_field::meter_numerator:
-            active_input = &timing_numerator_input_;
+        case editor_timing_input_field::meter_numerator:
+            active_input = &timing_panel_.inputs.meter_numerator;
             break;
-        case timing_input_field::meter_denominator:
-            active_input = &timing_denominator_input_;
+        case editor_timing_input_field::meter_denominator:
+            active_input = &timing_panel_.inputs.meter_denominator;
             break;
-        case timing_input_field::none:
+        case editor_timing_input_field::none:
             break;
     }
 
@@ -689,47 +501,48 @@ void editor_scene::handle_text_input() {
 
     int codepoint = GetCharPressed();
     while (codepoint > 0) {
-        if (accepts_character(active_timing_input_field_, codepoint, *active_input) && active_input->size() < 16) {
+        if (accepts_character(timing_panel_.active_input_field, codepoint, *active_input) && active_input->size() < 16) {
             active_input->push_back(static_cast<char>(codepoint));
-            timing_input_error_.clear();
+            timing_panel_.input_error.clear();
         }
         codepoint = GetCharPressed();
     }
 
     if (IsKeyPressed(KEY_BACKSPACE) && !active_input->empty()) {
         active_input->pop_back();
-        timing_input_error_.clear();
+        timing_panel_.input_error.clear();
     }
 
     if (IsKeyPressed(KEY_ENTER)) {
         apply_selected_timing_event();
-        active_timing_input_field_ = timing_input_field::none;
-        timing_bar_pick_mode_ = false;
+        timing_panel_.active_input_field = editor_timing_input_field::none;
+        timing_panel_.bar_pick_mode = false;
     }
 }
 
 void editor_scene::handle_timeline_interaction() {
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
-    const Rectangle content = timeline_content_rect();
+    const editor_timeline_metrics metrics = timeline_metrics();
+    const Rectangle content = metrics.content_rect();
     const bool timeline_hovered = ui::is_hovered(content, ui::draw_layer::base);
 
-    if (timing_bar_pick_mode_) {
-        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && timeline_hovered && selected_timing_event_index_.has_value()) {
-            const int tick = snap_tick(timeline_y_to_tick(mouse.y));
-            const bar_beat_position position = bar_beat_at_tick(tick);
-            if (*selected_timing_event_index_ < state_.data().timing_events.size()) {
-                const timing_event& event = state_.data().timing_events[*selected_timing_event_index_];
+    if (timing_panel_.bar_pick_mode) {
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && timeline_hovered && timing_panel_.selected_event_index.has_value()) {
+            const int tick = snap_tick(metrics.y_to_tick(mouse.y));
+            const editor_meter_map::bar_beat_position position = meter_map_.bar_beat_at_tick(tick);
+            if (*timing_panel_.selected_event_index < state_.data().timing_events.size()) {
+                const timing_event& event = state_.data().timing_events[*timing_panel_.selected_event_index];
                 const std::string value = std::to_string(position.measure) + ":" + std::to_string(position.beat);
                 if (event.type == timing_event_type::bpm) {
-                    timing_tick_input_ = value;
+                    timing_panel_.inputs.bpm_bar = value;
                 } else {
-                    timing_measure_input_ = value;
+                    timing_panel_.inputs.meter_bar = value;
                 }
-                timing_input_error_.clear();
+                timing_panel_.input_error.clear();
             }
-            timing_bar_pick_mode_ = false;
+            timing_panel_.bar_pick_mode = false;
         } else if (IsMouseButtonPressed(MOUSE_BUTTON_RIGHT) || IsKeyPressed(KEY_ESCAPE)) {
-            timing_bar_pick_mode_ = false;
+            timing_panel_.bar_pick_mode = false;
         }
         return;
     }
@@ -740,7 +553,7 @@ void editor_scene::handle_timeline_interaction() {
 
     if (!timeline_hovered) {
         if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
-            note_dragging_ = false;
+            timeline_drag_.active = false;
         }
         return;
     }
@@ -748,46 +561,39 @@ void editor_scene::handle_timeline_interaction() {
     if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
         const std::optional<int> lane = lane_at_position(mouse);
         if (lane.has_value()) {
-            note_dragging_ = true;
-            drag_lane_ = *lane;
-            drag_start_tick_ = snap_tick(timeline_y_to_tick(mouse.y));
-            drag_current_tick_ = drag_start_tick_;
+            timeline_drag_.active = true;
+            timeline_drag_.lane = *lane;
+            timeline_drag_.start_tick = snap_tick(metrics.y_to_tick(mouse.y));
+            timeline_drag_.current_tick = timeline_drag_.start_tick;
         }
     }
 
-    if (note_dragging_ && (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || IsMouseButtonReleased(MOUSE_BUTTON_LEFT))) {
-        drag_current_tick_ = snap_tick(timeline_y_to_tick(mouse.y));
+    if (timeline_drag_.active && (IsMouseButtonDown(MOUSE_BUTTON_LEFT) || IsMouseButtonReleased(MOUSE_BUTTON_LEFT))) {
+        timeline_drag_.current_tick = snap_tick(metrics.y_to_tick(mouse.y));
     }
 
-    if (!note_dragging_ || !IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+    if (!timeline_drag_.active || !IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
         return;
     }
 
-    note_dragging_ = false;
-    drag_current_tick_ = snap_tick(timeline_y_to_tick(mouse.y));
+    timeline_drag_.current_tick = snap_tick(metrics.y_to_tick(mouse.y));
+    const std::optional<note_data> note = dragged_note();
+    timeline_drag_.active = false;
 
-    note_data note;
-    note.lane = drag_lane_;
-    note.tick = std::min(drag_start_tick_, drag_current_tick_);
-    note.end_tick = std::max(drag_start_tick_, drag_current_tick_);
-    note.type = (note.end_tick - note.tick) >= snap_interval() ? note_type::hold : note_type::tap;
-    if (note.type == note_type::tap) {
-        note.end_tick = note.tick;
-    }
-
-    if (state_.has_note_overlap(note)) {
+    if (!note.has_value() || state_.has_note_overlap(*note)) {
         return;
     }
 
-    state_.add_note(note);
+    state_.add_note(*note);
     selected_note_index_ = state_.data().notes.empty() ? std::nullopt : std::optional<size_t>(state_.data().notes.size() - 1);
 }
 
 void editor_scene::apply_scroll_and_zoom(float dt) {
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const float wheel = GetMouseWheelMove();
-    const Rectangle content = timeline_content_rect();
-    const Rectangle track = timeline_scrollbar_track_rect();
+    const editor_timeline_metrics metrics = timeline_metrics();
+    const Rectangle content = metrics.content_rect();
+    const Rectangle track = metrics.scrollbar_track_rect();
     const ui::scrollbar_interaction scrollbar = ui::update_vertical_scrollbar(
         track, content_height_pixels(), scroll_offset_pixels(), scrollbar_dragging_, scrollbar_drag_offset_, 40.0f);
     bottom_tick_target_ = -kStartPaddingTicks + scrollbar.scroll_offset * ticks_per_pixel_;
@@ -809,7 +615,7 @@ void editor_scene::apply_scroll_and_zoom(float dt) {
     }
 
     if (IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)) {
-        const int anchor_tick = timeline_y_to_tick(mouse.y);
+        const int anchor_tick = metrics.y_to_tick(mouse.y);
         const float zoom_scale = wheel > 0.0f ? 0.85f : 1.15f;
         ticks_per_pixel_ = std::clamp(ticks_per_pixel_ * zoom_scale, kMinTicksPerPixel, kMaxTicksPerPixel);
         bottom_tick_target_ = static_cast<float>(anchor_tick) - (mouse.y - content.y) * ticks_per_pixel_;
@@ -831,10 +637,10 @@ void editor_scene::apply_scroll_and_zoom(float dt) {
 }
 
 void editor_scene::select_timing_event(std::optional<size_t> index, bool scroll_into_view) {
-    selected_timing_event_index_ = index;
-    active_timing_input_field_ = timing_input_field::none;
-    timing_input_error_.clear();
-    timing_bar_pick_mode_ = false;
+    timing_panel_.selected_event_index = index;
+    timing_panel_.active_input_field = editor_timing_input_field::none;
+    timing_panel_.input_error.clear();
+    timing_panel_.bar_pick_mode = false;
     load_timing_event_inputs();
 
     if (scroll_into_view && index.has_value() && *index < state_.data().timing_events.size()) {
@@ -847,10 +653,10 @@ void editor_scene::select_timing_event(std::optional<size_t> index, bool scroll_
             constexpr float kTimingListViewportHeight = 174.0f;
             const float row_top = static_cast<float>(std::distance(timing_indices.begin(), it)) * (kTimingRowHeight + kTimingRowGap);
             const float row_bottom = row_top + kTimingRowHeight;
-            if (row_top < timing_list_scroll_offset_) {
-                timing_list_scroll_offset_ = row_top;
-            } else if (row_bottom > timing_list_scroll_offset_ + kTimingListViewportHeight) {
-                timing_list_scroll_offset_ = row_bottom - kTimingListViewportHeight;
+            if (row_top < timing_panel_.list_scroll_offset) {
+                timing_panel_.list_scroll_offset = row_top;
+            } else if (row_bottom > timing_panel_.list_scroll_offset + kTimingListViewportHeight) {
+                timing_panel_.list_scroll_offset = row_bottom - kTimingListViewportHeight;
             }
         }
     }
@@ -864,9 +670,9 @@ void editor_scene::scroll_to_tick(int tick) {
 }
 
 void editor_scene::sync_timing_event_selection() {
-    if (selected_timing_event_index_.has_value() &&
-        *selected_timing_event_index_ >= state_.data().timing_events.size()) {
-        selected_timing_event_index_ = state_.data().timing_events.empty()
+    if (timing_panel_.selected_event_index.has_value() &&
+        *timing_panel_.selected_event_index >= state_.data().timing_events.size()) {
+        timing_panel_.selected_event_index = state_.data().timing_events.empty()
             ? std::nullopt
             : std::optional<size_t>(state_.data().timing_events.size() - 1);
     }
@@ -874,55 +680,55 @@ void editor_scene::sync_timing_event_selection() {
 
 bool editor_scene::apply_selected_timing_event() {
     sync_timing_event_selection();
-    if (!selected_timing_event_index_.has_value()) {
-        timing_input_error_ = "Select a timing event first.";
+    if (!timing_panel_.selected_event_index.has_value()) {
+        timing_panel_.input_error = "Select a timing event first.";
         return false;
     }
 
-    const size_t index = *selected_timing_event_index_;
+    const size_t index = *timing_panel_.selected_event_index;
     if (index >= state_.data().timing_events.size()) {
-        timing_input_error_ = "Selected timing event is out of range.";
+        timing_panel_.input_error = "Selected timing event is out of range.";
         return false;
     }
 
     timing_event updated = state_.data().timing_events[index];
     if (updated.type == timing_event_type::bpm) {
-        bar_beat_position position;
+        editor_meter_map::bar_beat_position position;
         float bpm = 0.0f;
-        if (!try_parse_bar_beat(timing_tick_input_, position)) {
-            timing_input_error_ = "Bar must be in M:B format.";
+        if (!try_parse_bar_beat(timing_panel_.inputs.bpm_bar, position)) {
+            timing_panel_.input_error = "Bar must be in M:B format.";
             return false;
         }
-        if (!try_parse_float(timing_bpm_input_, bpm) || bpm <= 0.0f) {
-            timing_input_error_ = "BPM must be greater than zero.";
+        if (!try_parse_float(timing_panel_.inputs.bpm_value, bpm) || bpm <= 0.0f) {
+            timing_panel_.input_error = "BPM must be greater than zero.";
             return false;
         }
-        const std::optional<int> tick = tick_from_bar_beat(position.measure, position.beat);
+        const std::optional<int> tick = meter_map_.tick_from_bar_beat(position.measure, position.beat);
         if (!tick.has_value()) {
-            timing_input_error_ = "Bar is outside the current meter layout.";
+            timing_panel_.input_error = "Bar is outside the current meter layout.";
             return false;
         }
         updated.tick = *tick;
         updated.bpm = bpm;
     } else {
-        bar_beat_position position;
+        editor_meter_map::bar_beat_position position;
         int numerator = 0;
         int denominator = 0;
-        if (!try_parse_bar_beat(timing_measure_input_, position)) {
-            timing_input_error_ = "Bar must be in M:B format.";
+        if (!try_parse_bar_beat(timing_panel_.inputs.meter_bar, position)) {
+            timing_panel_.input_error = "Bar must be in M:B format.";
             return false;
         }
-        if (!try_parse_int(timing_numerator_input_, numerator) || numerator <= 0) {
-            timing_input_error_ = "Numerator must be 1 or greater.";
+        if (!try_parse_int(timing_panel_.inputs.meter_numerator, numerator) || numerator <= 0) {
+            timing_panel_.input_error = "Numerator must be 1 or greater.";
             return false;
         }
-        if (!try_parse_int(timing_denominator_input_, denominator) || denominator <= 0) {
-            timing_input_error_ = "Denominator must be 1 or greater.";
+        if (!try_parse_int(timing_panel_.inputs.meter_denominator, denominator) || denominator <= 0) {
+            timing_panel_.input_error = "Denominator must be 1 or greater.";
             return false;
         }
-        const std::optional<int> tick = tick_from_bar_beat(position.measure, position.beat);
+        const std::optional<int> tick = meter_map_.tick_from_bar_beat(position.measure, position.beat);
         if (!tick.has_value()) {
-            timing_input_error_ = "Bar is outside the current meter layout.";
+            timing_panel_.input_error = "Bar is outside the current meter layout.";
             return false;
         }
         updated.tick = *tick;
@@ -931,17 +737,17 @@ bool editor_scene::apply_selected_timing_event() {
     }
 
     if (updated.type == timing_event_type::bpm && state_.data().timing_events[index].tick == 0 && updated.tick != 0) {
-        timing_input_error_ = "The BPM event at tick 0 must stay at tick 0.";
+        timing_panel_.input_error = "The BPM event at tick 0 must stay at tick 0.";
         return false;
     }
 
     if (!state_.modify_timing_event(index, updated)) {
-        timing_input_error_ = "Failed to update the timing event.";
+        timing_panel_.input_error = "Failed to update the timing event.";
         return false;
     }
 
-    rebuild_meter_segments();
-    timing_input_error_.clear();
+    meter_map_.rebuild(state_.data());
+    timing_panel_.input_error.clear();
     load_timing_event_inputs();
     scroll_to_tick(updated.tick);
     return true;
@@ -956,8 +762,8 @@ void editor_scene::add_timing_event(timing_event_type type) {
         event.numerator = 4;
         event.denominator = 4;
     } else {
-        const bar_beat_position position = bar_beat_at_tick(event.tick);
-        const std::optional<int> snapped_tick = tick_from_bar_beat(position.measure, 1);
+        const editor_meter_map::bar_beat_position position = meter_map_.bar_beat_at_tick(event.tick);
+        const std::optional<int> snapped_tick = meter_map_.tick_from_bar_beat(position.measure, 1);
         event.tick = snapped_tick.value_or(event.tick);
         event.bpm = 0.0f;
         event.numerator = 4;
@@ -965,62 +771,64 @@ void editor_scene::add_timing_event(timing_event_type type) {
     }
 
     state_.add_timing_event(event);
-    rebuild_meter_segments();
+    meter_map_.rebuild(state_.data());
     select_timing_event(state_.data().timing_events.size() - 1, true);
 }
 
 void editor_scene::delete_selected_timing_event() {
     sync_timing_event_selection();
-    if (!selected_timing_event_index_.has_value()) {
-        timing_input_error_ = "Select a timing event first.";
+    if (!timing_panel_.selected_event_index.has_value()) {
+        timing_panel_.input_error = "Select a timing event first.";
         return;
     }
     if (!can_delete_selected_timing_event()) {
-        timing_input_error_ = "The BPM event at tick 0 cannot be deleted.";
+        timing_panel_.input_error = "The BPM event at tick 0 cannot be deleted.";
         return;
     }
 
-    const size_t index = *selected_timing_event_index_;
+    const size_t index = *timing_panel_.selected_event_index;
     if (!state_.remove_timing_event(index)) {
-        timing_input_error_ = "Failed to delete the timing event.";
+        timing_panel_.input_error = "Failed to delete the timing event.";
         return;
     }
 
-    rebuild_meter_segments();
+    meter_map_.rebuild(state_.data());
     sync_timing_event_selection();
-    timing_input_error_.clear();
+    timing_panel_.input_error.clear();
     load_timing_event_inputs();
 }
 
 bool editor_scene::can_delete_selected_timing_event() const {
-    if (!selected_timing_event_index_.has_value() || *selected_timing_event_index_ >= state_.data().timing_events.size()) {
+    if (!timing_panel_.selected_event_index.has_value() ||
+        *timing_panel_.selected_event_index >= state_.data().timing_events.size()) {
         return false;
     }
-    const timing_event& event = state_.data().timing_events[*selected_timing_event_index_];
+    const timing_event& event = state_.data().timing_events[*timing_panel_.selected_event_index];
     return !(event.type == timing_event_type::bpm && event.tick == 0);
 }
 
 void editor_scene::load_timing_event_inputs() {
     sync_timing_event_selection();
-    if (!selected_timing_event_index_.has_value() || *selected_timing_event_index_ >= state_.data().timing_events.size()) {
+    if (!timing_panel_.selected_event_index.has_value() ||
+        *timing_panel_.selected_event_index >= state_.data().timing_events.size()) {
         clear_timing_event_inputs();
         return;
     }
 
-    const timing_event& event = state_.data().timing_events[*selected_timing_event_index_];
-    timing_tick_input_ = bar_beat_label(event.tick);
-    timing_bpm_input_ = TextFormat("%.1f", event.bpm);
-    timing_measure_input_ = bar_beat_label(event.tick);
-    timing_numerator_input_ = std::to_string(event.numerator);
-    timing_denominator_input_ = std::to_string(event.denominator);
+    const timing_event& event = state_.data().timing_events[*timing_panel_.selected_event_index];
+    timing_panel_.inputs.bpm_bar = meter_map_.bar_beat_label(event.tick);
+    timing_panel_.inputs.bpm_value = TextFormat("%.1f", event.bpm);
+    timing_panel_.inputs.meter_bar = meter_map_.bar_beat_label(event.tick);
+    timing_panel_.inputs.meter_numerator = std::to_string(event.numerator);
+    timing_panel_.inputs.meter_denominator = std::to_string(event.denominator);
 }
 
 void editor_scene::clear_timing_event_inputs() {
-    timing_tick_input_.clear();
-    timing_bpm_input_.clear();
-    timing_measure_input_.clear();
-    timing_numerator_input_.clear();
-    timing_denominator_input_.clear();
+    timing_panel_.inputs.bpm_bar.clear();
+    timing_panel_.inputs.bpm_value.clear();
+    timing_panel_.inputs.meter_bar.clear();
+    timing_panel_.inputs.meter_numerator.clear();
+    timing_panel_.inputs.meter_denominator.clear();
 }
 
 void editor_scene::draw_left_panel() {
@@ -1065,217 +873,59 @@ void editor_scene::draw_left_panel() {
 }
 
 void editor_scene::draw_right_panel() {
-    const auto& t = *g_theme;
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const Rectangle content = ui::inset(kRightPanelRect, ui::edge_insets::uniform(16.0f));
-    const Rectangle timing_box = {content.x, content.y, content.width, 262.0f};
-    const Rectangle editor_box = {content.x, timing_box.y + timing_box.height + 12.0f, content.width, 238.0f};
-    const Rectangle note_box = {content.x, editor_box.y + editor_box.height + 12.0f, content.width, 56.0f};
-    bool clicked_input_row = false;
-
-    auto draw_input_row = [&](Rectangle rect, const char* label, const std::string& value,
-                              timing_input_field field, float label_width = 84.0f) {
-        const bool selected = active_timing_input_field_ == field;
-        const bool picking_bar = timing_bar_pick_mode_ &&
-                                 (field == timing_input_field::bpm_measure || field == timing_input_field::meter_measure);
-        const ui::row_state row = ui::draw_row(
-            rect,
-            selected ? t.row_selected : t.row,
-            selected ? t.row_selected_hover : t.row_hover,
-            selected ? t.border_active : t.border,
-            1.5f);
-        if (row.clicked) {
-            active_timing_input_field_ = field;
-            timing_bar_pick_mode_ = field == timing_input_field::bpm_measure ||
-                                    field == timing_input_field::meter_measure;
-            timing_input_error_.clear();
-            clicked_input_row = true;
-        }
-
-        const Rectangle content_rect = ui::inset(row.visual, ui::edge_insets::symmetric(0.0f, 12.0f));
-        const Rectangle label_rect = {content_rect.x, content_rect.y, label_width, content_rect.height};
-        const Rectangle input_rect = {
-            content_rect.x + label_width,
-            content_rect.y + 4.0f,
-            content_rect.width - label_width,
-            content_rect.height - 8.0f
-        };
-
-        DrawRectangleRec(input_rect, selected ? with_alpha(t.panel, 255) : with_alpha(t.section, 255));
-        DrawRectangleLinesEx(input_rect, 1.5f, picking_bar ? t.accent : (selected ? t.border_active : t.border_light));
-        ui::draw_text_in_rect(label, 16, label_rect, selected ? t.text : t.text_secondary, ui::text_align::left);
-
-        std::string display_value = value;
-        if (display_value.empty()) {
-            display_value = picking_bar ? "Click Timeline" : "Enter value";
-        }
-        if (picking_bar) {
-            display_value = "Click Timeline";
-        }
-        if (selected && !picking_bar && (GetTime() * 2.0 - std::floor(GetTime() * 2.0)) < 0.5) {
-            display_value += "_";
-        }
-
-        ui::draw_text_in_rect(display_value.c_str(), 16,
-                              ui::inset(input_rect, ui::edge_insets::symmetric(0.0f, 10.0f)),
-                              value.empty() && !selected ? t.text_hint : (picking_bar ? t.accent : t.text),
-                              ui::text_align::left);
-    };
-
-    ui::draw_section(timing_box);
-    ui::draw_text_in_rect("Timing Events", 22,
-                          {timing_box.x + 12.0f, timing_box.y + 10.0f, timing_box.width - 24.0f, 28.0f},
-                          t.text, ui::text_align::left);
-
-    const Rectangle timing_list_view_rect = {
-        timing_box.x + 10.0f,
-        timing_box.y + 42.0f,
-        timing_box.width - 32.0f,
-        timing_box.height - 88.0f
-    };
-    const Rectangle timing_list_scrollbar_rect = {
-        timing_list_view_rect.x + timing_list_view_rect.width + 6.0f,
-        timing_list_view_rect.y,
-        6.0f,
-        timing_list_view_rect.height
-    };
+    sync_timing_event_selection();
     const auto timing_indices = sorted_timing_event_indices();
-    const float timing_row_height = 30.0f;
-    const float timing_row_gap = 4.0f;
-    const float timing_list_content_height = timing_indices.empty()
-        ? timing_list_view_rect.height
-        : static_cast<float>(timing_indices.size()) * timing_row_height +
-              static_cast<float>(std::max<int>(0, static_cast<int>(timing_indices.size()) - 1)) * timing_row_gap;
-    const float timing_list_max_scroll = std::max(0.0f, timing_list_content_height - timing_list_view_rect.height);
-    timing_list_scroll_offset_ = std::clamp(timing_list_scroll_offset_, 0.0f, timing_list_max_scroll);
-
-    const ui::scrollbar_interaction timing_scrollbar = ui::update_vertical_scrollbar(
-        timing_list_scrollbar_rect, timing_list_content_height, timing_list_scroll_offset_,
-        timing_list_scrollbar_dragging_, timing_list_scrollbar_drag_offset_, 28.0f);
-    if (timing_scrollbar.changed || timing_scrollbar.dragging) {
-        timing_list_scroll_offset_ = timing_scrollbar.scroll_offset;
+    std::vector<editor_timing_panel_item> items;
+    items.reserve(timing_indices.size());
+    for (const size_t index : timing_indices) {
+        const timing_event& event = state_.data().timing_events[index];
+        items.push_back({
+            index,
+            std::string(timing_event_type_label(event.type)) + " " + meter_map_.bar_beat_label(event.tick),
+            event.type == timing_event_type::bpm ? TextFormat("%.1f", event.bpm) : TextFormat("%d/%d", event.numerator, event.denominator),
+            timing_panel_.selected_event_index.has_value() && *timing_panel_.selected_event_index == index
+        });
     }
-
-    if (CheckCollisionPointRec(mouse, timing_list_view_rect) && GetMouseWheelMove() != 0.0f) {
-        timing_list_scroll_offset_ = std::clamp(
-            timing_list_scroll_offset_ - GetMouseWheelMove() * 42.0f,
-            0.0f, timing_list_max_scroll);
+    std::optional<timing_event> selected_event;
+    if (timing_panel_.selected_event_index.has_value() &&
+        *timing_panel_.selected_event_index < state_.data().timing_events.size()) {
+        selected_event = state_.data().timing_events[*timing_panel_.selected_event_index];
     }
+    const editor_timing_panel_result panel_result = editor_timing_panel::draw(
+        {content, mouse, std::move(items), selected_event, can_delete_selected_timing_event()},
+        timing_panel_);
 
-    {
-        ui::scoped_clip_rect clip_scope(timing_list_view_rect);
-        float row_y = timing_list_view_rect.y - timing_list_scroll_offset_;
-        for (const size_t index : timing_indices) {
-            const timing_event& event = state_.data().timing_events[index];
-            const bool selected = selected_timing_event_index_.has_value() && *selected_timing_event_index_ == index;
-            const Rectangle row_rect = {timing_list_view_rect.x, row_y, timing_list_view_rect.width, timing_row_height};
-            const ui::row_state row = ui::draw_selectable_row(row_rect, selected, 1.5f);
-            if (row.clicked) {
-                select_timing_event(index, true);
-            }
-
-            const std::string label = std::string(timing_event_type_label(event.type)) + " " + bar_beat_label(event.tick);
-            const std::string value = event.type == timing_event_type::bpm
-                ? TextFormat("%.1f", event.bpm)
-                : TextFormat("%d/%d", event.numerator, event.denominator);
-            ui::draw_label_value(ui::inset(row.visual, ui::edge_insets::symmetric(0.0f, 10.0f)),
-                                 label.c_str(), value.c_str(), 15,
-                                 selected ? t.text : t.text_secondary,
-                                 selected ? t.text : t.text_muted, 118.0f);
-            row_y += timing_row_height + timing_row_gap;
-        }
+    if (panel_result.selected_event_index.has_value()) {
+        select_timing_event(panel_result.selected_event_index, true);
     }
-    ui::draw_scrollbar(timing_list_scrollbar_rect, timing_list_content_height, timing_list_scroll_offset_,
-                       t.scrollbar_track, t.scrollbar_thumb, 28.0f);
-
-    const float timing_button_gap = 8.0f;
-    const float timing_button_width = (timing_box.width - 24.0f - timing_button_gap * 2.0f) / 3.0f;
-    const Rectangle add_bpm_rect = {
-        timing_box.x + 12.0f,
-        timing_box.y + timing_box.height - 42.0f,
-        timing_button_width,
-        28.0f
-    };
-    const Rectangle add_meter_rect = {
-        add_bpm_rect.x + timing_button_width + timing_button_gap,
-        add_bpm_rect.y,
-        timing_button_width,
-        28.0f
-    };
-    const Rectangle delete_rect = {
-        add_meter_rect.x + timing_button_width + timing_button_gap,
-        add_bpm_rect.y,
-        timing_button_width,
-        28.0f
-    };
-    if (ui::draw_button(add_bpm_rect, "BPM", 14).clicked) {
+    if (panel_result.add_bpm) {
         add_timing_event(timing_event_type::bpm);
     }
-    if (ui::draw_button(add_meter_rect, "Meter", 14).clicked) {
+    if (panel_result.add_meter) {
         add_timing_event(timing_event_type::meter);
     }
-    const bool delete_enabled = can_delete_selected_timing_event();
-    const ui::button_state delete_button = ui::draw_button_colored(
-        delete_rect, "Delete", 14,
-        delete_enabled ? t.row : t.section,
-        delete_enabled ? t.row_hover : t.section,
-        delete_enabled ? t.text : t.text_hint, 1.5f);
-    if (delete_enabled && delete_button.clicked) {
+    if (panel_result.delete_selected) {
         delete_selected_timing_event();
     }
-
-    ui::draw_section(editor_box);
-    ui::draw_text_in_rect("Event Editor", 22,
-                          {editor_box.x + 12.0f, editor_box.y + 10.0f, editor_box.width - 24.0f, 28.0f},
-                          t.text, ui::text_align::left);
-
-    sync_timing_event_selection();
-    if (selected_timing_event_index_.has_value() && *selected_timing_event_index_ < state_.data().timing_events.size()) {
-        const timing_event& event = state_.data().timing_events[*selected_timing_event_index_];
-        ui::draw_label_value({editor_box.x + 12.0f, editor_box.y + 44.0f, editor_box.width - 24.0f, 22.0f},
-                             "Type", timing_event_type_label(event.type), 16,
-                             t.text_secondary, t.text, 76.0f);
-        if (event.type == timing_event_type::bpm) {
-            draw_input_row({editor_box.x + 12.0f, editor_box.y + 74.0f, editor_box.width - 24.0f, 32.0f},
-                           "Bar", timing_tick_input_, timing_input_field::bpm_measure);
-            draw_input_row({editor_box.x + 12.0f, editor_box.y + 112.0f, editor_box.width - 24.0f, 32.0f},
-                           "BPM", timing_bpm_input_, timing_input_field::bpm_value);
-        } else {
-            draw_input_row({editor_box.x + 12.0f, editor_box.y + 74.0f, editor_box.width - 24.0f, 32.0f},
-                           "Bar", timing_measure_input_, timing_input_field::meter_measure);
-            draw_input_row({editor_box.x + 12.0f, editor_box.y + 112.0f, (editor_box.width - 32.0f) * 0.5f, 32.0f},
-                           "Num", timing_numerator_input_, timing_input_field::meter_numerator, 40.0f);
-            draw_input_row({editor_box.x + 20.0f + (editor_box.width - 32.0f) * 0.5f, editor_box.y + 112.0f,
-                            (editor_box.width - 32.0f) * 0.5f, 32.0f},
-                           "Den", timing_denominator_input_, timing_input_field::meter_denominator, 40.0f);
-        }
-
-        if (!timing_input_error_.empty()) {
-            ui::draw_text_in_rect(timing_input_error_.c_str(), 16,
-                                  {editor_box.x + 12.0f, editor_box.y + 182.0f, editor_box.width - 24.0f, 36.0f},
-                                  t.error, ui::text_align::left);
-        }
-
-        if (ui::draw_button({editor_box.x + editor_box.width - 92.0f, editor_box.y + editor_box.height - 42.0f,
-                             80.0f, 28.0f}, "Apply", 14).clicked) {
-            apply_selected_timing_event();
-            active_timing_input_field_ = timing_input_field::none;
-            timing_bar_pick_mode_ = false;
-        }
-    } else {
-        ui::draw_text_in_rect("Select a timing event from the list.", 18,
-                              {editor_box.x + 12.0f, editor_box.y + 54.0f, editor_box.width - 24.0f, 24.0f},
-                              t.text_hint, ui::text_align::left);
+    if (panel_result.apply_selected) {
+        apply_selected_timing_event();
+        timing_panel_.active_input_field = editor_timing_input_field::none;
+        timing_panel_.bar_pick_mode = false;
     }
 
+    const Rectangle editor_box = {content.x, content.y + 262.0f + 12.0f, content.width, 238.0f};
     if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
-        active_timing_input_field_ != timing_input_field::none &&
-        !clicked_input_row &&
+        timing_panel_.active_input_field != editor_timing_input_field::none &&
+        !panel_result.clicked_input_row &&
         !CheckCollisionPointRec(mouse, editor_box)) {
-        active_timing_input_field_ = timing_input_field::none;
-        timing_bar_pick_mode_ = false;
+        timing_panel_.active_input_field = editor_timing_input_field::none;
+        timing_panel_.bar_pick_mode = false;
     }
 
+    const Rectangle note_box = {content.x, editor_box.y + editor_box.height + 12.0f, content.width, 56.0f};
+    const auto& t = *g_theme;
     ui::draw_section(note_box);
     if (selected_note_index_.has_value() && *selected_note_index_ < state_.data().notes.size()) {
         const note_data& note = state_.data().notes[*selected_note_index_];
@@ -1296,102 +946,34 @@ void editor_scene::draw_right_panel() {
 }
 
 void editor_scene::draw_timeline() const {
-    const auto& t = *g_theme;
+    const editor_timeline_metrics metrics = timeline_metrics();
     const int min_tick = std::max(0, static_cast<int>(std::floor(bottom_tick_ - kMinVisibleTicks * 0.1f)));
     const int max_tick = static_cast<int>(std::ceil(bottom_tick_ + visible_tick_span()));
-    const Rectangle content = timeline_content_rect();
-    const Rectangle track = timeline_scrollbar_track_rect();
-
-    DrawRectangleRec(ui::inset(kTimelineRect, 10.0f), t.section);
-    {
-        ui::scoped_clip_rect clip_scope(content);
-        draw_timeline_grid(min_tick, max_tick);
-        draw_timeline_notes();
-        if (note_dragging_) {
-            note_data preview;
-            preview.lane = drag_lane_;
-            preview.tick = std::min(drag_start_tick_, drag_current_tick_);
-            preview.end_tick = std::max(drag_start_tick_, drag_current_tick_);
-            preview.type = (preview.end_tick - preview.tick) >= snap_interval() ? note_type::hold : note_type::tap;
-            if (preview.type == note_type::tap) {
-                preview.end_tick = preview.tick;
-            }
-
-            const note_draw_info info = note_rects(preview);
-            const Color fill = state_.has_note_overlap(preview) ? with_alpha(t.error, 150) : with_alpha(t.success, 150);
-            const Color outline = state_.has_note_overlap(preview) ? t.error : t.success;
-            if (info.has_body) {
-                DrawRectangleRounded(info.body_rect, 0.4f, 6, fill);
-                DrawRectangleRounded(info.tail_rect, 0.4f, 6, fill);
-                DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
-            }
-            DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
-            DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
-        }
+    std::vector<editor_timeline_note> notes;
+    notes.reserve(state_.data().notes.size());
+    for (const note_data& note : state_.data().notes) {
+        notes.push_back(make_timeline_note(note));
     }
-    ui::draw_scrollbar(track, content_height_pixels(), scroll_offset_pixels(),
-                       t.scrollbar_track, t.scrollbar_thumb, 40.0f);
-
-    DrawRectangleLinesEx(kTimelineRect, 2.0f, t.border);
-}
-
-void editor_scene::draw_timeline_grid(int min_tick, int max_tick) const {
-    const auto& t = *g_theme;
-    const int key_count = std::max(1, state_.data().meta.key_count);
-    const Rectangle content = timeline_content_rect();
-
-    for (int lane = 0; lane < key_count; ++lane) {
-        const Rectangle rect = lane_rect(lane);
-        DrawRectangleRec(rect, lane % 2 == 0 ? with_alpha(t.row, 100) : with_alpha(t.section, 110));
-        DrawRectangleLinesEx(rect, 1.0f, with_alpha(t.border_light, 180));
-        ui::draw_text_in_rect(TextFormat("L%d", lane + 1), 16,
-                              {rect.x, kTimelineRect.y + 4.0f, rect.width, 20.0f},
-                              t.text_hint);
+    std::optional<editor_timeline_note> preview_note;
+    bool preview_has_overlap = false;
+    if (const std::optional<note_data> preview_data = dragged_note(); preview_data.has_value()) {
+        preview_note = make_timeline_note(*preview_data);
+        preview_has_overlap = state_.has_note_overlap(*preview_data);
     }
 
-    const int interval = snap_interval();
-    const int first_snap_tick = std::max(0, (min_tick / interval) * interval);
-    for (int tick = first_snap_tick; tick <= max_tick; tick += interval) {
-        const float y = tick_to_timeline_y(tick);
-        ui::draw_line_f(content.x, y, content.x + content.width, y, t.editor_grid_snap);
-    }
-
-    for (const grid_line& line : visible_grid_lines(min_tick, max_tick)) {
-        const float y = tick_to_timeline_y(line.tick);
-        const Color color = line.major ? t.editor_grid_major : t.editor_grid_minor;
-        ui::draw_line_f(content.x, y, content.x + content.width, y, color);
-        if (line.major) {
-            ui::draw_line_f(content.x, y + 1.0f, content.x + content.width, y + 1.0f,
-                            t.editor_grid_major_glow);
-        }
-        ui::draw_text_f(TextFormat("%d:%d", line.measure, line.beat), content.x + 8.0f, y - 10.0f,
-                        line.major ? 16 : 14, line.major ? t.text : t.text_secondary);
-    }
-}
-
-void editor_scene::draw_timeline_notes() const {
-    const auto& t = *g_theme;
-    for (size_t i = 0; i < state_.data().notes.size(); ++i) {
-        const note_data& note = state_.data().notes[i];
-        if (note.lane < 0 || note.lane >= state_.data().meta.key_count) {
-            continue;
-        }
-
-        const note_draw_info info = note_rects(note);
-        const bool selected = selected_note_index_.has_value() && *selected_note_index_ == i;
-        const Color head_fill = selected ? t.row_active : t.note_color;
-        const Color outline = selected ? t.border_active : t.note_outline;
-        const Color hold_fill = selected ? with_alpha(t.row_active, 200) : with_alpha(t.accent, 170);
-
-        if (info.has_body) {
-            DrawRectangleRounded(info.body_rect, 0.4f, 6, hold_fill);
-            DrawRectangleRounded(info.tail_rect, 0.4f, 6, selected ? with_alpha(t.row_active, 230) : with_alpha(t.accent, 220));
-            DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
-        }
-
-        DrawRectangleRounded(info.head_rect, 0.3f, 6, head_fill);
-        DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
-    }
+    editor_timeline_view::draw({
+        metrics,
+        meter_map_.visible_grid_lines(min_tick, max_tick),
+        std::move(notes),
+        selected_note_index_,
+        preview_note,
+        preview_has_overlap,
+        min_tick,
+        max_tick,
+        snap_interval(),
+        content_height_pixels(),
+        scroll_offset_pixels()
+    });
 }
 
 void editor_scene::draw_cursor_hud() const {
@@ -1401,24 +983,16 @@ void editor_scene::draw_cursor_hud() const {
         return;
     }
 
-    const int tick = std::max(0, timeline_y_to_tick(mouse.y));
+    const int tick = std::max(0, timeline_metrics().y_to_tick(mouse.y));
     const int snapped_tick = snap_tick(tick);
-    const double beat = beat_number_at_tick(tick);
-    const int whole_beat = std::max(0, static_cast<int>(std::floor(beat - 1.0)));
-    const auto it = std::upper_bound(meter_segments_.begin(), meter_segments_.end(), tick,
-                                     [](int value, const meter_segment& segment) {
-                                         return value < segment.start_tick;
-                                     });
-    const meter_segment& segment = it == meter_segments_.begin() ? meter_segments_.front() : *std::prev(it);
-    const int numerator = std::max(segment.numerator, 1);
-    const int measure = segment.measure_index_offset + (whole_beat - segment.beat_index_offset) / numerator + 1;
-    const int beat_in_measure = (whole_beat - segment.beat_index_offset) % numerator + 1;
+    const double beat = meter_map_.beat_number_at_tick(tick);
+    const editor_meter_map::bar_beat_position position = meter_map_.bar_beat_at_tick(tick);
     const Rectangle hud_rect = ui::place(kTimelineRect, 340.0f, 34.0f,
                                          ui::anchor::bottom_left, ui::anchor::bottom_left,
                                          {12.0f, -12.0f});
     DrawRectangleRec(hud_rect, with_alpha(t.panel, 240));
     DrawRectangleLinesEx(hud_rect, 1.5f, t.border);
-    ui::draw_text_f(TextFormat("bar %d:%d   beat %.2f   snap %d", measure, beat_in_measure, beat, snapped_tick),
+    ui::draw_text_f(TextFormat("bar %d:%d   beat %.2f   snap %d", position.measure, position.beat, beat, snapped_tick),
                     hud_rect.x + 12.0f, hud_rect.y + 8.0f, 18, t.text);
 }
 

--- a/src/scenes/editor_scene.h
+++ b/src/scenes/editor_scene.h
@@ -5,7 +5,10 @@
 #include <vector>
 
 #include "raylib.h"
+#include "editor_meter_map.h"
 #include "editor_state.h"
+#include "editor_timeline_view.h"
+#include "editor_timing_panel.h"
 #include "scene.h"
 #include "song_loader.h"
 
@@ -19,70 +22,28 @@ public:
     void draw() override;
 
 private:
-    struct grid_line {
-        int tick = 0;
-        bool major = false;
-        int measure = 1;
-        int beat = 1;
-    };
-
-    struct meter_segment {
+    struct timeline_note_drag_state {
+        bool active = false;
+        int lane = 0;
         int start_tick = 0;
-        int numerator = 4;
-        int denominator = 4;
-        int beat_index_offset = 0;
-        int measure_index_offset = 0;
+        int current_tick = 0;
     };
 
-    struct note_draw_info {
-        Rectangle head_rect = {};
-        Rectangle body_rect = {};
-        Rectangle tail_rect = {};
-        bool has_body = false;
-    };
-
-public:
-    struct bar_beat_position {
-        int measure = 1;
-        int beat = 1;
-    };
-
-    enum class timing_input_field {
-        none,
-        bpm_measure,
-        bpm_value,
-        meter_measure,
-        meter_numerator,
-        meter_denominator,
-    };
-
-private:
     chart_data make_new_chart_data() const;
-    void rebuild_meter_segments();
-    std::vector<grid_line> visible_grid_lines(int min_tick, int max_tick) const;
+    std::optional<note_data> dragged_note() const;
     std::vector<size_t> sorted_timing_event_indices() const;
-    Rectangle timeline_content_rect() const;
-    Rectangle timeline_scrollbar_track_rect() const;
+    editor_timeline_metrics timeline_metrics() const;
     float visible_tick_span() const;
     float content_tick_span() const;
     float content_height_pixels() const;
     float scroll_offset_pixels() const;
     float max_bottom_tick() const;
-    float tick_to_timeline_y(int tick) const;
-    int timeline_y_to_tick(float y) const;
-    float lane_width() const;
-    Rectangle lane_rect(int lane) const;
-    double beat_number_at_tick(int tick) const;
-    bar_beat_position bar_beat_at_tick(int tick) const;
-    std::optional<int> tick_from_bar_beat(int measure, int beat) const;
-    std::string bar_beat_label(int tick) const;
     int snap_division() const;
     int snap_interval() const;
     int snap_tick(int raw_tick) const;
     int default_timing_event_tick() const;
     std::optional<int> lane_at_position(Vector2 point) const;
     std::optional<size_t> note_at_position(Vector2 point) const;
-    note_draw_info note_rects(const note_data& note) const;
     void rebuild_hit_regions() const;
     void handle_shortcuts();
     void handle_text_input();
@@ -100,8 +61,6 @@ private:
     void draw_left_panel();
     void draw_right_panel();
     void draw_timeline() const;
-    void draw_timeline_grid(int min_tick, int max_tick) const;
-    void draw_timeline_notes() const;
     void draw_cursor_hud() const;
     void draw_header_tools();
 
@@ -109,7 +68,8 @@ private:
     std::optional<std::string> chart_path_;
     int new_chart_key_count_ = 4;
     editor_state state_;
-    std::vector<meter_segment> meter_segments_;
+    editor_meter_map meter_map_;
+    editor_timing_panel_state timing_panel_;
     std::vector<std::string> load_errors_;
     int audio_length_tick_ = 0;
     float bottom_tick_ = 0.0f;
@@ -118,22 +78,7 @@ private:
     int snap_index_ = 4;
     bool snap_dropdown_open_ = false;
     std::optional<size_t> selected_note_index_;
-    std::optional<size_t> selected_timing_event_index_;
-    timing_input_field active_timing_input_field_ = timing_input_field::none;
-    std::string timing_tick_input_;
-    std::string timing_bpm_input_;
-    std::string timing_measure_input_;
-    std::string timing_numerator_input_;
-    std::string timing_denominator_input_;
-    std::string timing_input_error_;
-    bool timing_bar_pick_mode_ = false;
-    float timing_list_scroll_offset_ = 0.0f;
-    bool timing_list_scrollbar_dragging_ = false;
-    float timing_list_scrollbar_drag_offset_ = 0.0f;
-    bool note_dragging_ = false;
-    int drag_lane_ = 0;
-    int drag_start_tick_ = 0;
-    int drag_current_tick_ = 0;
+    timeline_note_drag_state timeline_drag_;
     bool scrollbar_dragging_ = false;
     float scrollbar_drag_offset_ = 0.0f;
 };


### PR DESCRIPTION
## 概要
- editor_scene から meter/bar:beat/grid 変換ロジックを editor_meter_map に分離
- Timing Events UI を editor_timing_panel に分離
- タイムライン描画と geometry を editor_timeline_view に分離
- ノート配置ドラッグ状態を構造体化して editor_scene の責務を整理

## 確認
- ユーザー環境でビルド通過

Closes #92