### PR TITLE
エディタで右クリックしたノートを即削除する

### DIFF
--- a/src/scenes/editor/editor_scene_types.h
+++ b/src/scenes/editor/editor_scene_types.h
@@ -197,6 +197,7 @@ struct editor_timeline_context {
 struct editor_timeline_result {
     std::optional<size_t> selected_note_index;
     editor_timeline_note_drag_state drag_state;
+    std::optional<size_t> note_to_delete_index;
     bool request_seek = false;
     int seek_tick = 0;
     bool scroll_seek_if_paused = false;

--- a/src/scenes/editor/editor_timeline_controller.cpp
+++ b/src/scenes/editor/editor_timeline_controller.cpp
@@ -114,7 +114,13 @@ editor_timeline_result editor_timeline_controller::update(editor_timing_panel_st
     }
 
     if (context.right_pressed) {
-        result.selected_note_index = context.timeline_hovered ? note_at_position(context, context.mouse) : std::nullopt;
+        result.note_to_delete_index = context.timeline_hovered ? note_at_position(context, context.mouse) : std::nullopt;
+        if (result.note_to_delete_index.has_value() &&
+            result.selected_note_index.has_value() &&
+            *result.selected_note_index == *result.note_to_delete_index) {
+            result.selected_note_index.reset();
+        }
+        return result;
     }
 
     if (!context.timeline_hovered) {

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -768,6 +768,11 @@ void editor_scene::handle_timeline_interaction() {
     if (result.request_apply_selected_timing) {
         apply_selected_timing_event();
     }
+    if (result.note_to_delete_index.has_value()) {
+        if (state_->remove_note(*result.note_to_delete_index)) {
+            selected_note_index_.reset();
+        }
+    }
     if (result.note_to_add.has_value()) {
         state_->add_note(*result.note_to_add);
         selected_note_index_ = state_->data().notes.empty()

--- a/src/tests/editor_timeline_controller_smoke.cpp
+++ b/src/tests/editor_timeline_controller_smoke.cpp
@@ -51,8 +51,8 @@ int main() {
             timing_panel,
             {state.get(), &meter_map, metrics, {lane_rect.x + lane_rect.width * 0.5f, y}, true,
              false, false, false, true, false, false, 4, std::nullopt, {}});
-        if (!result.selected_note_index.has_value() || *result.selected_note_index != 0) {
-            std::cerr << "right click should select the note under the cursor\n";
+        if (!result.note_to_delete_index.has_value() || *result.note_to_delete_index != 0) {
+            std::cerr << "right click should request deleting the note under the cursor\n";
             return EXIT_FAILURE;
         }
     }


### PR DESCRIPTION
## 概要
- エディタモードで既存ノートを右クリックした時点で削除要求を返すよう変更
- 実際の削除は editor_state::remove_note(...) 経由にして Undo/Redo の対象を維持
- 右クリックで削除したノートが選択中だった場合は選択状態もリセットするよう調整

Closes #116