### PR TITLE
プレイヤー向けにグローバルと曲別のノーツオフセットを設定できるようにする

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ add_executable(raythm src/main.cpp
         src/gameplay/input_handler.h
         src/gameplay/judge_system.cpp
         src/gameplay/judge_system.h
+        src/gameplay/player_note_offsets.cpp
+        src/gameplay/player_note_offsets.h
         src/gameplay/score_system.cpp
         src/gameplay/score_system.h
         src/gameplay/song_loader.cpp

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -85,6 +85,10 @@ std::filesystem::path settings_path() {
     return app_data_root() / "settings.json";
 }
 
+std::filesystem::path song_offsets_path() {
+    return app_data_root() / "song_offsets.txt";
+}
+
 void ensure_directories() {
     std::filesystem::create_directories(app_data_root());
     std::filesystem::create_directories(songs_root());

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -35,6 +35,9 @@ std::filesystem::path legacy_songs_root();
 // AppData/Local/raythm/settings.json
 std::filesystem::path settings_path();
 
+// AppData/Local/raythm/song_offsets.txt
+std::filesystem::path song_offsets_path();
+
 // Create songs/ and charts/ directories if they don't exist.
 void ensure_directories();
 

--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -23,6 +23,7 @@ struct game_settings {
     float camera_angle_degrees = 45.0f;
     float lane_width = 3.5f;
     float note_speed = 0.045f;
+    int global_note_offset_ms = 0;
     float bgm_volume = 1.0f;
     float se_volume = 1.0f;
     int target_fps = 144;

--- a/src/gameplay/player_note_offsets.cpp
+++ b/src/gameplay/player_note_offsets.cpp
@@ -1,0 +1,106 @@
+#include "player_note_offsets.h"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "app_paths.h"
+
+namespace {
+
+constexpr int kMinOffsetMs = -1000;
+constexpr int kMaxOffsetMs = 1000;
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+}  // namespace
+
+player_song_offset_map load_player_song_offsets() {
+    player_song_offset_map offsets;
+
+    std::ifstream input(app_paths::song_offsets_path());
+    if (!input.is_open()) {
+        return offsets;
+    }
+
+    std::string line;
+    while (std::getline(input, line)) {
+        const size_t delimiter = line.find('\t');
+        if (delimiter == std::string::npos) {
+            continue;
+        }
+
+        const std::string song_id = trim(std::string_view(line).substr(0, delimiter));
+        const std::string value = trim(std::string_view(line).substr(delimiter + 1));
+        if (song_id.empty() || value.empty()) {
+            continue;
+        }
+
+        try {
+            const int offset_ms = std::clamp(std::stoi(value), kMinOffsetMs, kMaxOffsetMs);
+            if (offset_ms != 0) {
+                offsets[song_id] = offset_ms;
+            }
+        } catch (...) {
+            // Ignore malformed rows and keep the rest.
+        }
+    }
+
+    return offsets;
+}
+
+int load_player_song_offset(const std::string& song_id) {
+    if (song_id.empty()) {
+        return 0;
+    }
+
+    const player_song_offset_map offsets = load_player_song_offsets();
+    const auto it = offsets.find(song_id);
+    return it == offsets.end() ? 0 : it->second;
+}
+
+bool save_player_song_offset(const std::string& song_id, int offset_ms) {
+    if (song_id.empty()) {
+        return false;
+    }
+
+    player_song_offset_map offsets = load_player_song_offsets();
+    const int clamped_offset = std::clamp(offset_ms, kMinOffsetMs, kMaxOffsetMs);
+    if (clamped_offset == 0) {
+        offsets.erase(song_id);
+    } else {
+        offsets[song_id] = clamped_offset;
+    }
+
+    std::vector<std::pair<std::string, int>> ordered(offsets.begin(), offsets.end());
+    std::sort(ordered.begin(), ordered.end(), [](const auto& left, const auto& right) {
+        return left.first < right.first;
+    });
+
+    app_paths::ensure_directories();
+    std::ofstream output(app_paths::song_offsets_path(), std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    for (const auto& [id, value] : ordered) {
+        output << id << '\t' << value << '\n';
+    }
+    return true;
+}

--- a/src/gameplay/player_note_offsets.h
+++ b/src/gameplay/player_note_offsets.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+using player_song_offset_map = std::unordered_map<std::string, int>;
+
+player_song_offset_map load_player_song_offsets();
+int load_player_song_offset(const std::string& song_id);
+bool save_player_song_offset(const std::string& song_id, int offset_ms);

--- a/src/gameplay/settings_io.cpp
+++ b/src/gameplay/settings_io.cpp
@@ -131,6 +131,8 @@ void load_settings(game_settings& settings) {
         settings.lane_width = std::clamp(std::stof(*v), 0.6f, 5.0f);
     if (auto v = extract_number_token(content, "noteSpeed"))
         settings.note_speed = std::clamp(std::stof(*v), kMinNoteSpeed, kMaxNoteSpeed);
+    if (auto v = extract_number_token(content, "globalNoteOffsetMs"))
+        settings.global_note_offset_ms = std::clamp(std::stoi(*v), -10000, 10000);
     if (auto v = extract_number_token(content, "bgmVolume"))
         settings.bgm_volume = std::clamp(std::stof(*v), 0.0f, 1.0f);
     if (auto v = extract_number_token(content, "seVolume"))
@@ -159,6 +161,7 @@ void save_settings(const game_settings& settings) {
     out << "  \"cameraAngle\": " << settings.camera_angle_degrees << ",\n";
     out << "  \"laneWidth\": " << settings.lane_width << ",\n";
     out << "  \"noteSpeed\": " << settings.note_speed << ",\n";
+    out << "  \"globalNoteOffsetMs\": " << settings.global_note_offset_ms << ",\n";
     out << "  \"bgmVolume\": " << settings.bgm_volume << ",\n";
     out << "  \"seVolume\": " << settings.se_volume << ",\n";
     out << "  \"targetFps\": " << settings.target_fps << ",\n";

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -7,6 +7,7 @@
 #include "audio_manager.h"
 #include "game_settings.h"
 #include "path_utils.h"
+#include "player_note_offsets.h"
 #include "play_speed_compensation.h"
 
 namespace {
@@ -92,7 +93,12 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
     state.input_handler = input_handler(g_settings.keys);
     state.input_handler.set_key_count(state.key_count);
 
-    state.timing_engine.init(state.chart_data->timing_events, state.chart_data->meta.resolution, state.chart_data->meta.offset);
+    const int local_song_offset_ms = state.song_data.has_value()
+        ? load_player_song_offset(state.song_data->meta.song_id)
+        : 0;
+    const int effective_offset_ms =
+        state.chart_data->meta.offset + g_settings.global_note_offset_ms + local_song_offset_ms;
+    state.timing_engine.init(state.chart_data->timing_events, state.chart_data->meta.resolution, effective_offset_ms);
     state.start_ms = std::max(0.0, state.timing_engine.tick_to_ms(state.start_tick));
     state.judge_system.init(state.chart_data->notes, state.timing_engine);
     state.score_system.init(static_cast<int>(state.chart_data->notes.size()));

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -77,13 +77,21 @@ result_scene::result_scene(scene_manager& manager, result_data result, bool rank
       song_(std::move(song)), chart_path_(std::move(chart_path)), chart_(std::move(chart)), key_count_(key_count) {
 }
 
+void result_scene::return_to_song_select() const {
+    song_select::recent_result_offset recent_result;
+    recent_result.song_id = song_.meta.song_id;
+    recent_result.chart_id = chart_.chart_id;
+    recent_result.avg_offset_ms = result_.avg_offset;
+    manager_.change_scene(std::make_unique<song_select_scene>(manager_, song_.meta.song_id, chart_.chart_id, recent_result));
+}
+
 void result_scene::update(float dt) {
     fade_in_timer_ = std::max(0.0f, fade_in_timer_ - dt);
 
     if (IsKeyPressed(KEY_ENTER)) {
-        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+        return_to_song_select();
     } else if (IsKeyPressed(KEY_ESCAPE)) {
-        manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+        return_to_song_select();
     } else if (IsKeyPressed(KEY_R)) {
         manager_.change_scene(std::make_unique<play_scene>(manager_, song_, chart_path_, key_count_));
     }
@@ -196,7 +204,8 @@ void result_scene::draw() {
         ui::draw_label_value(stat_rows[3], "Slow", TextFormat("%d", result_.slow_count), 24, t.text_dim, t.slow);
         ui::draw_label_value(stat_rows[4], "Ranking", ranking_enabled_ ? "Eligible" : "Disabled",
                              24, t.text_dim, ranking_enabled_ ? t.success : t.error);
-        ui::draw_text_in_rect("ENTER: Song Select    R: Retry", 20, kStatsHintRect, t.text_hint, ui::text_align::left);
+        ui::draw_text_in_rect("ENTER: Song Select    R: Retry    Use AUTO APPLY there", 20,
+                              kStatsHintRect, t.text_hint, ui::text_align::left);
     }
 
     // フェードイン（暗い状態から明るくなる）

--- a/src/scenes/result_scene.h
+++ b/src/scenes/result_scene.h
@@ -16,6 +16,8 @@ public:
     void draw() override;
 
 private:
+    void return_to_song_select() const;
+
     result_data result_;
     bool ranking_enabled_ = true;
     song_data song_;

--- a/src/scenes/settings/settings_layout.h
+++ b/src/scenes/settings/settings_layout.h
@@ -95,6 +95,29 @@ inline Rectangle arrow_right_rect(const Rectangle& row_rect) {
     return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
 }
 
+inline Rectangle double_arrow_left_rect(const Rectangle& row_rect) {
+    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, 18.0f));
+    const ui::rect_pair columns = ui::split_columns(content, 200.0f);
+    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 4.0f + 30.0f, kArrowButtonSize,
+                                                 ui::anchor::center_right, ui::anchor::center_right);
+    return {button_pair_area.x, button_pair_area.y, kArrowButtonSize, kArrowButtonSize};
+}
+
+inline Rectangle single_arrow_left_rect(const Rectangle& row_rect) {
+    const Rectangle left = double_arrow_left_rect(row_rect);
+    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+}
+
+inline Rectangle single_arrow_right_rect(const Rectangle& row_rect) {
+    const Rectangle left = single_arrow_left_rect(row_rect);
+    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+}
+
+inline Rectangle double_arrow_right_rect(const Rectangle& row_rect) {
+    const Rectangle left = single_arrow_right_rect(row_rect);
+    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+}
+
 inline Rectangle key_slot_rect(int index) {
     return ui::place(kContentRect, 560.0f, 48.0f,
                      ui::anchor::top_left, ui::anchor::top_left,

--- a/src/scenes/settings/settings_pages.cpp
+++ b/src/scenes/settings/settings_pages.cpp
@@ -16,6 +16,10 @@ constexpr float kMinNoteSpeed = 0.010f;
 constexpr float kMaxNoteSpeed = 0.200f;
 constexpr float kNoteSpeedDisplayScale = 10.0f;
 
+std::string format_offset_label(int offset_ms) {
+    return (offset_ms > 0 ? "+" : "") + std::to_string(offset_ms) + " ms";
+}
+
 }  // namespace
 
 settings_gameplay_page::settings_gameplay_page(game_settings& settings) : settings_(settings) {
@@ -52,6 +56,16 @@ void settings_gameplay_page::update() {
             settings_.lane_width = 0.6f + ratio * (10.0f - 0.6f);
         }
     }
+
+    if (ui::is_clicked(settings::double_arrow_left_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+        settings_.global_note_offset_ms = std::max(-10000, settings_.global_note_offset_ms - 5);
+    } else if (ui::is_clicked(settings::single_arrow_left_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+        settings_.global_note_offset_ms = std::max(-10000, settings_.global_note_offset_ms - 1);
+    } else if (ui::is_clicked(settings::single_arrow_right_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+        settings_.global_note_offset_ms = std::min(10000, settings_.global_note_offset_ms + 1);
+    } else if (ui::is_clicked(settings::double_arrow_right_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+        settings_.global_note_offset_ms = std::min(10000, settings_.global_note_offset_ms + 5);
+    }
 }
 
 void settings_gameplay_page::draw() const {
@@ -75,6 +89,27 @@ void settings_gameplay_page::draw() const {
                                  settings::clamp01(ratio), settings::kSliderLeftInset, settings::kSliderRightInset,
                                  settings::kLayer, 22, settings::kSliderTopOffset);
     }
+
+    const std::string global_offset_label = format_offset_label(settings_.global_note_offset_ms);
+    const ui::row_state offset_row = ui::draw_row(settings::kGeneralRows[3], g_theme->row, g_theme->row_hover, g_theme->border);
+    const Rectangle content = ui::inset(offset_row.visual, ui::edge_insets::symmetric(0.0f, 18.0f));
+    const ui::rect_pair columns = ui::split_columns(content, 200.0f);
+    const Rectangle button_group = ui::place(columns.second, settings::kArrowButtonSize * 4.0f + 30.0f,
+                                             settings::kArrowButtonSize,
+                                             ui::anchor::center_right, ui::anchor::center_right);
+    const Rectangle value_rect = {
+        columns.second.x,
+        columns.second.y,
+        button_group.x - columns.second.x - 16.0f,
+        columns.second.height
+    };
+
+    ui::draw_text_in_rect("Global Offset", 22, columns.first, g_theme->text, ui::text_align::left);
+    ui::draw_text_in_rect(global_offset_label.c_str(), 22, value_rect, g_theme->text_dim, ui::text_align::right);
+    ui::draw_button(settings::double_arrow_left_rect(settings::kGeneralRows[3]), "<<", 22);
+    ui::draw_button(settings::single_arrow_left_rect(settings::kGeneralRows[3]), "<", 22);
+    ui::draw_button(settings::single_arrow_right_rect(settings::kGeneralRows[3]), ">", 22);
+    ui::draw_button(settings::double_arrow_right_rect(settings::kGeneralRows[3]), ">>", 22);
 }
 
 settings_audio_page::settings_audio_page(game_settings& settings, const settings_runtime_applier& runtime_applier)

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -6,6 +6,7 @@
 
 #include "app_paths.h"
 #include "path_utils.h"
+#include "player_note_offsets.h"
 #include "song_loader.h"
 
 namespace {
@@ -39,6 +40,7 @@ namespace song_select {
 
 catalog_data load_catalog() {
     catalog_data catalog;
+    const player_song_offset_map song_offsets = load_player_song_offsets();
 
     const song_load_result legacy_result = song_loader::load_all(path_utils::to_utf8(app_paths::legacy_songs_root()),
                                                                  content_source::legacy_assets);
@@ -59,6 +61,9 @@ catalog_data load_catalog() {
     for (const song_data& song : all_songs) {
         song_entry entry;
         entry.song = song;
+        if (const auto it = song_offsets.find(song.meta.song_id); it != song_offsets.end()) {
+            entry.local_note_offset_ms = it->second;
+        }
 
         for (const std::string& chart_path : song.chart_paths) {
             const chart_parse_result parse_result = song_loader::load_chart(chart_path);

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -1,5 +1,8 @@
 #include "song_select/song_select_detail_view.h"
 
+#include <cmath>
+#include <string>
+
 #include "scene_common.h"
 #include "song_select/song_select_layout.h"
 #include "theme.h"
@@ -13,6 +16,21 @@ std::string key_mode_label(int key_count) {
 
 const char* source_label(content_source source) {
     return source == content_source::app_data ? "AppData" : "Legacy";
+}
+
+std::string format_offset_label(int offset_ms) {
+    return (offset_ms > 0 ? "+" : "") + std::to_string(offset_ms) + "ms";
+}
+
+std::string format_recent_offset_label(float offset_ms) {
+    const int rounded_offset = static_cast<int>(std::lround(offset_ms));
+    if (rounded_offset > 0) {
+        return std::to_string(rounded_offset) + "ms";
+    }
+    if (rounded_offset < 0) {
+        return std::to_string(rounded_offset) + "ms";
+    }
+    return "0ms";
 }
 
 }  // namespace
@@ -55,6 +73,9 @@ void draw_song_details(const state& state, const preview_controller& preview_con
     const float content_anim = 1.0f - state.song_change_anim_t;
     const float content_offset_x = 18.0f * state.song_change_anim_t;
     const unsigned char content_alpha = static_cast<unsigned char>(145.0f + 110.0f * content_anim);
+    const int local_offset_ms = song->local_note_offset_ms;
+    const bool has_recent_result = state.recent_result_offset.has_value() &&
+                                   state.recent_result_offset->song_id == song->song.meta.song_id;
 
     ui::draw_section(layout::kJacketRect);
     if (preview_controller.jacket_loaded()) {
@@ -67,8 +88,8 @@ void draw_song_details(const state& state, const preview_controller& preview_con
     }
     DrawRectangleLinesEx(layout::kJacketRect, 2.0f, theme.border_image);
 
-    const float detail_x = layout::kJacketRect.x + layout::kJacketRect.width + 20.0f;
-    const float detail_max_width = layout::kLeftPanelRect.x + layout::kLeftPanelRect.width - detail_x - 16.0f;
+    const float detail_x = layout::kDetailColumnX;
+    const float detail_max_width = layout::kDetailColumnWidth;
     const double now = GetTime();
     draw_marquee_text(song->song.meta.title.c_str(), detail_x + content_offset_x, layout::kJacketRect.y + 4.0f, 40,
                       with_alpha(theme.text, content_alpha), detail_max_width, now);
@@ -87,6 +108,36 @@ void draw_song_details(const state& state, const preview_controller& preview_con
         ui::draw_text_f(selected_chart->meta.chart_author.c_str(), detail_x + content_offset_x,
                         layout::kJacketRect.y + 194.0f, 20, with_alpha(theme.text_muted, content_alpha));
     }
+
+    const std::string local_label = format_offset_label(local_offset_ms);
+    ui::draw_text_in_rect("Local Offset", 20, layout::kLocalOffsetLabelRect,
+                          with_alpha(theme.text, content_alpha), ui::text_align::left);
+
+    const Rectangle controls = layout::kLocalOffsetControlsRect;
+    const Rectangle value_rect = {controls.x, controls.y, 120.0f, controls.height};
+    ui::draw_text_in_rect(local_label.c_str(), 26, value_rect, with_alpha(theme.accent, content_alpha), ui::text_align::left);
+
+    ui::draw_button_colored(layout::local_offset_double_left_rect(), "<<", 18,
+                            with_alpha(theme.row, content_alpha), with_alpha(theme.row_hover, content_alpha),
+                            with_alpha(theme.text, content_alpha));
+    ui::draw_button_colored(layout::local_offset_left_rect(), "<", 18,
+                            with_alpha(theme.row, content_alpha), with_alpha(theme.row_hover, content_alpha),
+                            with_alpha(theme.text, content_alpha));
+    ui::draw_button_colored(layout::local_offset_right_rect(), ">", 18,
+                            with_alpha(theme.row, content_alpha), with_alpha(theme.row_hover, content_alpha),
+                            with_alpha(theme.text, content_alpha));
+    ui::draw_button_colored(layout::local_offset_double_right_rect(), ">>", 18,
+                            with_alpha(theme.row, content_alpha), with_alpha(theme.row_hover, content_alpha),
+                            with_alpha(theme.text, content_alpha));
+
+    const std::string auto_apply_label = has_recent_result
+        ? format_recent_offset_label(state.recent_result_offset->avg_offset_ms)
+        : "-";
+    ui::draw_button_colored(
+        layout::auto_apply_button_rect(), auto_apply_label.c_str(), 18,
+        has_recent_result ? with_alpha(theme.row, content_alpha) : with_alpha(theme.row, 170),
+        has_recent_result ? with_alpha(theme.row_hover, content_alpha) : with_alpha(theme.row, 170),
+        has_recent_result ? with_alpha(theme.text, content_alpha) : with_alpha(theme.text_muted, 210));
 }
 
 void draw_status_message(const state& state) {

--- a/src/scenes/song_select/song_select_layout.h
+++ b/src/scenes/song_select/song_select_layout.h
@@ -12,10 +12,12 @@ inline constexpr ui::draw_layer kSceneLayer = ui::draw_layer::base;
 inline constexpr float kRowHeight = 60.0f;
 inline constexpr float kScrollWheelStep = 80.0f;
 inline constexpr float kScrollLerpSpeed = 12.0f;
+inline constexpr float kOffsetAdjustButtonSize = 34.0f;
+inline constexpr float kAutoApplyButtonWidth = 72.0f;
 inline constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
 inline constexpr Rectangle kSettingsButtonRect = ui::place(kScreenRect, 162.0f, 30.0f,
                                                            ui::anchor::top_right, ui::anchor::top_right,
-                                                           {-24.0f, 8.0f});
+                                                           {-24.0f, 4.0f});
 inline constexpr Rectangle kSongListRect = ui::place(kScreenRect, 466.0f, 660.0f,
                                                      ui::anchor::top_right, ui::anchor::top_right,
                                                      {-24.0f, 44.0f});
@@ -25,6 +27,10 @@ inline constexpr Rectangle kLeftPanelRect = ui::place(kScreenRect, 750.0f, 660.0
 inline constexpr Rectangle kJacketRect = ui::place(kLeftPanelRect, 320.0f, 320.0f,
                                                    ui::anchor::top_left, ui::anchor::top_left,
                                                    {20.0f, 24.0f});
+inline constexpr float kDetailColumnX = kJacketRect.x + kJacketRect.width + 20.0f;
+inline constexpr float kDetailColumnWidth = kLeftPanelRect.x + kLeftPanelRect.width - kDetailColumnX - 16.0f;
+inline constexpr Rectangle kLocalOffsetLabelRect = {kDetailColumnX, kJacketRect.y + 236.0f, kDetailColumnWidth, 22.0f};
+inline constexpr Rectangle kLocalOffsetControlsRect = {kDetailColumnX, kJacketRect.y + 262.0f, kDetailColumnWidth, 34.0f};
 inline constexpr Rectangle kSceneTitleRect = ui::place(kScreenRect, 360.0f, 30.0f,
                                                        ui::anchor::top_left, ui::anchor::top_left,
                                                        {30.0f, 12.0f});
@@ -55,6 +61,40 @@ inline Rectangle make_context_menu_rect(Vector2 anchor, int item_count) {
     rect.x = std::clamp(rect.x, 12.0f, kScreenRect.width - rect.width - 12.0f);
     rect.y = std::clamp(rect.y, 12.0f, kScreenRect.height - rect.height - 12.0f);
     return rect;
+}
+
+inline Rectangle local_offset_double_left_rect() {
+    const Rectangle area = {
+        kLocalOffsetControlsRect.x + 104.0f,
+        kLocalOffsetControlsRect.y,
+        kOffsetAdjustButtonSize * 4.0f + 10.0f * 3.0f,
+        kOffsetAdjustButtonSize
+    };
+    return {area.x, area.y, kOffsetAdjustButtonSize, kOffsetAdjustButtonSize};
+}
+
+inline Rectangle local_offset_left_rect() {
+    const Rectangle left = local_offset_double_left_rect();
+    return {left.x + left.width + 10.0f, left.y, left.width, left.height};
+}
+
+inline Rectangle local_offset_right_rect() {
+    const Rectangle left = local_offset_left_rect();
+    return {left.x + left.width + 10.0f, left.y, left.width, left.height};
+}
+
+inline Rectangle local_offset_double_right_rect() {
+    const Rectangle left = local_offset_right_rect();
+    return {left.x + left.width + 10.0f, left.y, left.width, left.height};
+}
+
+inline Rectangle auto_apply_button_rect() {
+    return {
+        kLocalOffsetControlsRect.x + kLocalOffsetControlsRect.width - kAutoApplyButtonWidth - 16.0f,
+        kLocalOffsetControlsRect.y,
+        kAutoApplyButtonWidth,
+        kOffsetAdjustButtonSize
+    };
 }
 
 }  // namespace song_select::layout

--- a/src/scenes/song_select/song_select_state.cpp
+++ b/src/scenes/song_select/song_select_state.cpp
@@ -52,6 +52,7 @@ void reset_for_enter(state& state) {
     state.confirmation_dialog = {};
     state.status_message.clear();
     state.status_message_is_error = false;
+    state.recent_result_offset.reset();
 }
 
 void tick_animations(state& state, float dt) {

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -18,6 +19,7 @@ struct chart_option {
 struct song_entry {
     song_data song;
     std::vector<chart_option> charts;
+    int local_note_offset_ms = 0;
 };
 
 struct catalog_data {
@@ -52,6 +54,12 @@ struct confirmation_dialog_state {
     int chart_index = -1;
 };
 
+struct recent_result_offset {
+    std::string song_id;
+    std::string chart_id;
+    float avg_offset_ms = 0.0f;
+};
+
 struct state {
     std::vector<song_entry> songs;
     std::vector<std::string> load_errors;
@@ -67,6 +75,7 @@ struct state {
     confirmation_dialog_state confirmation_dialog;
     std::string status_message;
     bool status_message_is_error = false;
+    std::optional<recent_result_offset> recent_result_offset;
 };
 
 const song_entry* selected_song(const state& state);

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -4,6 +4,7 @@
 #include <cmath>
 #include <utility>
 
+#include "player_note_offsets.h"
 #include "raylib.h"
 #include "scene_manager.h"
 #include "song_select/song_select_detail_view.h"
@@ -14,13 +15,27 @@
 #include "ui_draw.h"
 #include "virtual_screen.h"
 
-song_select_scene::song_select_scene(scene_manager& manager, std::string preferred_song_id)
-    : scene(manager), preferred_song_id_(std::move(preferred_song_id)) {
+namespace {
+
+std::string format_offset_label(int offset_ms) {
+    return (offset_ms > 0 ? "+" : "") + std::to_string(offset_ms) + "ms";
+}
+
+}  // namespace
+
+song_select_scene::song_select_scene(scene_manager& manager, std::string preferred_song_id,
+                                     std::string preferred_chart_id,
+                                     std::optional<song_select::recent_result_offset> recent_result_offset)
+    : scene(manager),
+      preferred_song_id_(std::move(preferred_song_id)),
+      preferred_chart_id_(std::move(preferred_chart_id)),
+      recent_result_offset_(std::move(recent_result_offset)) {
 }
 
 void song_select_scene::on_enter() {
     song_select::reset_for_enter(state_);
-    reload_song_library(preferred_song_id_);
+    state_.recent_result_offset = recent_result_offset_;
+    reload_song_library(preferred_song_id_, preferred_chart_id_);
 }
 
 void song_select_scene::on_exit() {
@@ -48,6 +63,42 @@ void song_select_scene::apply_delete_result(const song_select::delete_result& re
 
     reload_song_library(result.preferred_song_id, result.preferred_chart_id);
     song_select::queue_status_message(state_, result.message, false);
+}
+
+bool song_select_scene::adjust_selected_song_local_offset(int delta_ms) {
+    if (state_.selected_song_index < 0 || state_.selected_song_index >= static_cast<int>(state_.songs.size())) {
+        return false;
+    }
+
+    auto& song = state_.songs[static_cast<size_t>(state_.selected_song_index)];
+    const int next_offset = std::clamp(song.local_note_offset_ms + delta_ms, -1000, 1000);
+    if (!save_player_song_offset(song.song.meta.song_id, next_offset)) {
+        song_select::queue_status_message(state_, "Failed to save local offset.", true);
+        return false;
+    }
+
+    song.local_note_offset_ms = next_offset;
+    return true;
+}
+
+bool song_select_scene::apply_recent_result_offset() {
+    if (!state_.recent_result_offset.has_value()) {
+        return false;
+    }
+
+    const song_select::song_entry* selected = song_select::selected_song(state_);
+    if (selected == nullptr || selected->song.meta.song_id != state_.recent_result_offset->song_id) {
+        return false;
+    }
+
+    const int adjustment_ms = static_cast<int>(std::lround(state_.recent_result_offset->avg_offset_ms));
+    if (!adjust_selected_song_local_offset(adjustment_ms)) {
+        return false;
+    }
+
+    state_.recent_result_offset.reset();
+    recent_result_offset_.reset();
+    return true;
 }
 
 bool song_select_scene::handle_song_list_pointer(Vector2 mouse, bool left_pressed, bool right_pressed) {
@@ -232,6 +283,31 @@ void song_select_scene::update(float dt) {
     }
 
     if (state_.songs.empty()) {
+        return;
+    }
+
+    if (ui::is_clicked(song_select::layout::local_offset_double_left_rect(), song_select::layout::kSceneLayer)) {
+        adjust_selected_song_local_offset(-5);
+        return;
+    }
+
+    if (ui::is_clicked(song_select::layout::local_offset_left_rect(), song_select::layout::kSceneLayer)) {
+        adjust_selected_song_local_offset(-1);
+        return;
+    }
+
+    if (ui::is_clicked(song_select::layout::local_offset_right_rect(), song_select::layout::kSceneLayer)) {
+        adjust_selected_song_local_offset(1);
+        return;
+    }
+
+    if (ui::is_clicked(song_select::layout::local_offset_double_right_rect(), song_select::layout::kSceneLayer)) {
+        adjust_selected_song_local_offset(5);
+        return;
+    }
+
+    if (ui::is_clicked(song_select::layout::auto_apply_button_rect(), song_select::layout::kSceneLayer) &&
+        apply_recent_result_offset()) {
         return;
     }
 

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 
 #include "raylib.h"
@@ -11,7 +12,9 @@
 
 class song_select_scene final : public scene {
 public:
-    explicit song_select_scene(scene_manager& manager, std::string preferred_song_id = "");
+    explicit song_select_scene(scene_manager& manager, std::string preferred_song_id = "",
+                               std::string preferred_chart_id = "",
+                               std::optional<song_select::recent_result_offset> recent_result_offset = std::nullopt);
 
     void on_enter() override;
     void on_exit() override;
@@ -23,6 +26,8 @@ private:
                              const std::string& preferred_chart_id = "");
     void sync_selected_song_media();
     void apply_delete_result(const song_select::delete_result& result);
+    bool adjust_selected_song_local_offset(int delta_ms);
+    bool apply_recent_result_offset();
     bool handle_song_list_pointer(Vector2 mouse, bool left_pressed, bool right_pressed);
     void apply_context_menu_command(song_select::context_menu_command command);
     void apply_confirmation_command(song_select::confirmation_command command);
@@ -30,4 +35,6 @@ private:
     song_select::state state_;
     song_select::preview_controller preview_controller_;
     std::string preferred_song_id_;
+    std::string preferred_chart_id_;
+    std::optional<song_select::recent_result_offset> recent_result_offset_;
 };


### PR DESCRIPTION
## 概要
- 設定画面にグローバルノーツオフセットを追加
- 曲選択画面に曲別ローカルオフセットと自動適用UIを追加
- プレイ時に譜面 offset とグローバル/ローカル offset を合算して反映

Closes #125
