### PR TITLE
ノーツの終了判定が異常に厳しい問題を修正

### DIFF
--- a/src/gameplay/judge_system.cpp
+++ b/src/gameplay/judge_system.cpp
@@ -36,10 +36,11 @@ void judge_system::update(double current_ms, const input_handler& input) {
                 continue;
             }
 
+            const double release_offset_ms = event.timestamp_ms - state.end_target_ms;
             state.holding = false;
             state.judged = true;
-            state.result = judge_result::miss;
-            emit_judge(judge_result::miss, event.timestamp_ms - state.target_ms, state.note_ref.lane);
+            state.result = evaluate_hold_release_offset(release_offset_ms);
+            emit_judge(state.result, release_offset_ms, state.note_ref.lane);
         }
     }
 
@@ -80,6 +81,10 @@ void judge_system::update(double current_ms, const input_handler& input) {
     }
 
     for (note_state& state : note_states_) {
+        if (state.holding && current_ms >= state.end_target_ms) {
+            state.holding = false;
+        }
+
         if (state.judged) {
             continue;
         }
@@ -124,6 +129,13 @@ judge_result judge_system::evaluate_offset(double offset_ms) const {
         return judge_result::bad;
     }
     return judge_result::miss;
+}
+
+judge_result judge_system::evaluate_hold_release_offset(double offset_ms) const {
+    if (offset_ms >= 0.0) {
+        return judge_result::perfect;
+    }
+    return evaluate_offset(offset_ms);
 }
 
 bool judge_system::is_in_judgement_window(double offset_ms) const {

--- a/src/gameplay/judge_system.h
+++ b/src/gameplay/judge_system.h
@@ -19,6 +19,7 @@ public:
 
 private:
     judge_result evaluate_offset(double offset_ms) const;
+    judge_result evaluate_hold_release_offset(double offset_ms) const;
     bool is_in_judgement_window(double offset_ms) const;
     void emit_judge(judge_result result, double offset_ms, int lane);
 

--- a/src/tests/judge_system_smoke.cpp
+++ b/src/tests/judge_system_smoke.cpp
@@ -56,6 +56,43 @@ int main() {
         std::cerr << "Hold release miss failed\n";
         return EXIT_FAILURE;
     }
+    if (hold_release_judge->offset_ms != -400.0) {
+        std::cerr << "Hold release miss should use end timing offset\n";
+        return EXIT_FAILURE;
+    }
+
+    judge_system hold_release_window_judge;
+    hold_release_window_judge.init({note_data{note_type::hold, 960, 1, 1440}}, engine);
+    input = input_handler();
+    input.set_key_count(4);
+    input.update_from_lane_states(std::array<bool, 4>{false, true, false, false}, 1000.0);
+    hold_release_window_judge.update(1000.0, input);
+
+    input.update_from_lane_states(std::array<bool, 4>{false, false, false, false}, 1390.0);
+    hold_release_window_judge.update(1390.0, input);
+    const std::optional<judge_event> hold_release_bad = hold_release_window_judge.get_last_judge();
+    if (!hold_release_bad.has_value() || hold_release_bad->result != judge_result::bad ||
+        hold_release_bad->offset_ms != -110.0) {
+        std::cerr << "Early hold release should grade within the shared window\n";
+        return EXIT_FAILURE;
+    }
+
+    judge_system hold_release_success_judge;
+    hold_release_success_judge.init({note_data{note_type::hold, 960, 1, 1440}}, engine);
+    input = input_handler();
+    input.set_key_count(4);
+    input.update_from_lane_states(std::array<bool, 4>{false, true, false, false}, 1000.0);
+    hold_release_success_judge.update(1000.0, input);
+    input.update_from_lane_states(std::array<bool, 4>{false, true, false, false}, 1510.0);
+    hold_release_success_judge.update(1510.0, input);
+    if (hold_release_success_judge.get_last_judge().has_value()) {
+        std::cerr << "Holding through the end should not emit an extra judge\n";
+        return EXIT_FAILURE;
+    }
+    if (hold_release_success_judge.note_states().front().holding) {
+        std::cerr << "Hold state should finish once the end timing has passed\n";
+        return EXIT_FAILURE;
+    }
 
     judge_system miss_judge;
     miss_judge.init({note_data{note_type::tap, 480, 0, 480}}, engine);


### PR DESCRIPTION
ロングノーツの終了判定が0msでも早くリリースされたときにMissになっていたので開始判定とどうようの判定ウィンドウを設けた。