### PR TITLE
settings_scene の責務を分離する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,13 @@ add_executable(raythm src/main.cpp
         src/scenes/play/play_session_types.h
         src/scenes/result_scene.cpp
         src/scenes/result_scene.h
+        src/scenes/settings/settings_key_config_state.cpp
+        src/scenes/settings/settings_key_config_state.h
+        src/scenes/settings/settings_layout.h
+        src/scenes/settings/settings_pages.cpp
+        src/scenes/settings/settings_pages.h
+        src/scenes/settings/settings_runtime_applier.cpp
+        src/scenes/settings/settings_runtime_applier.h
         src/scenes/settings_scene.cpp
         src/scenes/settings_scene.h
         src/scenes/theme.h

--- a/src/scenes/settings/settings_key_config_state.cpp
+++ b/src/scenes/settings/settings_key_config_state.cpp
@@ -1,0 +1,133 @@
+#include "settings/settings_key_config_state.h"
+
+#include <algorithm>
+#include <span>
+
+#include "key_names.h"
+#include "raylib.h"
+#include "settings/settings_layout.h"
+#include "theme.h"
+#include "ui_draw.h"
+
+bool settings_key_config_state::is_valid_play_key(int key) {
+    return key != KEY_ESCAPE && key != KEY_ENTER && key != KEY_UP && key != KEY_DOWN &&
+           key != KEY_LEFT && key != KEY_RIGHT && key != KEY_BACKSPACE && key != KEY_NULL;
+}
+
+void settings_key_config_state::reset() {
+    listening_ = false;
+    slot_ = -1;
+    error_.clear();
+    error_timer_ = 0.0f;
+}
+
+void settings_key_config_state::clear_selection() {
+    listening_ = false;
+    slot_ = -1;
+}
+
+void settings_key_config_state::tick(float dt) {
+    error_timer_ = std::max(0.0f, error_timer_ - dt);
+}
+
+bool settings_key_config_state::blocks_navigation() const {
+    return listening_;
+}
+
+void settings_key_config_state::show_error(const std::string& message) {
+    error_ = message;
+    error_timer_ = 2.0f;
+}
+
+void settings_key_config_state::handle_listening(game_settings& settings) {
+    if (IsKeyPressed(KEY_ESCAPE)) {
+        listening_ = false;
+        return;
+    }
+
+    const int pressed = GetKeyPressed();
+    if (pressed == KEY_NULL || slot_ < 0) {
+        return;
+    }
+
+    if (!is_valid_play_key(pressed)) {
+        show_error("This key cannot be assigned");
+        return;
+    }
+
+    std::span<KeyboardKey> keys = mode_ == 0
+        ? std::span<KeyboardKey>(settings.keys.keys_4)
+        : std::span<KeyboardKey>(settings.keys.keys_6);
+    const int count = mode_ == 0 ? 4 : 6;
+    for (int i = 0; i < count; ++i) {
+        if (i != slot_ && keys[static_cast<std::size_t>(i)] == static_cast<KeyboardKey>(pressed)) {
+            show_error(TextFormat("Key '%s' is already assigned to Lane %d", get_key_name(pressed), i + 1));
+            return;
+        }
+    }
+
+    keys[static_cast<std::size_t>(slot_)] = static_cast<KeyboardKey>(pressed);
+    listening_ = false;
+    error_.clear();
+}
+
+void settings_key_config_state::update(game_settings& settings) {
+    if (listening_) {
+        handle_listening(settings);
+        return;
+    }
+
+    const Rectangle mode_left = settings::arrow_left_rect(settings::kKeyModeRect);
+    const Rectangle mode_right = settings::arrow_right_rect(settings::kKeyModeRect);
+    if (ui::is_clicked(mode_left, settings::kLayer) || ui::is_clicked(mode_right, settings::kLayer)) {
+        mode_ = 1 - mode_;
+        slot_ = -1;
+        return;
+    }
+
+    const int max_keys = mode_ == 0 ? 4 : 6;
+    for (int i = 0; i < max_keys; ++i) {
+        const Rectangle row_rect = settings::key_slot_rect(i);
+        if (ui::is_clicked(row_rect, settings::kLayer)) {
+            if (slot_ == i) {
+                listening_ = true;
+                error_.clear();
+            } else {
+                slot_ = i;
+            }
+            return;
+        }
+    }
+}
+
+void settings_key_config_state::draw(const game_settings& settings) const {
+    const auto& theme = *g_theme;
+    ui::draw_value_selector(settings::kKeyModeRect, "Mode", mode_ == 0 ? "4K" : "6K", settings::kLayer);
+
+    const std::span<const KeyboardKey> keys = mode_ == 0
+        ? std::span<const KeyboardKey>(settings.keys.keys_4)
+        : std::span<const KeyboardKey>(settings.keys.keys_6);
+    const int count = mode_ == 0 ? 4 : 6;
+    for (int i = 0; i < count; ++i) {
+        const bool selected = slot_ == i;
+        const bool is_listening = selected && listening_;
+        const Rectangle row_rect = settings::key_slot_rect(i);
+        const ui::row_state row_state = ui::draw_row(row_rect,
+                                                     selected ? theme.row_selected : theme.row,
+                                                     selected ? theme.row_active : theme.row_hover,
+                                                     selected ? theme.border_active : theme.border);
+        const char* key_label = is_listening ? "Press a key..." : get_key_name(keys[static_cast<std::size_t>(i)]);
+        const ui::rect_pair columns = ui::split_columns(ui::inset(row_state.visual, 18.0f), 160.0f);
+        ui::draw_text_in_rect(TextFormat("Lane %d", i + 1), 24, columns.first, theme.text, ui::text_align::left);
+        ui::draw_text_in_rect(key_label, 24, columns.second, is_listening ? theme.error : theme.text_dim, ui::text_align::right);
+    }
+
+    if (error_timer_ > 0.0f && !error_.empty()) {
+        const unsigned char alpha = static_cast<unsigned char>(std::min(error_timer_ / 0.3f, 1.0f) * 255.0f);
+        ui::draw_text_in_rect(error_.c_str(), 22,
+                              ui::place(settings::kContentRect, 560.0f, 28.0f,
+                                        ui::anchor::top_left, ui::anchor::top_left,
+                                        {30.0f, 214.0f + static_cast<float>(count) * 62.0f + 8.0f}),
+                              with_alpha(theme.error, alpha), ui::text_align::left);
+    }
+}

--- a/src/scenes/settings/settings_key_config_state.h
+++ b/src/scenes/settings/settings_key_config_state.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+#include "game_settings.h"
+
+class settings_key_config_state {
+public:
+    void reset();
+    void clear_selection();
+    void tick(float dt);
+
+    void update(game_settings& settings);
+    void draw(const game_settings& settings) const;
+
+    [[nodiscard]] bool blocks_navigation() const;
+
+private:
+    [[nodiscard]] static bool is_valid_play_key(int key);
+    void show_error(const std::string& message);
+    void handle_listening(game_settings& settings);
+
+    int mode_ = 0;
+    int slot_ = -1;
+    bool listening_ = false;
+    std::string error_;
+    float error_timer_ = 0.0f;
+};

--- a/src/scenes/settings/settings_layout.h
+++ b/src/scenes/settings/settings_layout.h
@@ -1,0 +1,124 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <span>
+
+#include "raylib.h"
+#include "scene_common.h"
+#include "ui_draw.h"
+#include "virtual_screen.h"
+
+namespace settings {
+
+enum class page_id { gameplay, audio, video, key_config };
+
+struct page_descriptor {
+    const char* navigation_label;
+    const char* title;
+    const char* subtitle;
+};
+
+inline constexpr ui::draw_layer kLayer = ui::draw_layer::base;
+inline constexpr int kPageCount = 4;
+inline constexpr float kSliderLeftInset = 218.0f;
+inline constexpr float kSliderRightInset = 42.0f;
+inline constexpr float kSliderTopOffset = 26.0f;
+inline constexpr float kArrowButtonSize = 34.0f;
+
+inline constexpr std::array<page_descriptor, kPageCount> kPageDescriptors = {{
+    {"Gameplay", "Gameplay", "Play feel and lane settings"},
+    {"Audio", "Audio", "BGM and sound effect volume"},
+    {"Video", "Video", "Display and frame rate settings"},
+    {"Key Config", "Key Config", "Per-lane keyboard bindings"},
+}};
+
+inline const Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
+inline const Rectangle kSidebarRect = ui::place(kScreenRect, 256.0f, 660.0f,
+                                                ui::anchor::top_left, ui::anchor::top_left,
+                                                {24.0f, 44.0f});
+inline const Rectangle kContentRect = ui::place(kScreenRect, 956.0f, 660.0f,
+                                                ui::anchor::top_left, ui::anchor::top_left,
+                                                {300.0f, 44.0f});
+inline const Rectangle kSidebarHeaderRect = ui::place(kSidebarRect, 208.0f, 62.0f,
+                                                      ui::anchor::top_left, ui::anchor::top_left,
+                                                      {22.0f, 26.0f});
+inline const Rectangle kSidebarHintRect = ui::place(kSidebarRect, 208.0f, 24.0f,
+                                                    ui::anchor::top_left, ui::anchor::top_left,
+                                                    {24.0f, 352.0f});
+inline const Rectangle kTabArea = ui::place(kSidebarRect, 208.0f, 4.0f * 42.0f + 3.0f * 8.0f,
+                                            ui::anchor::top_center, ui::anchor::top_center,
+                                            {0.0f, 152.0f});
+inline const Rectangle kBackRect = ui::place(kSidebarRect, 208.0f, 42.0f,
+                                             ui::anchor::bottom_center, ui::anchor::bottom_center,
+                                             {0.0f, -38.0f});
+inline const Rectangle kContentHeaderRect = ui::place(kContentRect, 560.0f, 60.0f,
+                                                      ui::anchor::top_left, ui::anchor::top_left,
+                                                      {30.0f, 30.0f});
+inline const std::array<Rectangle, 8> kGeneralRows = {{
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 116.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 176.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 236.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 336.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 396.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 496.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 556.0f}),
+    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 616.0f}),
+}};
+inline const Rectangle kKeyModeRect = ui::place(kContentRect, 890.0f, 64.0f,
+                                                ui::anchor::top_left, ui::anchor::top_left,
+                                                {30.0f, 126.0f});
+
+inline float clamp01(float value) {
+    return std::clamp(value, 0.0f, 1.0f);
+}
+
+inline const page_descriptor& page_descriptor_for(page_id page) {
+    return kPageDescriptors[static_cast<std::size_t>(page)];
+}
+
+inline Rectangle slider_track_rect(const Rectangle& row_rect) {
+    return ui::make_slider_layout(row_rect, kSliderLeftInset, kSliderRightInset, 200.0f, 18.0f, kSliderTopOffset).track_rect;
+}
+
+inline Rectangle arrow_left_rect(const Rectangle& row_rect) {
+    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, 18.0f));
+    const ui::rect_pair columns = ui::split_columns(content, 200.0f);
+    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 2.0f + 10.0f, kArrowButtonSize,
+                                                 ui::anchor::center_right, ui::anchor::center_right);
+    return {button_pair_area.x, button_pair_area.y, kArrowButtonSize, kArrowButtonSize};
+}
+
+inline Rectangle arrow_right_rect(const Rectangle& row_rect) {
+    const Rectangle left = arrow_left_rect(row_rect);
+    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+}
+
+inline Rectangle key_slot_rect(int index) {
+    return ui::place(kContentRect, 560.0f, 48.0f,
+                     ui::anchor::top_left, ui::anchor::top_left,
+                     {30.0f, 214.0f + static_cast<float>(index) * 62.0f});
+}
+
+inline void build_tab_rects(std::span<Rectangle> out) {
+    ui::vstack(kTabArea, 42.0f, 8.0f, out);
+}
+
+inline float slider_ratio_from_mouse(const Rectangle& row_rect) {
+    const Rectangle track = slider_track_rect(row_rect);
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    return clamp01((mouse.x - track.x) / track.width);
+}
+
+inline int fps_option_index(int target_fps) {
+    constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
+    for (int i = 0; i < static_cast<int>(kFrameRateOptions.size()); ++i) {
+        if (kFrameRateOptions[static_cast<std::size_t>(i)] == target_fps) {
+            return i;
+        }
+    }
+    return 1;
+}
+
+}  // namespace settings

--- a/src/scenes/settings/settings_pages.cpp
+++ b/src/scenes/settings/settings_pages.cpp
@@ -1,0 +1,211 @@
+#include "settings/settings_pages.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <string>
+
+#include "raylib.h"
+#include "settings/settings_layout.h"
+#include "ui_draw.h"
+
+namespace {
+
+constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
+
+}  // namespace
+
+settings_gameplay_page::settings_gameplay_page(game_settings& settings) : settings_(settings) {
+}
+
+void settings_gameplay_page::reset_interaction() {
+    active_slider_ = slider::none;
+}
+
+void settings_gameplay_page::update() {
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        active_slider_ = slider::none;
+    }
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        if (ui::is_hovered(settings::kGeneralRows[0], settings::kLayer)) {
+            active_slider_ = slider::note_speed;
+        } else if (ui::is_hovered(settings::kGeneralRows[1], settings::kLayer)) {
+            active_slider_ = slider::camera_angle;
+        } else if (ui::is_hovered(settings::kGeneralRows[2], settings::kLayer)) {
+            active_slider_ = slider::lane_width;
+        }
+    }
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        if (active_slider_ == slider::note_speed) {
+            const float ratio = settings::slider_ratio_from_mouse(settings::kGeneralRows[0]);
+            settings_.note_speed = 0.020f + ratio * (0.090f - 0.020f);
+        } else if (active_slider_ == slider::camera_angle) {
+            const float ratio = settings::slider_ratio_from_mouse(settings::kGeneralRows[1]);
+            settings_.camera_angle_degrees = 5.0f + ratio * (90.0f - 5.0f);
+        } else if (active_slider_ == slider::lane_width) {
+            const float ratio = settings::slider_ratio_from_mouse(settings::kGeneralRows[2]);
+            settings_.lane_width = 0.6f + ratio * (10.0f - 0.6f);
+        }
+    }
+}
+
+void settings_gameplay_page::draw() const {
+    const char* labels[] = {"Note Speed", "Camera Angle", "Lane Width"};
+    const std::string values[] = {
+        TextFormat("%.3f", settings_.note_speed),
+        TextFormat("%.0f deg", settings_.camera_angle_degrees),
+        TextFormat("%.1f", settings_.lane_width),
+    };
+
+    for (int i = 0; i < 3; ++i) {
+        float ratio = 0.0f;
+        if (i == 0) {
+            ratio = (settings_.note_speed - 0.020f) / (0.090f - 0.020f);
+        } else if (i == 1) {
+            ratio = (settings_.camera_angle_degrees - 5.0f) / (90.0f - 5.0f);
+        } else {
+            ratio = (settings_.lane_width - 0.6f) / (10.0f - 0.6f);
+        }
+        ui::draw_slider_relative(settings::kGeneralRows[static_cast<std::size_t>(i)], labels[i], values[i].c_str(),
+                                 settings::clamp01(ratio), settings::kSliderLeftInset, settings::kSliderRightInset,
+                                 settings::kLayer, 22, settings::kSliderTopOffset);
+    }
+}
+
+settings_audio_page::settings_audio_page(game_settings& settings, const settings_runtime_applier& runtime_applier)
+    : settings_(settings), runtime_applier_(runtime_applier) {
+}
+
+void settings_audio_page::reset_interaction() {
+    active_slider_ = slider::none;
+}
+
+void settings_audio_page::update() {
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        active_slider_ = slider::none;
+    }
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        if (ui::is_hovered(settings::kGeneralRows[0], settings::kLayer)) {
+            active_slider_ = slider::bgm_volume;
+        } else if (ui::is_hovered(settings::kGeneralRows[1], settings::kLayer)) {
+            active_slider_ = slider::se_volume;
+        }
+    }
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        if (active_slider_ == slider::bgm_volume) {
+            settings_.bgm_volume = settings::slider_ratio_from_mouse(settings::kGeneralRows[0]);
+            runtime_applier_.apply_bgm_volume(settings_.bgm_volume);
+        } else if (active_slider_ == slider::se_volume) {
+            settings_.se_volume = settings::slider_ratio_from_mouse(settings::kGeneralRows[1]);
+            runtime_applier_.apply_se_volume(settings_.se_volume);
+        }
+    }
+}
+
+void settings_audio_page::draw() const {
+    const char* labels[] = {"BGM Volume", "SE Volume"};
+    const std::string values[] = {
+        TextFormat("%d%%", static_cast<int>(std::round(settings_.bgm_volume * 100.0f))),
+        TextFormat("%d%%", static_cast<int>(std::round(settings_.se_volume * 100.0f))),
+    };
+
+    for (int row = 0; row < 2; ++row) {
+        const float ratio = row == 0 ? settings_.bgm_volume : settings_.se_volume;
+        ui::draw_slider_relative(settings::kGeneralRows[static_cast<std::size_t>(row)], labels[row], values[row].c_str(), ratio,
+                                 settings::kSliderLeftInset, settings::kSliderRightInset,
+                                 settings::kLayer, 22, settings::kSliderTopOffset);
+    }
+}
+
+settings_video_page::settings_video_page(game_settings& settings, const settings_runtime_applier& runtime_applier)
+    : settings_(settings), runtime_applier_(runtime_applier) {
+}
+
+void settings_video_page::reset_interaction() {
+    dragging_frame_rate_ = false;
+}
+
+void settings_video_page::update() {
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        dragging_frame_rate_ = false;
+    }
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && ui::is_hovered(settings::kGeneralRows[0], settings::kLayer)) {
+        dragging_frame_rate_ = true;
+    }
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && dragging_frame_rate_) {
+        const float ratio = settings::slider_ratio_from_mouse(settings::kGeneralRows[0]);
+        const int index = static_cast<int>(std::round(ratio * static_cast<float>(kFrameRateOptions.size() - 1)));
+        settings_.target_fps =
+            kFrameRateOptions[static_cast<std::size_t>(std::clamp(index, 0, static_cast<int>(kFrameRateOptions.size()) - 1))];
+    }
+
+    bool resolution_changed = false;
+
+    if (ui::is_clicked(settings::arrow_left_rect(settings::kGeneralRows[1]), settings::kLayer)) {
+        settings_.resolution_index = std::max(0, settings_.resolution_index - 1);
+        resolution_changed = true;
+    } else if (ui::is_clicked(settings::arrow_right_rect(settings::kGeneralRows[1]), settings::kLayer)) {
+        settings_.resolution_index = std::min(kResolutionPresetCount - 1, settings_.resolution_index + 1);
+        resolution_changed = true;
+    }
+
+    if (resolution_changed) {
+        runtime_applier_.apply_resolution(settings_.resolution_index);
+    }
+
+    if (ui::is_clicked(settings::arrow_left_rect(settings::kGeneralRows[2]), settings::kLayer) ||
+        ui::is_clicked(settings::arrow_right_rect(settings::kGeneralRows[2]), settings::kLayer)) {
+        settings_.fullscreen = !settings_.fullscreen;
+        runtime_applier_.toggle_fullscreen();
+    }
+
+    if (ui::is_clicked(settings::arrow_left_rect(settings::kGeneralRows[3]), settings::kLayer) ||
+        ui::is_clicked(settings::arrow_right_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+        settings_.dark_mode = !settings_.dark_mode;
+        runtime_applier_.apply_theme(settings_.dark_mode);
+    }
+}
+
+void settings_video_page::draw() const {
+    const std::string fps_label = settings_.target_fps == 0 ? "Unlimited" : std::to_string(settings_.target_fps);
+    ui::draw_slider_relative(settings::kGeneralRows[0], "Frame Rate", fps_label.c_str(),
+                             static_cast<float>(settings::fps_option_index(settings_.target_fps)) / 3.0f,
+                             settings::kSliderLeftInset, settings::kSliderRightInset,
+                             settings::kLayer, 22, settings::kSliderTopOffset);
+    ui::draw_value_selector(settings::kGeneralRows[1], "Resolution", kResolutionPresets[settings_.resolution_index].label, settings::kLayer);
+    ui::draw_value_selector(settings::kGeneralRows[2], "Display", settings_.fullscreen ? "Fullscreen" : "Windowed", settings::kLayer);
+    ui::draw_value_selector(settings::kGeneralRows[3], "Theme", settings_.dark_mode ? "Dark" : "Light", settings::kLayer);
+}
+
+settings_key_config_page::settings_key_config_page(game_settings& settings) : settings_(settings) {
+}
+
+void settings_key_config_page::reset() {
+    state_.reset();
+}
+
+void settings_key_config_page::clear_selection() {
+    state_.clear_selection();
+}
+
+void settings_key_config_page::tick(float dt) {
+    state_.tick(dt);
+}
+
+void settings_key_config_page::update() {
+    state_.update(settings_);
+}
+
+void settings_key_config_page::draw() const {
+    state_.draw(settings_);
+}
+
+bool settings_key_config_page::blocks_navigation() const {
+    return state_.blocks_navigation();
+}

--- a/src/scenes/settings/settings_pages.h
+++ b/src/scenes/settings/settings_pages.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "game_settings.h"
+#include "settings/settings_key_config_state.h"
+#include "settings/settings_runtime_applier.h"
+
+class settings_gameplay_page {
+public:
+    explicit settings_gameplay_page(game_settings& settings);
+
+    void reset_interaction();
+    void update();
+    void draw() const;
+
+private:
+    enum class slider { none, note_speed, camera_angle, lane_width };
+
+    game_settings& settings_;
+    slider active_slider_ = slider::none;
+};
+
+class settings_audio_page {
+public:
+    settings_audio_page(game_settings& settings, const settings_runtime_applier& runtime_applier);
+
+    void reset_interaction();
+    void update();
+    void draw() const;
+
+private:
+    enum class slider { none, bgm_volume, se_volume };
+
+    game_settings& settings_;
+    const settings_runtime_applier& runtime_applier_;
+    slider active_slider_ = slider::none;
+};
+
+class settings_video_page {
+public:
+    settings_video_page(game_settings& settings, const settings_runtime_applier& runtime_applier);
+
+    void reset_interaction();
+    void update();
+    void draw() const;
+
+private:
+    game_settings& settings_;
+    const settings_runtime_applier& runtime_applier_;
+    bool dragging_frame_rate_ = false;
+};
+
+class settings_key_config_page {
+public:
+    explicit settings_key_config_page(game_settings& settings);
+
+    void reset();
+    void clear_selection();
+    void tick(float dt);
+    void update();
+    void draw() const;
+
+    [[nodiscard]] bool blocks_navigation() const;
+
+private:
+    game_settings& settings_;
+    settings_key_config_state state_;
+};

--- a/src/scenes/settings/settings_runtime_applier.cpp
+++ b/src/scenes/settings/settings_runtime_applier.cpp
@@ -1,0 +1,28 @@
+#include "settings/settings_runtime_applier.h"
+
+#include "audio_manager.h"
+#include "game_settings.h"
+#include "raylib.h"
+#include "theme.h"
+
+void settings_runtime_applier::apply_bgm_volume(float volume) const {
+    audio_manager::instance().set_bgm_volume(volume);
+    audio_manager::instance().set_preview_volume(volume);
+}
+
+void settings_runtime_applier::apply_se_volume(float volume) const {
+    audio_manager::instance().set_se_volume(volume);
+}
+
+void settings_runtime_applier::apply_resolution(int resolution_index) const {
+    const resolution_preset& preset = kResolutionPresets[resolution_index];
+    SetWindowSize(preset.width, preset.height);
+}
+
+void settings_runtime_applier::toggle_fullscreen() const {
+    ToggleFullscreen();
+}
+
+void settings_runtime_applier::apply_theme(bool dark_mode) const {
+    set_theme(dark_mode);
+}

--- a/src/scenes/settings/settings_runtime_applier.h
+++ b/src/scenes/settings/settings_runtime_applier.h
@@ -1,0 +1,10 @@
+#pragma once
+
+class settings_runtime_applier {
+public:
+    void apply_bgm_volume(float volume) const;
+    void apply_se_volume(float volume) const;
+    void apply_resolution(int resolution_index) const;
+    void toggle_fullscreen() const;
+    void apply_theme(bool dark_mode) const;
+};

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -1,144 +1,44 @@
 #include "settings_scene.h"
 
-#include <algorithm>
-#include <array>
-#include <cmath>
 #include <memory>
-#include <span>
 
-#include "audio_manager.h"
-#include "game_settings.h"
-#include "key_names.h"
 #include "raylib.h"
-#include "scene_common.h"
 #include "scene_manager.h"
 #include "settings_io.h"
+#include "settings/settings_layout.h"
 #include "song_select_scene.h"
 #include "theme.h"
 #include "title_scene.h"
 #include "ui_draw.h"
 #include "virtual_screen.h"
 
-namespace {
-constexpr ui::draw_layer kSettingsLayer = ui::draw_layer::base;
-constexpr int kPageCount = 4;
-const char* kPageNames[] = {"Gameplay", "Audio", "Video", "Key Config"};
-constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-constexpr Rectangle kSidebarRect = ui::place(kScreenRect, 256.0f, 660.0f,
-                                             ui::anchor::top_left, ui::anchor::top_left,
-                                             {24.0f, 44.0f});
-constexpr Rectangle kContentRect = ui::place(kScreenRect, 956.0f, 660.0f,
-                                             ui::anchor::top_left, ui::anchor::top_left,
-                                             {300.0f, 44.0f});
-constexpr Rectangle kSidebarHeaderRect = ui::place(kSidebarRect, 208.0f, 62.0f,
-                                                   ui::anchor::top_left, ui::anchor::top_left,
-                                                   {22.0f, 26.0f});
-constexpr Rectangle kSidebarHintRect = ui::place(kSidebarRect, 208.0f, 24.0f,
-                                                 ui::anchor::top_left, ui::anchor::top_left,
-                                                 {24.0f, 352.0f});
-constexpr Rectangle kTabArea = ui::place(kSidebarRect, 208.0f, 4.0f * 42.0f + 3.0f * 8.0f,
-                                         ui::anchor::top_center, ui::anchor::top_center,
-                                         {0.0f, 152.0f});
-constexpr Rectangle kBackRect = ui::place(kSidebarRect, 208.0f, 42.0f,
-                                          ui::anchor::bottom_center, ui::anchor::bottom_center,
-                                          {0.0f, -38.0f});
-constexpr Rectangle kContentHeaderRect = ui::place(kContentRect, 560.0f, 60.0f,
-                                                   ui::anchor::top_left, ui::anchor::top_left,
-                                                   {30.0f, 30.0f});
-constexpr Rectangle kGeneralRows[] = {
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 116.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 176.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 236.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 336.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 396.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 496.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 556.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 616.0f}),
-};
-constexpr Rectangle kKeyModeRect = ui::place(kContentRect, 890.0f, 64.0f,
-                                             ui::anchor::top_left, ui::anchor::top_left,
-                                             {30.0f, 126.0f});
-constexpr float kSliderLeftInset = 218.0f;
-constexpr float kSliderRightInset = 42.0f;
-constexpr float kSliderTopOffset = 26.0f;
-constexpr float kArrowButtonSize = 34.0f;
-
-// キーコンフィグで使用可能なキーかどうか（UIキーと衝突しないもの）。
-bool is_valid_play_key(int key) {
-    return key != KEY_ESCAPE && key != KEY_ENTER && key != KEY_UP && key != KEY_DOWN &&
-           key != KEY_LEFT && key != KEY_RIGHT && key != KEY_BACKSPACE && key != KEY_NULL;
-}
-
-float clamp01(float value) {
-    return std::clamp(value, 0.0f, 1.0f);
-}
-
-Rectangle slider_track_rect(const Rectangle& row_rect) {
-    return ui::make_slider_layout(row_rect, kSliderLeftInset, kSliderRightInset, 200.0f, 18.0f, kSliderTopOffset).track_rect;
-}
-
-Rectangle arrow_left_rect(const Rectangle& row_rect) {
-    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, 18.0f));
-    const ui::rect_pair columns = ui::split_columns(content, 200.0f);
-    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 2.0f + 10.0f, kArrowButtonSize,
-                                                 ui::anchor::center_right, ui::anchor::center_right);
-    return {button_pair_area.x, button_pair_area.y, kArrowButtonSize, kArrowButtonSize};
-}
-
-Rectangle arrow_right_rect(const Rectangle& row_rect) {
-    const Rectangle left = arrow_left_rect(row_rect);
-    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
-}
-
-Rectangle key_slot_rect(int index) {
-    return ui::place(kContentRect, 560.0f, 48.0f,
-                     ui::anchor::top_left, ui::anchor::top_left,
-                     {30.0f, 214.0f + static_cast<float>(index) * 62.0f});
-}
-
-void build_tab_rects(std::span<Rectangle> out) {
-    ui::vstack(kTabArea, 42.0f, 8.0f, out);
-}
-
-float slider_ratio_from_mouse(const Rectangle& row_rect, Vector2 mouse) {
-    const Rectangle track = slider_track_rect(row_rect);
-    return clamp01((mouse.x - track.x) / track.width);
-}
-
-int fps_option_index(int target_fps) {
-    constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
-    for (int i = 0; i < static_cast<int>(kFrameRateOptions.size()); ++i) {
-        if (kFrameRateOptions[static_cast<size_t>(i)] == target_fps) {
-            return i;
-        }
-    }
-    return 1;
-}
-}  // namespace
-
-settings_scene::settings_scene(scene_manager& manager, return_target target) : scene(manager), return_target_(target) {
+settings_scene::settings_scene(scene_manager& manager, return_target target)
+    : scene(manager),
+      return_target_(target),
+      gameplay_page_(g_settings),
+      audio_page_(g_settings, runtime_applier_),
+      video_page_(g_settings, runtime_applier_),
+      key_config_page_(g_settings) {
 }
 
 void settings_scene::on_enter() {
-    current_page_ = page::gameplay;
-    active_slider_ = general_slider::none;
-    listening_ = false;
-    key_config_slot_ = -1;
-    key_config_error_.clear();
-    error_timer_ = 0.0f;
+    current_page_ = settings::page_id::gameplay;
+    gameplay_page_.reset_interaction();
+    audio_page_.reset_interaction();
+    video_page_.reset_interaction();
+    key_config_page_.reset();
 }
 
 void settings_scene::update(float dt) {
     ui::begin_hit_regions();
-    error_timer_ = std::max(0.0f, error_timer_ - dt);
+    key_config_page_.tick(dt);
 
-    // リスニング中はページ切り替え・画面遷移を無効にする
-    if (listening_) {
-        update_key_config();
+    if (current_page_blocks_navigation()) {
+        update_current_page();
         return;
     }
 
-    if (ui::is_clicked(kBackRect, kSettingsLayer)) {
+    if (ui::is_clicked(settings::kBackRect, settings::kLayer)) {
         save_settings(g_settings);
         if (return_target_ == return_target::song_select) {
             manager_.change_scene(std::make_unique<song_select_scene>(manager_));
@@ -148,200 +48,16 @@ void settings_scene::update(float dt) {
         return;
     }
 
-    Rectangle tabs[kPageCount];
-    build_tab_rects(tabs);
-    for (int i = 0; i < kPageCount; ++i) {
-        if (ui::is_clicked(tabs[i], kSettingsLayer)) {
-            current_page_ = static_cast<page>(i);
-            key_config_slot_ = -1;
-            listening_ = false;
+    Rectangle tabs[settings::kPageCount];
+    settings::build_tab_rects(tabs);
+    for (int i = 0; i < settings::kPageCount; ++i) {
+        if (ui::is_clicked(tabs[i], settings::kLayer)) {
+            change_page(static_cast<settings::page_id>(i));
             break;
         }
     }
 
-    switch (current_page_) {
-        case page::gameplay:
-            update_gameplay();
-            break;
-        case page::audio:
-            update_audio();
-            break;
-        case page::video:
-            update_video();
-            break;
-        case page::key_config:
-            update_key_config();
-            break;
-    }
-}
-
-void settings_scene::update_gameplay() {
-    const Vector2 mouse = virtual_screen::get_virtual_mouse();
-
-    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
-        active_slider_ = general_slider::none;
-    }
-
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        if (ui::is_hovered(kGeneralRows[0], kSettingsLayer)) {
-            active_slider_ = general_slider::note_speed;
-        } else if (ui::is_hovered(kGeneralRows[1], kSettingsLayer)) {
-            active_slider_ = general_slider::camera_angle;
-        } else if (ui::is_hovered(kGeneralRows[2], kSettingsLayer)) {
-            active_slider_ = general_slider::lane_width;
-        }
-    }
-
-    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
-        if (active_slider_ == general_slider::note_speed) {
-            const float ratio = slider_ratio_from_mouse(kGeneralRows[0], mouse);
-            g_settings.note_speed = 0.020f + ratio * (0.090f - 0.020f);
-        } else if (active_slider_ == general_slider::camera_angle) {
-            const float ratio = slider_ratio_from_mouse(kGeneralRows[1], mouse);
-            g_settings.camera_angle_degrees = 5.0f + ratio * (90.0f - 5.0f);
-        } else if (active_slider_ == general_slider::lane_width) {
-            const float ratio = slider_ratio_from_mouse(kGeneralRows[2], mouse);
-            g_settings.lane_width = 0.6f + ratio * (10.0f - 0.6f);
-        }
-    }
-}
-
-void settings_scene::update_audio() {
-    const Vector2 mouse = virtual_screen::get_virtual_mouse();
-
-    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
-        active_slider_ = general_slider::none;
-    }
-
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        if (ui::is_hovered(kGeneralRows[0], kSettingsLayer)) {
-            active_slider_ = general_slider::bgm_volume;
-        } else if (ui::is_hovered(kGeneralRows[1], kSettingsLayer)) {
-            active_slider_ = general_slider::se_volume;
-        }
-    }
-
-    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
-        if (active_slider_ == general_slider::bgm_volume) {
-            const float ratio = slider_ratio_from_mouse(kGeneralRows[0], mouse);
-            g_settings.bgm_volume = ratio;
-            audio_manager::instance().set_bgm_volume(g_settings.bgm_volume);
-            audio_manager::instance().set_preview_volume(g_settings.bgm_volume);
-        } else if (active_slider_ == general_slider::se_volume) {
-            const float ratio = slider_ratio_from_mouse(kGeneralRows[1], mouse);
-            g_settings.se_volume = ratio;
-            audio_manager::instance().set_se_volume(g_settings.se_volume);
-        }
-    }
-}
-
-void settings_scene::update_video() {
-    const Vector2 mouse = virtual_screen::get_virtual_mouse();
-    constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
-
-    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
-        active_slider_ = general_slider::none;
-    }
-
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && ui::is_hovered(kGeneralRows[0], kSettingsLayer)) {
-        active_slider_ = general_slider::frame_rate;
-    }
-
-    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) && active_slider_ == general_slider::frame_rate) {
-        const float ratio = slider_ratio_from_mouse(kGeneralRows[0], mouse);
-        const int index = static_cast<int>(std::round(ratio * static_cast<float>(kFrameRateOptions.size() - 1)));
-        g_settings.target_fps =
-            kFrameRateOptions[static_cast<size_t>(std::clamp(index, 0, static_cast<int>(kFrameRateOptions.size()) - 1))];
-    }
-
-    bool resolution_changed = false;
-
-    if (ui::is_clicked(arrow_left_rect(kGeneralRows[1]), kSettingsLayer)) {
-        g_settings.resolution_index = std::max(0, g_settings.resolution_index - 1);
-        resolution_changed = true;
-    } else if (ui::is_clicked(arrow_right_rect(kGeneralRows[1]), kSettingsLayer)) {
-        g_settings.resolution_index = std::min(kResolutionPresetCount - 1, g_settings.resolution_index + 1);
-        resolution_changed = true;
-    }
-
-    if (resolution_changed) {
-        const resolution_preset& preset = kResolutionPresets[g_settings.resolution_index];
-        SetWindowSize(preset.width, preset.height);
-    }
-
-    if (ui::is_clicked(arrow_left_rect(kGeneralRows[2]), kSettingsLayer) ||
-        ui::is_clicked(arrow_right_rect(kGeneralRows[2]), kSettingsLayer)) {
-        g_settings.fullscreen = !g_settings.fullscreen;
-        ToggleFullscreen();
-    }
-
-    // テーマ切り替え
-    if (ui::is_clicked(arrow_left_rect(kGeneralRows[3]), kSettingsLayer) ||
-        ui::is_clicked(arrow_right_rect(kGeneralRows[3]), kSettingsLayer)) {
-        g_settings.dark_mode = !g_settings.dark_mode;
-        set_theme(g_settings.dark_mode);
-    }
-}
-
-void settings_scene::update_key_config() {
-    const int max_keys = key_config_mode_ == 0 ? 4 : 6;
-
-    if (listening_) {
-        // ESC でリスニングキャンセル
-        if (IsKeyPressed(KEY_ESCAPE)) {
-            listening_ = false;
-            return;
-        }
-
-        // 押されたキーを検出
-        const int pressed = GetKeyPressed();
-        if (pressed == KEY_NULL) return;
-
-        if (!is_valid_play_key(pressed)) {
-            key_config_error_ = "This key cannot be assigned";
-            error_timer_ = 2.0f;
-            return;
-        }
-
-        // 重複チェック
-        const std::span<KeyboardKey> keys = key_config_mode_ == 0
-            ? std::span<KeyboardKey>(g_settings.keys.keys_4)
-            : std::span<KeyboardKey>(g_settings.keys.keys_6);
-        const int count = key_config_mode_ == 0 ? 4 : 6;
-        for (int i = 0; i < count; ++i) {
-            if (i != key_config_slot_ && keys[static_cast<size_t>(i)] == static_cast<KeyboardKey>(pressed)) {
-                key_config_error_ = TextFormat("Key '%s' is already assigned to Lane %d", get_key_name(pressed), i + 1);
-                error_timer_ = 2.0f;
-                return;
-            }
-        }
-
-        keys[static_cast<size_t>(key_config_slot_)] = static_cast<KeyboardKey>(pressed);
-        listening_ = false;
-        key_config_error_.clear();
-        return;
-    }
-
-    const Rectangle mode_left = arrow_left_rect(kKeyModeRect);
-    const Rectangle mode_right = arrow_right_rect(kKeyModeRect);
-    if (ui::is_clicked(mode_left, kSettingsLayer) || ui::is_clicked(mode_right, kSettingsLayer)) {
-        key_config_mode_ = 1 - key_config_mode_;
-        key_config_slot_ = -1;
-        return;
-    }
-
-    for (int i = 0; i < max_keys; ++i) {
-        const Rectangle row_rect = key_slot_rect(i);
-        if (ui::is_clicked(row_rect, kSettingsLayer)) {
-            if (key_config_slot_ == i) {
-                listening_ = true;
-                key_config_error_.clear();
-            } else {
-                key_config_slot_ = i;
-            }
-            return;
-        }
-    }
+    update_current_page();
 }
 
 void settings_scene::draw() {
@@ -349,145 +65,82 @@ void settings_scene::draw() {
     virtual_screen::begin();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
-    ui::draw_panel(kSidebarRect);
-    ui::draw_panel(kContentRect);
+    ui::draw_panel(settings::kSidebarRect);
+    ui::draw_panel(settings::kContentRect);
 
-    ui::draw_header_block(kSidebarHeaderRect, "SETTINGS", "Saved on exit");
+    ui::draw_header_block(settings::kSidebarHeaderRect, "SETTINGS", "Saved on exit");
 
-    Rectangle tabs[kPageCount];
-    build_tab_rects(tabs);
-    for (int i = 0; i < kPageCount; ++i) {
+    Rectangle tabs[settings::kPageCount];
+    settings::build_tab_rects(tabs);
+    for (int i = 0; i < settings::kPageCount; ++i) {
+        const settings::page_descriptor& descriptor = settings::page_descriptor_for(static_cast<settings::page_id>(i));
         if (static_cast<int>(current_page_) == i) {
-            ui::draw_button_colored(tabs[i], kPageNames[i], 22,
+            ui::draw_button_colored(tabs[i], descriptor.navigation_label, 22,
                                     t.row_selected, t.row_active, t.text);
         } else {
-            ui::draw_button_colored(tabs[i], kPageNames[i], 22,
+            ui::draw_button_colored(tabs[i], descriptor.navigation_label, 22,
                                     t.row, t.row_hover, t.text_secondary);
         }
     }
 
-    draw_marquee_text("Click tabs to switch pages", kSidebarHintRect.x, kSidebarHintRect.y,
-                      20, t.text_muted, kSidebarHintRect.width, GetTime());
-    ui::draw_button(kBackRect, "BACK", 22);
+    draw_marquee_text("Click tabs to switch pages", settings::kSidebarHintRect.x, settings::kSidebarHintRect.y,
+                      20, t.text_muted, settings::kSidebarHintRect.width, GetTime());
+    ui::draw_button(settings::kBackRect, "BACK", 22);
 
-    const char* page_title = "";
-    const char* page_subtitle = "";
-    switch (current_page_) {
-        case page::gameplay:
-            page_title = "Gameplay";
-            page_subtitle = "Play feel and lane settings";
-            break;
-        case page::audio:
-            page_title = "Audio";
-            page_subtitle = "BGM and sound effect volume";
-            break;
-        case page::video:
-            page_title = "Video";
-            page_subtitle = "Display and frame rate settings";
-            break;
-        case page::key_config:
-            page_title = "Key Config";
-            page_subtitle = "Per-lane keyboard bindings";
-            break;
-    }
-    ui::draw_header_block(kContentHeaderRect, page_title, page_subtitle);
+    const settings::page_descriptor& descriptor = settings::page_descriptor_for(current_page_);
+    ui::draw_header_block(settings::kContentHeaderRect, descriptor.title, descriptor.subtitle);
 
-    switch (current_page_) {
-        case page::gameplay:
-            draw_gameplay();
-            break;
-        case page::audio:
-            draw_audio();
-            break;
-        case page::video:
-            draw_video();
-            break;
-        case page::key_config:
-            draw_key_config();
-            break;
-    }
+    draw_current_page();
 
     virtual_screen::end();
     ClearBackground(BLACK);
     virtual_screen::draw_to_screen();
 }
 
-void settings_scene::draw_gameplay() {
-    const char* labels[] = {"Note Speed", "Camera Angle", "Lane Width"};
-    const std::string values[] = {
-        TextFormat("%.3f", g_settings.note_speed),
-        TextFormat("%.0f deg", g_settings.camera_angle_degrees),
-        TextFormat("%.1f", g_settings.lane_width),
-    };
-
-    for (int i = 0; i < 3; ++i) {
-        float ratio = 0.0f;
-        if (i == 0) {
-            ratio = (g_settings.note_speed - 0.020f) / (0.090f - 0.020f);
-        } else if (i == 1) {
-            ratio = (g_settings.camera_angle_degrees - 5.0f) / (90.0f - 5.0f);
-        } else {
-            ratio = (g_settings.lane_width - 0.6f) / (10.0f - 0.6f);
-        }
-        ui::draw_slider_relative(kGeneralRows[i], labels[i], values[i].c_str(), clamp01(ratio),
-                                 kSliderLeftInset, kSliderRightInset, kSettingsLayer, 22, kSliderTopOffset);
+void settings_scene::update_current_page() {
+    switch (current_page_) {
+        case settings::page_id::gameplay:
+            gameplay_page_.update();
+            break;
+        case settings::page_id::audio:
+            audio_page_.update();
+            break;
+        case settings::page_id::video:
+            video_page_.update();
+            break;
+        case settings::page_id::key_config:
+            key_config_page_.update();
+            break;
     }
 }
 
-void settings_scene::draw_audio() {
-    const char* labels[] = {"BGM Volume", "SE Volume"};
-    const std::string values[] = {
-        TextFormat("%d%%", static_cast<int>(std::round(g_settings.bgm_volume * 100.0f))),
-        TextFormat("%d%%", static_cast<int>(std::round(g_settings.se_volume * 100.0f))),
-    };
-
-    for (int row = 0; row < 2; ++row) {
-        const int i = row;
-        const float ratio = row == 0 ? g_settings.bgm_volume : g_settings.se_volume;
-        ui::draw_slider_relative(kGeneralRows[i], labels[row], values[row].c_str(), ratio,
-                                 kSliderLeftInset, kSliderRightInset, kSettingsLayer, 22, kSliderTopOffset);
+void settings_scene::draw_current_page() const {
+    switch (current_page_) {
+        case settings::page_id::gameplay:
+            gameplay_page_.draw();
+            break;
+        case settings::page_id::audio:
+            audio_page_.draw();
+            break;
+        case settings::page_id::video:
+            video_page_.draw();
+            break;
+        case settings::page_id::key_config:
+            key_config_page_.draw();
+            break;
     }
 }
 
-void settings_scene::draw_video() {
-    const std::string fps_label = g_settings.target_fps == 0 ? "Unlimited" : std::to_string(g_settings.target_fps);
-    ui::draw_slider_relative(kGeneralRows[0], "Frame Rate", fps_label.c_str(),
-                             static_cast<float>(fps_option_index(g_settings.target_fps)) / 3.0f,
-                             kSliderLeftInset, kSliderRightInset, kSettingsLayer, 22, kSliderTopOffset);
-    ui::draw_value_selector(kGeneralRows[1], "Resolution", kResolutionPresets[g_settings.resolution_index].label, kSettingsLayer);
-    ui::draw_value_selector(kGeneralRows[2], "Display", g_settings.fullscreen ? "Fullscreen" : "Windowed", kSettingsLayer);
-    ui::draw_value_selector(kGeneralRows[3], "Theme", g_settings.dark_mode ? "Dark" : "Light", kSettingsLayer);
+void settings_scene::change_page(settings::page_id next_page) {
+    gameplay_page_.reset_interaction();
+    audio_page_.reset_interaction();
+    video_page_.reset_interaction();
+    if (current_page_ == settings::page_id::key_config && next_page != settings::page_id::key_config) {
+        key_config_page_.clear_selection();
+    }
+    current_page_ = next_page;
 }
 
-void settings_scene::draw_key_config() {
-    const auto& t = *g_theme;
-    ui::draw_value_selector(kKeyModeRect, "Mode", key_config_mode_ == 0 ? "4K" : "6K", kSettingsLayer);
-
-    // キースロット表示
-    const std::span<const KeyboardKey> keys = key_config_mode_ == 0
-        ? std::span<const KeyboardKey>(g_settings.keys.keys_4)
-        : std::span<const KeyboardKey>(g_settings.keys.keys_6);
-    const int count = key_config_mode_ == 0 ? 4 : 6;
-    for (int i = 0; i < count; ++i) {
-        const bool selected = key_config_slot_ == i;
-        const bool is_listening = selected && listening_;
-        const Rectangle row_rect = key_slot_rect(i);
-        const ui::row_state row_state = ui::draw_row(row_rect,
-                                                     selected ? t.row_selected : t.row,
-                                                     selected ? t.row_active : t.row_hover,
-                                                     selected ? t.border_active : t.border);
-        const char* key_label = is_listening ? "Press a key..." : get_key_name(keys[static_cast<size_t>(i)]);
-        const ui::rect_pair columns = ui::split_columns(ui::inset(row_state.visual, 18.0f), 160.0f);
-        ui::draw_text_in_rect(TextFormat("Lane %d", i + 1), 24, columns.first, t.text, ui::text_align::left);
-        ui::draw_text_in_rect(key_label, 24, columns.second, is_listening ? t.error : t.text_dim, ui::text_align::right);
-    }
-
-    if (error_timer_ > 0.0f && !key_config_error_.empty()) {
-        const unsigned char alpha = static_cast<unsigned char>(std::min(error_timer_ / 0.3f, 1.0f) * 255.0f);
-        ui::draw_text_in_rect(key_config_error_.c_str(), 22,
-                              ui::place(kContentRect, 560.0f, 28.0f,
-                                        ui::anchor::top_left, ui::anchor::top_left,
-                                        {30.0f, 214.0f + static_cast<float>(count) * 62.0f + 8.0f}),
-                              with_alpha(t.error, alpha), ui::text_align::left);
-    }
+bool settings_scene::current_page_blocks_navigation() const {
+    return current_page_ == settings::page_id::key_config && key_config_page_.blocks_navigation();
 }

--- a/src/scenes/settings_scene.h
+++ b/src/scenes/settings_scene.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include <string>
-
 #include "scene.h"
+#include "settings/settings_layout.h"
+#include "settings/settings_pages.h"
 
 // 設定画面。Gameplay / Audio / Video / Key Config の4ページ構成。
 class settings_scene final : public scene {
@@ -16,26 +16,16 @@ public:
     void draw() override;
 
 private:
-    enum class page { gameplay, audio, video, key_config };
-    enum class general_slider { none, note_speed, camera_angle, lane_width, bgm_volume, se_volume, frame_rate };
+    void update_current_page();
+    void draw_current_page() const;
+    void change_page(settings::page_id next_page);
+    [[nodiscard]] bool current_page_blocks_navigation() const;
 
-    void update_gameplay();
-    void update_audio();
-    void update_video();
-    void update_key_config();
-    void draw_gameplay();
-    void draw_audio();
-    void draw_video();
-    void draw_key_config();
-
-    page current_page_ = page::gameplay;
-
-    // キーコンフィグ用状態
-    int key_config_mode_ = 0;       // 0 = 4K, 1 = 6K
-    int key_config_slot_ = -1;      // 選択中のスロット（-1 = 未選択）
-    bool listening_ = false;        // キー入力待ち状態
-    std::string key_config_error_;  // 重複エラーメッセージ
-    float error_timer_ = 0.0f;     // エラー表示タイマー
-    general_slider active_slider_ = general_slider::none;
+    settings::page_id current_page_ = settings::page_id::gameplay;
     return_target return_target_ = return_target::title;
+    settings_runtime_applier runtime_applier_;
+    settings_gameplay_page gameplay_page_;
+    settings_audio_page audio_page_;
+    settings_video_page video_page_;
+    settings_key_config_page key_config_page_;
 };


### PR DESCRIPTION
## 概要
- settings_scene をページルーティングと保存導線に寄せました
- Gameplay / Audio / Video / Key Config の処理を settings 配下の専用クラスへ分離しました
- runtime 副作用を settings_runtime_applier に集約し、Key Config の状態管理を独立クラスへ切り出しました

## 確認
- g++ -std=gnu++20 -fsyntax-only で settings_scene 関連ファイルの構文チェック
- フルビルドは未実施（ユーザー環境で確認予定）

Closes #97