### PR TITLE
GitHub ActionsでWindows向け自動リリースを追加

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -1,0 +1,88 @@
+name: Windows Release
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: windows-release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup MSYS2
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            base-devel
+            git
+            mingw-w64-ucrt-x86_64-toolchain
+            mingw-w64-ucrt-x86_64-cmake
+            mingw-w64-ucrt-x86_64-ninja
+
+      - name: Install NSIS
+        shell: powershell
+        run: |
+          choco install nsis --no-progress -y
+          "${env:ProgramFiles(x86)}\NSIS" >> $env:GITHUB_PATH
+
+      - name: Compute release metadata
+        id: meta
+        shell: powershell
+        run: |
+          $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+          $packageVersion = Get-Date -Format "yyyy.MM.dd"
+          $shortSha = "${env:GITHUB_SHA}".Substring(0, 7)
+          $assetName = "raythm-$packageVersion.$env:GITHUB_RUN_NUMBER-windows-x64"
+          $tag = "main-build-$timestamp-$shortSha"
+          $releaseName = "raythm main build $timestamp ($shortSha)"
+
+          "package_version=$packageVersion.$env:GITHUB_RUN_NUMBER" >> $env:GITHUB_OUTPUT
+          "asset_name=$assetName" >> $env:GITHUB_OUTPUT
+          "tag=$tag" >> $env:GITHUB_OUTPUT
+          "release_name=$releaseName" >> $env:GITHUB_OUTPUT
+          "installer_path=dist/$assetName.exe" >> $env:GITHUB_OUTPUT
+
+      - name: Configure
+        shell: msys2 {0}
+        run: >
+          cmake -S . -B build -G Ninja
+          -DCMAKE_BUILD_TYPE=Release
+          "-DRAYTHM_PACKAGE_VERSION=${{ steps.meta.outputs.package_version }}"
+          "-DRAYTHM_PACKAGE_FILE_NAME=${{ steps.meta.outputs.asset_name }}"
+
+      - name: Build
+        shell: msys2 {0}
+        run: cmake --build build --config Release --target raythm --parallel
+
+      - name: Package installer
+        shell: msys2 {0}
+        run: cpack --config build/CPackConfig.cmake -G NSIS -B dist
+
+      - name: Upload workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.asset_name }}
+          path: ${{ steps.meta.outputs.installer_path }}
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          name: ${{ steps.meta.outputs.release_name }}
+          generate_release_notes: true
+          prerelease: true
+          files: ${{ steps.meta.outputs.installer_path }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 4.1)
 project(raythm)
 
 set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_SKIP_INSTALL_ALL_DEPENDENCY ON)
+set(RAYTHM_PACKAGE_VERSION "0.1.0" CACHE STRING "Version string used for Windows release packages")
+set(RAYTHM_PACKAGE_FILE_NAME
+        "raythm-${RAYTHM_PACKAGE_VERSION}-windows-x64"
+        CACHE STRING "Package file name without extension")
 
 include(FetchContent)
 FetchContent_Declare(
@@ -381,3 +386,19 @@ add_custom_command(TARGET audio_manager_smoke POST_BUILD
 install(TARGETS raythm RUNTIME DESTINATION .)
 install(FILES ${RAYTHM_RUNTIME_DLLS} DESTINATION .)
 install(DIRECTORY ${CMAKE_SOURCE_DIR}/assets DESTINATION .)
+
+if(WIN32)
+    set(CPACK_PACKAGE_NAME "raythm")
+    set(CPACK_PACKAGE_VENDOR "Rofutok112")
+    set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "beatmania-style rhythm game")
+    set(CPACK_PACKAGE_INSTALL_DIRECTORY "raythm")
+    set(CPACK_PACKAGE_VERSION "${RAYTHM_PACKAGE_VERSION}")
+    set(CPACK_PACKAGE_FILE_NAME "${RAYTHM_PACKAGE_FILE_NAME}")
+    set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_SOURCE_DIR}/LICENSE")
+    set(CPACK_NSIS_DISPLAY_NAME "raythm")
+    set(CPACK_NSIS_PACKAGE_NAME "raythm")
+    set(CPACK_NSIS_ENABLE_UNINSTALL_BEFORE_INSTALL ON)
+    set(CPACK_NSIS_MANIFEST_DPI_AWARE ON)
+    set(CPACK_MONOLITHIC_INSTALL ON)
+    include(CPack)
+endif()


### PR DESCRIPTION
## 概要
- main push / workflow_dispatch をトリガーに Windows リリース用の GitHub Actions を追加
- MSYS2(UCRT64) で raythm 本体をビルドし、CPack + NSIS でインストーラーを生成
- 生成したインストーラーを GitHub Release と workflow artifact に自動添付する構成を追加
- install 時に全 smoke target を巻き込まないように CMake の package 設定を調整

## 確認
- ローカルで `cmake -S . -B build-ci-verify-mingw -G "MinGW Makefiles" "-DRAYTHM_PACKAGE_VERSION=2026.04.04.1" "-DRAYTHM_PACKAGE_FILE_NAME=raythm-2026.04.04.1-windows-x64"` を実行して configure 成功
- ローカルで `cmake --build build-ci-verify-mingw --target raythm --parallel 4` を実行して `raythm.exe` のビルド成功
- ローカルで `cpack --config build-ci-verify-mingw/CPackConfig.cmake -G ZIP -B dist-local` を実行して配布物生成成功
- NSIS 実行自体は GitHub Actions 上での確認待ち

Closes #138
