### PR TITLE
譜面エディタのオーディオ同期と低遅延SE再生を実装

### DIFF
--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -6,14 +6,39 @@
 #include "bass.h"
 
 namespace {
+constexpr unsigned long kLowLatencyUpdatePeriodMs = 10;
+constexpr unsigned long kLowLatencyDeviceBufferMs = 20;
+constexpr unsigned long kSeSampleMaxVoices = 16;
+
+struct se_sample_entry {
+    unsigned long handle = 0;
+};
+
 struct se_voice_entry {
     unsigned long handle = 0;
     float local_volume = 1.0f;
+    bool stream_fallback = false;
 };
+
+std::unordered_map<std::string, se_sample_entry>& se_samples() {
+    static std::unordered_map<std::string, se_sample_entry> samples;
+    return samples;
+}
 
 std::unordered_map<int, se_voice_entry>& se_voices() {
     static std::unordered_map<int, se_voice_entry> voices;
     return voices;
+}
+
+void free_se_samples() {
+    for (auto& [path, sample] : se_samples()) {
+        (void)path;
+        if (sample.handle != 0) {
+            BASS_SampleFree(sample.handle);
+            sample.handle = 0;
+        }
+    }
+    se_samples().clear();
 }
 }
 
@@ -31,12 +56,15 @@ bool audio_manager::initialize() {
         return true;
     }
 
+    BASS_SetConfig(BASS_CONFIG_UPDATEPERIOD, kLowLatencyUpdatePeriodMs);
+    BASS_SetConfig(BASS_CONFIG_DEV_BUFFER, kLowLatencyDeviceBufferMs);
     initialized_ = BASS_Init(-1, 44100, 0, nullptr, nullptr) != FALSE;
     return initialized_;
 }
 
 void audio_manager::shutdown() {
     stop_all_se();
+    free_se_samples();
     free_voice(bgm_handle_);
     free_voice(preview_handle_);
 
@@ -167,13 +195,32 @@ int audio_manager::play_se(const std::string& file_path, float volume) {
         return 0;
     }
 
-    unsigned long handle = create_stream(file_path);
+    unsigned long handle = 0;
+    bool stream_fallback = false;
+    auto sample_it = se_samples().find(file_path);
+    if (sample_it == se_samples().end()) {
+        const unsigned long sample_handle = BASS_SampleLoad(
+            FALSE, file_path.c_str(), 0, 0, kSeSampleMaxVoices, BASS_SAMPLE_OVER_POS);
+        if (sample_handle != 0) {
+            sample_it = se_samples().emplace(file_path, se_sample_entry{sample_handle}).first;
+        }
+    }
+
+    if (sample_it != se_samples().end() && sample_it->second.handle != 0) {
+        handle = BASS_SampleGetChannel(sample_it->second.handle, FALSE);
+    }
+
+    if (handle == 0) {
+        handle = create_stream(file_path);
+        stream_fallback = true;
+    }
+
     if (!is_voice_loaded(handle)) {
         return 0;
     }
 
     const int voice_id = next_se_voice_id_++;
-    se_voices()[voice_id] = {handle, std::clamp(volume, 0.0f, 1.0f)};
+    se_voices()[voice_id] = {handle, std::clamp(volume, 0.0f, 1.0f), stream_fallback};
     BASS_ChannelSetAttribute(handle, BASS_ATTRIB_VOL, se_voices()[voice_id].local_volume * se_volume_);
     play_voice(handle, true);
     return voice_id;
@@ -199,7 +246,9 @@ void audio_manager::stop_se(int voice_id) {
     }
 
     stop_voice(it->second.handle);
-    free_voice(it->second.handle);
+    if (it->second.stream_fallback) {
+        free_voice(it->second.handle);
+    }
     se_voices().erase(it);
 }
 
@@ -207,7 +256,9 @@ void audio_manager::stop_all_se() {
     for (auto& [voice_id, voice] : se_voices()) {
         (void)voice_id;
         stop_voice(voice.handle);
-        free_voice(voice.handle);
+        if (voice.stream_fallback) {
+            free_voice(voice.handle);
+        }
     }
     se_voices().clear();
 }
@@ -225,7 +276,9 @@ void audio_manager::set_se_volume(float volume) {
 void audio_manager::update() {
     for (auto it = se_voices().begin(); it != se_voices().end();) {
         if (!is_voice_loaded(it->second.handle) || BASS_ChannelIsActive(it->second.handle) == BASS_ACTIVE_STOPPED) {
-            free_voice(it->second.handle);
+            if (it->second.stream_fallback) {
+                free_voice(it->second.handle);
+            }
             it = se_voices().erase(it);
         } else {
             ++it;

--- a/src/editor/editor_timeline_view.cpp
+++ b/src/editor/editor_timeline_view.cpp
@@ -144,6 +144,12 @@ void editor_timeline_view::draw(const editor_timeline_view_model& model) {
             DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
             DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
         }
+
+        if (model.playback_tick.has_value()) {
+            const float y = model.metrics.tick_to_y(*model.playback_tick);
+            ui::draw_line_f(content.x, y, content.x + content.width, y, with_alpha(t.accent, 240));
+            ui::draw_line_f(content.x, y + 1.0f, content.x + content.width, y + 1.0f, with_alpha(t.text, 170));
+        }
     }
 
     ui::draw_scrollbar(track, model.content_height_pixels, model.scroll_offset_pixels,

--- a/src/editor/editor_timeline_view.h
+++ b/src/editor/editor_timeline_view.h
@@ -51,6 +51,7 @@ struct editor_timeline_view_model {
     std::vector<editor_meter_map::grid_line> grid_lines;
     std::vector<editor_timeline_note> notes;
     std::optional<size_t> selected_note_index;
+    std::optional<int> playback_tick;
     std::optional<editor_timeline_note> preview_note;
     bool preview_has_overlap = false;
     int min_tick = 0;

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -2,11 +2,12 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdio>
 #include <filesystem>
 #include <iterator>
 #include <memory>
 
-#include "audio.h"
+#include "audio_manager.h"
 #include "chart_parser.h"
 #include "scene_common.h"
 #include "scene_manager.h"
@@ -45,9 +46,12 @@ constexpr float kScrollWheelViewportRatio = 0.36f;
 constexpr float kNoteHeadHeight = 14.0f;
 constexpr int kSnapDivisions[] = {1, 2, 4, 8, 16, 32};
 constexpr const char* kSnapLabels[] = {"1/1", "1/2", "1/4", "1/8", "1/16", "1/32"};
-constexpr Rectangle kHeaderToolsRect = ui::place(kHeaderRect, 360.0f, 34.0f,
+constexpr Rectangle kHeaderToolsRect = ui::place(kHeaderRect, 168.0f, 34.0f,
                                                  ui::anchor::center_right, ui::anchor::center_right,
                                                  {-18.0f, 0.0f});
+constexpr Rectangle kPlaybackRect = ui::place(kTimelineRect, 232.0f, 34.0f,
+                                              ui::anchor::bottom_left, ui::anchor::bottom_left,
+                                              {12.0f, -54.0f});
 constexpr float kDropdownItemHeight = 30.0f;
 constexpr float kDropdownItemSpacing = 4.0f;
 constexpr Rectangle kMetadataConfirmRect = ui::place(kScreenRect, 420.0f, 196.0f,
@@ -60,6 +64,8 @@ constexpr Rectangle kSnapDropdownMenuRect = {
     12.0f + static_cast<float>(std::size(kSnapLabels)) * kDropdownItemHeight +
         static_cast<float>(std::size(kSnapLabels) - 1) * kDropdownItemSpacing
 };
+constexpr float kPlaybackFollowViewportRatio = 0.35f;
+constexpr float kPlaybackRestartEpsilonSeconds = 0.01f;
 
 const char* note_type_label(note_type type) {
     return type == note_type::hold ? "Hold" : "Tap";
@@ -158,6 +164,20 @@ bool try_parse_bar_beat(const std::string& text, editor_meter_map::bar_beat_posi
     return true;
 }
 
+std::string format_playback_time(double seconds) {
+    const int total_ms = std::max(0, static_cast<int>(std::lround(seconds * 1000.0)));
+    const int minutes = total_ms / 60000;
+    const int whole_seconds = (total_ms / 1000) % 60;
+    const int centiseconds = (total_ms % 1000) / 10;
+    char buffer[32];
+    std::snprintf(buffer, sizeof(buffer), "%02d:%02d.%02d", minutes, whole_seconds, centiseconds);
+    return buffer;
+}
+
+std::filesystem::path repo_root() {
+    return std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
+}
+
 }
 
 editor_scene::editor_scene(scene_manager& manager, song_data song, std::string chart_path)
@@ -171,6 +191,13 @@ editor_scene::editor_scene(scene_manager& manager, song_data song, int key_count
 void editor_scene::on_enter() {
     load_errors_.clear();
     audio_length_tick_ = 0;
+    audio_loaded_ = false;
+    audio_playing_ = false;
+    audio_time_seconds_ = 0.0;
+    playback_tick_ = 0;
+    previous_playback_tick_ = 0;
+    previous_audio_playing_ = false;
+    hitsound_path_.clear();
 
     if (chart_path_.has_value()) {
         const chart_parse_result result = chart_parser::parse(*chart_path_);
@@ -205,18 +232,28 @@ void editor_scene::on_enter() {
     scroll_timing_list_to_bottom();
 
     const std::filesystem::path audio_path = std::filesystem::path(song_.directory) / song_.meta.audio_file;
-    if (std::filesystem::exists(audio_path)) {
-        audio music;
-        music.load(audio_path.string());
-        if (music.is_loaded()) {
-            const double length_ms = music.get_length_seconds() * 1000.0;
-            audio_length_tick_ = std::max(0, state_.engine().ms_to_tick(length_ms));
-        }
+    if (std::filesystem::exists(audio_path) &&
+        audio_manager::instance().load_bgm(audio_path.string())) {
+        audio_loaded_ = true;
+        const double length_ms = audio_manager::instance().get_bgm_length_seconds() * 1000.0;
+        audio_length_tick_ = std::max(0, state_.engine().ms_to_tick(length_ms));
     }
+
+    const std::filesystem::path hitsound_path = repo_root() / "assets" / "audio" / "hitsound.mp3";
+    hitsound_path_ = std::filesystem::exists(hitsound_path) ? hitsound_path.string() : "";
+
+    update_audio_clock();
+    previous_playback_tick_ = playback_tick_;
+}
+
+void editor_scene::on_exit() {
+    audio_manager::instance().stop_bgm();
+    audio_manager::instance().stop_all_se();
 }
 
 void editor_scene::update(float dt) {
     rebuild_hit_regions();
+    update_audio_clock();
 
     if (metadata_panel_.key_count_confirm_open && IsKeyPressed(KEY_ESCAPE)) {
         close_key_count_confirmation();
@@ -241,6 +278,8 @@ void editor_scene::update(float dt) {
     handle_shortcuts();
     handle_text_input();
     handle_timeline_interaction();
+    update_audio_clock();
+    update_note_hitsounds();
     apply_scroll_and_zoom(dt);
 }
 
@@ -400,6 +439,108 @@ int editor_scene::default_timing_event_tick() const {
     return std::max(snap_interval(), snap_tick(static_cast<int>(bottom_tick_ + visible_tick_span() * 0.5f)));
 }
 
+void editor_scene::update_audio_clock() {
+    if (!audio_loaded_ || !audio_manager::instance().is_bgm_loaded()) {
+        audio_loaded_ = false;
+        audio_playing_ = false;
+        audio_time_seconds_ = 0.0;
+        playback_tick_ = 0;
+        return;
+    }
+
+    const audio_clock_snapshot bgm_clock = audio_manager::instance().get_bgm_clock();
+    audio_playing_ = bgm_clock.playing;
+    double seconds = audio_playing_ ? bgm_clock.audio_time_seconds : bgm_clock.stream_position_seconds;
+    const double length_seconds = audio_manager::instance().get_bgm_length_seconds();
+    if (length_seconds > 0.0) {
+        seconds = std::clamp(seconds, 0.0, length_seconds);
+    } else {
+        seconds = std::max(0.0, seconds);
+    }
+
+    audio_time_seconds_ = seconds;
+    playback_tick_ = std::max(0, state_.engine().ms_to_tick(audio_time_seconds_ * 1000.0));
+}
+
+void editor_scene::toggle_audio_playback() {
+    if (!audio_loaded_) {
+        return;
+    }
+
+    if (audio_manager::instance().is_bgm_playing()) {
+        audio_manager::instance().pause_bgm();
+    } else {
+        const double length_seconds = audio_manager::instance().get_bgm_length_seconds();
+        const double position_seconds = audio_manager::instance().get_bgm_position_seconds();
+        const bool restart = length_seconds > 0.0 &&
+                             position_seconds >= std::max(0.0, length_seconds - kPlaybackRestartEpsilonSeconds);
+        audio_manager::instance().play_bgm(restart);
+    }
+    update_audio_clock();
+    previous_playback_tick_ = playback_tick_;
+    previous_audio_playing_ = audio_playing_;
+}
+
+void editor_scene::seek_audio_to_tick(int tick, bool scroll_into_view) {
+    if (!audio_loaded_) {
+        return;
+    }
+
+    const int clamped_tick = std::max(0, tick);
+    const double target_ms = state_.engine().tick_to_ms(clamped_tick);
+    audio_manager::instance().seek_bgm(target_ms / 1000.0);
+    update_audio_clock();
+    previous_playback_tick_ = playback_tick_;
+    previous_audio_playing_ = audio_playing_;
+
+    if (scroll_into_view) {
+        scroll_to_tick(playback_tick_);
+    }
+}
+
+void editor_scene::update_note_hitsounds() {
+    if (!audio_loaded_ || hitsound_path_.empty()) {
+        previous_playback_tick_ = playback_tick_;
+        previous_audio_playing_ = audio_playing_;
+        return;
+    }
+
+    if (!audio_playing_) {
+        previous_playback_tick_ = playback_tick_;
+        previous_audio_playing_ = false;
+        return;
+    }
+
+    if (!previous_audio_playing_) {
+        previous_playback_tick_ = playback_tick_;
+        previous_audio_playing_ = true;
+        return;
+    }
+
+    if (playback_tick_ <= previous_playback_tick_) {
+        previous_playback_tick_ = playback_tick_;
+        previous_audio_playing_ = true;
+        return;
+    }
+
+    for (const note_data& note : state_.data().notes) {
+        if (note.tick > previous_playback_tick_ && note.tick <= playback_tick_) {
+            audio_manager::instance().play_se(hitsound_path_, 0.45f);
+        }
+    }
+
+    previous_playback_tick_ = playback_tick_;
+    previous_audio_playing_ = true;
+}
+
+std::string editor_scene::playback_status_text() const {
+    if (!audio_loaded_) {
+        return "No audio";
+    }
+
+    return std::string(audio_playing_ ? "Playing " : "Paused ") + format_playback_time(audio_time_seconds_);
+}
+
 std::optional<int> editor_scene::lane_at_position(Vector2 point) const {
     const editor_timeline_metrics metrics = timeline_metrics();
     const Rectangle content = metrics.content_rect();
@@ -441,6 +582,15 @@ std::optional<size_t> editor_scene::note_at_position(Vector2 point) const {
 }
 
 void editor_scene::handle_shortcuts() {
+    if (!has_active_metadata_input() &&
+        timing_panel_.active_input_field == editor_timing_input_field::none &&
+        !metadata_panel_.key_count_confirm_open &&
+        !timing_panel_.bar_pick_mode &&
+        !timeline_drag_.active &&
+        IsKeyPressed(KEY_SPACE)) {
+        toggle_audio_playback();
+    }
+
     if ((IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)) && IsKeyPressed(KEY_Z)) {
         if (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT)) {
             state_.redo();
@@ -525,6 +675,12 @@ void editor_scene::handle_timeline_interaction() {
         return;
     }
 
+    if ((IsKeyDown(KEY_LEFT_ALT) || IsKeyDown(KEY_RIGHT_ALT)) && IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        seek_audio_to_tick(snap_tick(metrics.y_to_tick(mouse.y)), !audio_playing_);
+        timeline_drag_.active = false;
+        return;
+    }
+
     if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
         const std::optional<int> lane = lane_at_position(mouse);
         if (lane.has_value()) {
@@ -568,32 +724,23 @@ void editor_scene::apply_scroll_and_zoom(float dt) {
         bottom_tick_ = bottom_tick_target_;
     }
 
-    if (wheel == 0.0f || !CheckCollisionPointRec(mouse, content)) {
-        bottom_tick_target_ = std::clamp(bottom_tick_target_, 0.0f, max_bottom_tick());
-        if (bottom_tick_target_ <= 0.0f || bottom_tick_target_ >= max_bottom_tick()) {
-            bottom_tick_ = bottom_tick_target_;
-            return;
-        }
-        bottom_tick_ += (bottom_tick_target_ - bottom_tick_) * std::min(1.0f, kScrollLerpSpeed * dt);
-        if (std::fabs(bottom_tick_ - bottom_tick_target_) < 0.5f) {
-            bottom_tick_ = bottom_tick_target_;
-        }
-        return;
-    }
-
-    if (IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)) {
+    if (wheel != 0.0f && CheckCollisionPointRec(mouse, content) &&
+        (IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL))) {
         const int anchor_tick = metrics.y_to_tick(mouse.y);
         const float zoom_scale = wheel > 0.0f ? 0.85f : 1.15f;
         ticks_per_pixel_ = std::clamp(ticks_per_pixel_ * zoom_scale, kMinTicksPerPixel, kMaxTicksPerPixel);
         bottom_tick_target_ = static_cast<float>(anchor_tick) -
                               (content.y + content.height - mouse.y) * ticks_per_pixel_;
         bottom_tick_target_ = std::clamp(bottom_tick_target_, 0.0f, max_bottom_tick());
-        bottom_tick_ = bottom_tick_target_;
-        return;
+    } else if (!audio_playing_ && wheel != 0.0f && CheckCollisionPointRec(mouse, content)) {
+        bottom_tick_target_ = std::clamp(bottom_tick_target_ + wheel * visible_tick_span() * kScrollWheelViewportRatio,
+                                         0.0f, max_bottom_tick());
+    } else if (audio_playing_) {
+        bottom_tick_target_ = std::clamp(static_cast<float>(playback_tick_) - visible_tick_span() * kPlaybackFollowViewportRatio,
+                                         0.0f, max_bottom_tick());
     }
 
-    bottom_tick_target_ = std::clamp(bottom_tick_target_ + wheel * visible_tick_span() * kScrollWheelViewportRatio,
-                                     0.0f, max_bottom_tick());
+    bottom_tick_target_ = std::clamp(bottom_tick_target_, 0.0f, max_bottom_tick());
     if (bottom_tick_target_ <= 0.0f || bottom_tick_target_ >= max_bottom_tick()) {
         bottom_tick_ = bottom_tick_target_;
         return;
@@ -1065,6 +1212,7 @@ void editor_scene::draw_timeline() const {
         meter_map_.visible_grid_lines(min_tick, max_tick),
         std::move(notes),
         selected_note_index_,
+        audio_loaded_ ? std::optional<int>(playback_tick_) : std::nullopt,
         preview_note,
         preview_has_overlap,
         min_tick,
@@ -1096,11 +1244,18 @@ void editor_scene::draw_cursor_hud() const {
 }
 
 void editor_scene::draw_header_tools() {
+    const auto& t = *g_theme;
+    ui::draw_section(kPlaybackRect);
+    const std::string playback_status = playback_status_text();
+    ui::draw_label_value(ui::inset(kPlaybackRect, ui::edge_insets::symmetric(0.0f, 12.0f)),
+                         "Audio", playback_status.c_str(), 16,
+                         t.text, audio_loaded_ ? t.text_secondary : t.text_muted, 56.0f);
+
     // 描画は queue に寄せるが、ヒットテストはまだ即時計算のままにしている。
     // 次段で layer と hit test 優先順位を統合すると、modal / pause 系も同じ仕組みに載せられる。
     const ui::dropdown_state dropdown = ui::enqueue_dropdown(
         kSnapDropdownRect, kSnapDropdownMenuRect,
-        "Tools", kSnapLabels[snap_index_],
+        "Snap", kSnapLabels[snap_index_],
         std::span<const char* const>(kSnapLabels, std::size(kSnapLabels)),
         snap_index_, snap_dropdown_open_,
         ui::draw_layer::base, ui::draw_layer::overlay,

--- a/src/scenes/editor_scene.h
+++ b/src/scenes/editor_scene.h
@@ -19,6 +19,7 @@ public:
     editor_scene(scene_manager& manager, song_data song, int key_count);
 
     void on_enter() override;
+    void on_exit() override;
     void update(float dt) override;
     void draw() override;
 
@@ -52,6 +53,11 @@ private:
     int snap_interval() const;
     int snap_tick(int raw_tick) const;
     int default_timing_event_tick() const;
+    void update_audio_clock();
+    void update_note_hitsounds();
+    void toggle_audio_playback();
+    void seek_audio_to_tick(int tick, bool scroll_into_view);
+    std::string playback_status_text() const;
     std::optional<int> lane_at_position(Vector2 point) const;
     std::optional<size_t> note_at_position(Vector2 point) const;
     void rebuild_hit_regions() const;
@@ -89,6 +95,13 @@ private:
     editor_timing_panel_state timing_panel_;
     std::vector<std::string> load_errors_;
     int audio_length_tick_ = 0;
+    bool audio_loaded_ = false;
+    bool audio_playing_ = false;
+    double audio_time_seconds_ = 0.0;
+    int playback_tick_ = 0;
+    int previous_playback_tick_ = 0;
+    bool previous_audio_playing_ = false;
+    std::string hitsound_path_;
     float bottom_tick_ = 0.0f;
     float bottom_tick_target_ = 0.0f;
     float ticks_per_pixel_ = 2.0f;


### PR DESCRIPTION
## 概要
- 譜面エディタで BGM 再生 / 一時停止、シーク、再生ヘッド表示、現在時刻表示を追加
- 再生中にノート通過で共通クリック音を鳴らす editor プレビューを追加
- SE 再生を sample キャッシュ優先に切り替え、低遅延向けの初期設定を追加

## 確認
- ユーザー環境で editor の音声再生とクリック音再生を確認済み

Closes #74
Closes #47