### PR TITLE
エディタ再生中のAlt+クリックで停止して移動する

### DIFF
--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -754,8 +754,14 @@ void editor_scene::handle_timeline_interaction() {
     timeline_drag_ = result.drag_state;
 
     if (result.request_seek) {
+        const bool was_playing = audio_playing_;
+        if (was_playing) {
+            audio_manager::instance().pause_bgm();
+            space_playback_start_tick_.reset();
+            sync_transport_state(true);
+        }
         seek_audio_to_tick(result.seek_tick);
-        if (result.scroll_seek_if_paused && !audio_playing_) {
+        if (was_playing || result.scroll_seek_if_paused) {
             scroll_to_tick(playback_tick_);
         }
     }


### PR DESCRIPTION
## 概要
- エディタ再生中に Alt + 左クリック でシークしたとき、再生を停止するよう変更
- 停止後はクリックした tick に移動し、表示位置もそこへ揃えるよう更新
- Space 再生の復帰用に持っている開始位置は、この操作では破棄するよう調整

Closes #152