### PR TITLE
Installer 経由でも AppData を初期化する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,6 +195,13 @@ add_executable(song_select_state_smoke
         src/scenes/song_select/song_select_state.h
         src/tests/song_select_state_smoke.cpp)
 
+add_executable(settings_io_smoke
+        src/core/app_paths.cpp
+        src/core/app_paths.h
+        src/gameplay/settings_io.cpp
+        src/gameplay/settings_io.h
+        src/tests/settings_io_smoke.cpp)
+
 add_executable(input_handler_smoke
         src/platform/windows_input_source.cpp
         src/platform/windows_input_source.h
@@ -351,6 +358,7 @@ target_include_directories(chart_serializer_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS}
 target_include_directories(editor_state_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(song_loader_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(song_select_state_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(settings_io_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(input_handler_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(timing_engine_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(judge_system_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
@@ -364,6 +372,7 @@ target_include_directories(editor_panel_controller_smoke PRIVATE ${RAYTHM_INCLUD
 target_include_directories(audio_manager_smoke PRIVATE ${RAYTHM_BASS_DIR} ${RAYTHM_INCLUDE_DIRS})
 target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32)
 target_link_libraries(song_select_state_smoke PRIVATE raylib)
+target_link_libraries(settings_io_smoke PRIVATE raylib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
 target_link_libraries(judge_system_smoke PRIVATE raylib)
 target_link_libraries(play_flow_controller_smoke PRIVATE raylib)

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -1,6 +1,7 @@
 #include "app_paths.h"
 
 #include <cstdlib>
+#include <system_error>
 
 #ifdef _WIN32
 #include <windows.h>
@@ -90,9 +91,10 @@ std::filesystem::path song_offsets_path() {
 }
 
 void ensure_directories() {
-    std::filesystem::create_directories(app_data_root());
-    std::filesystem::create_directories(songs_root());
-    std::filesystem::create_directories(charts_root());
+    std::error_code ec;
+    std::filesystem::create_directories(app_data_root(), ec);
+    std::filesystem::create_directories(songs_root(), ec);
+    std::filesystem::create_directories(charts_root(), ec);
 }
 
 }

--- a/src/gameplay/settings_io.cpp
+++ b/src/gameplay/settings_io.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <string>
 #include <string_view>
+#include <system_error>
 
 #include "app_paths.h"
 
@@ -150,6 +151,17 @@ void load_settings(game_settings& settings) {
         parse_key_array(*v, settings.keys.keys_4);
     if (auto v = extract_string(content, "keys6"))
         parse_key_array(*v, settings.keys.keys_6);
+}
+
+void initialize_settings_storage(const game_settings& defaults) {
+    app_paths::ensure_directories();
+
+    std::error_code ec;
+    if (fs::exists(settings_path(), ec) && !ec) {
+        return;
+    }
+
+    save_settings(defaults);
 }
 
 void save_settings(const game_settings& settings) {

--- a/src/gameplay/settings_io.h
+++ b/src/gameplay/settings_io.h
@@ -5,5 +5,8 @@
 // settings.json からゲーム設定を読み込む。ファイルが存在しない場合はデフォルト値のまま。
 void load_settings(game_settings& settings);
 
+// 初回起動向けに AppData と settings.json を用意する。
+void initialize_settings_storage(const game_settings& defaults);
+
 // ゲーム設定を settings.json に書き出す。
 void save_settings(const game_settings& settings);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include "platform/windows_input_source.h"
 
 int main() {
+    initialize_settings_storage(g_settings);
     load_settings(g_settings);
     set_theme(g_settings.dark_mode);
     audio_manager::instance().set_bgm_volume(g_settings.bgm_volume);

--- a/src/tests/settings_io_smoke.cpp
+++ b/src/tests/settings_io_smoke.cpp
@@ -1,0 +1,128 @@
+#include <cmath>
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <system_error>
+
+#include "app_paths.h"
+#include "game_settings.h"
+#include "settings_io.h"
+
+namespace {
+namespace fs = std::filesystem;
+
+bool set_local_app_data(const std::string& value) {
+#ifdef _WIN32
+    return _putenv_s("LOCALAPPDATA", value.c_str()) == 0;
+#else
+    return setenv("LOCALAPPDATA", value.c_str(), 1) == 0;
+#endif
+}
+
+class local_app_data_guard {
+public:
+    explicit local_app_data_guard(const fs::path& path) {
+        if (const char* current = std::getenv("LOCALAPPDATA")) {
+            previous_value_ = current;
+        }
+        active_ = set_local_app_data(path.string());
+    }
+
+    ~local_app_data_guard() {
+        if (!active_) {
+            return;
+        }
+        set_local_app_data(previous_value_);
+    }
+
+    bool active() const {
+        return active_;
+    }
+
+private:
+    std::string previous_value_;
+    bool active_ = false;
+};
+
+void expect(bool condition, const std::string& message, bool& ok) {
+    if (!condition) {
+        std::cerr << message << '\n';
+        ok = false;
+    }
+}
+
+}  // namespace
+
+int main() {
+    const fs::path temp_local_app_data = fs::temp_directory_path() / "raythm_settings_io_smoke";
+
+    std::error_code ec;
+    fs::remove_all(temp_local_app_data, ec);
+    ec.clear();
+    fs::create_directories(temp_local_app_data, ec);
+    if (ec) {
+        std::cerr << "Failed to prepare temporary LOCALAPPDATA root\n";
+        return EXIT_FAILURE;
+    }
+
+    bool ok = true;
+    {
+        local_app_data_guard guard(temp_local_app_data);
+        if (!guard.active()) {
+            std::cerr << "Failed to update LOCALAPPDATA for smoke test\n";
+            return EXIT_FAILURE;
+        }
+
+        game_settings defaults;
+        defaults.camera_angle_degrees = 30.0f;
+        defaults.target_fps = 240;
+        defaults.fullscreen = true;
+        defaults.dark_mode = true;
+
+        initialize_settings_storage(defaults);
+
+        expect(fs::is_directory(app_paths::app_data_root()), "Expected AppData root to be created.", ok);
+        expect(fs::is_directory(app_paths::songs_root()), "Expected songs directory to be created.", ok);
+        expect(fs::is_directory(app_paths::charts_root()), "Expected charts directory to be created.", ok);
+        expect(fs::is_regular_file(app_paths::settings_path()), "Expected settings.json to be created.", ok);
+
+        game_settings loaded;
+        load_settings(loaded);
+        expect(std::fabs(loaded.camera_angle_degrees - defaults.camera_angle_degrees) < 0.001f,
+               "Expected default camera angle to be written to settings.json.",
+               ok);
+        expect(loaded.target_fps == defaults.target_fps,
+               "Expected default target FPS to be written to settings.json.",
+               ok);
+        expect(loaded.fullscreen == defaults.fullscreen,
+               "Expected default fullscreen flag to be written to settings.json.",
+               ok);
+        expect(loaded.dark_mode == defaults.dark_mode,
+               "Expected default dark mode flag to be written to settings.json.",
+               ok);
+
+        game_settings different_defaults = defaults;
+        different_defaults.target_fps = 60;
+        different_defaults.fullscreen = false;
+        initialize_settings_storage(different_defaults);
+
+        game_settings loaded_again;
+        load_settings(loaded_again);
+        expect(loaded_again.target_fps == defaults.target_fps,
+               "Expected existing settings.json not to be overwritten.",
+               ok);
+        expect(loaded_again.fullscreen == defaults.fullscreen,
+               "Expected existing fullscreen setting not to be overwritten.",
+               ok);
+    }
+
+    fs::remove_all(temp_local_app_data, ec);
+
+    if (!ok) {
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "settings_io smoke test passed\n";
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## 概要
- 起動時に AppData 配下のユーザーデータ保存先を初期化する処理を追加
- `settings.json` が存在しない初回起動時はデフォルト設定ファイルも作成
- AppData 初期化を検証する `settings_io_smoke` を追加

## 確認
- `settings_io_smoke` を追加して初回起動時の AppData 初期化を確認できる状態にした

Closes #144
