### PR TITLE
ノーツ縦幅を設定から調整できるようにする

### DIFF
--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -23,6 +23,7 @@ struct game_settings {
     float camera_angle_degrees = 45.0f;
     float lane_width = 3.5f;
     float note_speed = 0.045f;
+    float note_height = 1.0f;
     int global_note_offset_ms = 0;
     float bgm_volume = 1.0f;
     float se_volume = 1.0f;

--- a/src/gameplay/settings_io.cpp
+++ b/src/gameplay/settings_io.cpp
@@ -16,6 +16,8 @@ namespace {
 namespace fs = std::filesystem;
 constexpr float kMinNoteSpeed = 0.010f;
 constexpr float kMaxNoteSpeed = 0.200f;
+constexpr float kMinNoteHeight = 0.5f;
+constexpr float kMaxNoteHeight = 2.0f;
 
 fs::path settings_path() {
     return app_paths::settings_path();
@@ -132,6 +134,8 @@ void load_settings(game_settings& settings) {
         settings.lane_width = std::clamp(std::stof(*v), 0.6f, 5.0f);
     if (auto v = extract_number_token(content, "noteSpeed"))
         settings.note_speed = std::clamp(std::stof(*v), kMinNoteSpeed, kMaxNoteSpeed);
+    if (auto v = extract_number_token(content, "noteHeight"))
+        settings.note_height = std::clamp(std::stof(*v), kMinNoteHeight, kMaxNoteHeight);
     if (auto v = extract_number_token(content, "globalNoteOffsetMs"))
         settings.global_note_offset_ms = std::clamp(std::stoi(*v), -10000, 10000);
     if (auto v = extract_number_token(content, "bgmVolume"))
@@ -173,6 +177,7 @@ void save_settings(const game_settings& settings) {
     out << "  \"cameraAngle\": " << settings.camera_angle_degrees << ",\n";
     out << "  \"laneWidth\": " << settings.lane_width << ",\n";
     out << "  \"noteSpeed\": " << settings.note_speed << ",\n";
+    out << "  \"noteHeight\": " << settings.note_height << ",\n";
     out << "  \"globalNoteOffsetMs\": " << settings.global_note_offset_ms << ",\n";
     out << "  \"bgmVolume\": " << settings.bgm_volume << ",\n";
     out << "  \"seVolume\": " << settings.se_volume << ",\n";

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -53,6 +53,12 @@ constexpr Rectangle kJudgeFeedbackRect = ui::place(kScreenRect, 320.0f, 42.0f,
                                                    {0.0f, 34.0f});
 constexpr Rectangle kFailureTextRect = ui::place(kScreenRect, 360.0f, 44.0f,
                                                  ui::anchor::center, ui::anchor::center);
+constexpr float kTapNoteBaseHeight = 0.2f;
+constexpr float kTapNoteBaseLength = 0.78f;
+constexpr float kTapNoteWireHeight = 0.22f;
+constexpr float kTapNoteWireLength = 0.82f;
+constexpr float kHoldNoteBaseHeight = 0.12f;
+constexpr float kHoldNoteWireHeight = 0.14f;
 
 float lane_center_x(int lane, int key_count) {
     const float total_width = key_count * g_settings.lane_width + (key_count - 1) * kLaneGap;
@@ -242,18 +248,24 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
                 const float visual_head_z = note_state.holding ? judgement_z : head_z;
                 const float segment_start = std::max(std::min(visual_head_z, tail_z), lane_start_z);
                 const float segment_end = std::min(std::max(head_z, tail_z), lane_end_z);
+                const float hold_height = kHoldNoteBaseHeight * g_settings.note_height;
+                const float hold_wire_height = kHoldNoteWireHeight * g_settings.note_height;
                 if (segment_end > segment_start) {
                     DrawCube({center_x, 0.30f, (segment_start + segment_end) * 0.5f}, g_settings.lane_width * 0.92f,
-                             0.12f, segment_end - segment_start, note_color);
+                             hold_height, segment_end - segment_start, note_color);
                     DrawCubeWires({center_x, 0.30f, (segment_start + segment_end) * 0.5f},
-                                  g_settings.lane_width * 0.94f, 0.14f, segment_end - segment_start + 0.04f,
+                                  g_settings.lane_width * 0.94f, hold_wire_height, segment_end - segment_start + 0.04f,
                                   note_outline);
                 }
             }
 
             if (note_state.note_ref.type == note_type::tap) {
-                DrawCube({center_x, 0.22f, head_z}, g_settings.lane_width * 0.92f, 0.2f, 0.78f, note_color);
-                DrawCubeWires({center_x, 0.22f, head_z}, g_settings.lane_width * 0.92f, 0.22f, 0.82f, note_outline);
+                DrawCube({center_x, 0.22f, head_z}, g_settings.lane_width * 0.92f,
+                         kTapNoteBaseHeight * g_settings.note_height,
+                         kTapNoteBaseLength * g_settings.note_height, note_color);
+                DrawCubeWires({center_x, 0.22f, head_z}, g_settings.lane_width * 0.92f,
+                              kTapNoteWireHeight * g_settings.note_height,
+                              kTapNoteWireLength * g_settings.note_height, note_outline);
             }
         }
     }

--- a/src/scenes/settings/settings_pages.cpp
+++ b/src/scenes/settings/settings_pages.cpp
@@ -14,6 +14,8 @@ namespace {
 constexpr std::array<int, 4> kFrameRateOptions = {120, 144, 240, 0};
 constexpr float kMinNoteSpeed = 0.010f;
 constexpr float kMaxNoteSpeed = 0.200f;
+constexpr float kMinNoteHeight = 0.5f;
+constexpr float kMaxNoteHeight = 2.0f;
 constexpr float kNoteSpeedDisplayScale = 10.0f;
 
 std::string format_offset_label(int offset_ms) {
@@ -41,6 +43,8 @@ void settings_gameplay_page::update() {
             active_slider_ = slider::camera_angle;
         } else if (ui::is_hovered(settings::kGeneralRows[2], settings::kLayer)) {
             active_slider_ = slider::lane_width;
+        } else if (ui::is_hovered(settings::kGeneralRows[3], settings::kLayer)) {
+            active_slider_ = slider::note_height;
         }
     }
 
@@ -54,36 +58,42 @@ void settings_gameplay_page::update() {
         } else if (active_slider_ == slider::lane_width) {
             const float ratio = settings::slider_ratio_from_mouse(settings::kGeneralRows[2]);
             settings_.lane_width = 0.6f + ratio * (10.0f - 0.6f);
+        } else if (active_slider_ == slider::note_height) {
+            const float ratio = settings::slider_ratio_from_mouse(settings::kGeneralRows[3]);
+            settings_.note_height = kMinNoteHeight + ratio * (kMaxNoteHeight - kMinNoteHeight);
         }
     }
 
-    if (ui::is_clicked(settings::double_arrow_left_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+    if (ui::is_clicked(settings::double_arrow_left_rect(settings::kGeneralRows[4]), settings::kLayer)) {
         settings_.global_note_offset_ms = std::max(-10000, settings_.global_note_offset_ms - 5);
-    } else if (ui::is_clicked(settings::single_arrow_left_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+    } else if (ui::is_clicked(settings::single_arrow_left_rect(settings::kGeneralRows[4]), settings::kLayer)) {
         settings_.global_note_offset_ms = std::max(-10000, settings_.global_note_offset_ms - 1);
-    } else if (ui::is_clicked(settings::single_arrow_right_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+    } else if (ui::is_clicked(settings::single_arrow_right_rect(settings::kGeneralRows[4]), settings::kLayer)) {
         settings_.global_note_offset_ms = std::min(10000, settings_.global_note_offset_ms + 1);
-    } else if (ui::is_clicked(settings::double_arrow_right_rect(settings::kGeneralRows[3]), settings::kLayer)) {
+    } else if (ui::is_clicked(settings::double_arrow_right_rect(settings::kGeneralRows[4]), settings::kLayer)) {
         settings_.global_note_offset_ms = std::min(10000, settings_.global_note_offset_ms + 5);
     }
 }
 
 void settings_gameplay_page::draw() const {
-    const char* labels[] = {"Note Speed", "Camera Angle", "Lane Width"};
+    const char* labels[] = {"Note Speed", "Camera Angle", "Lane Width", "Note Height"};
     const std::string values[] = {
         TextFormat("%.1f", settings_.note_speed * kNoteSpeedDisplayScale),
         TextFormat("%.0f deg", settings_.camera_angle_degrees),
         TextFormat("%.1f", settings_.lane_width),
+        TextFormat("%.2f", settings_.note_height),
     };
 
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 4; ++i) {
         float ratio = 0.0f;
         if (i == 0) {
             ratio = (settings_.note_speed - kMinNoteSpeed) / (kMaxNoteSpeed - kMinNoteSpeed);
         } else if (i == 1) {
             ratio = (settings_.camera_angle_degrees - 5.0f) / (90.0f - 5.0f);
-        } else {
+        } else if (i == 2) {
             ratio = (settings_.lane_width - 0.6f) / (10.0f - 0.6f);
+        } else {
+            ratio = (settings_.note_height - kMinNoteHeight) / (kMaxNoteHeight - kMinNoteHeight);
         }
         ui::draw_slider_relative(settings::kGeneralRows[static_cast<std::size_t>(i)], labels[i], values[i].c_str(),
                                  settings::clamp01(ratio), settings::kSliderLeftInset, settings::kSliderRightInset,
@@ -91,7 +101,7 @@ void settings_gameplay_page::draw() const {
     }
 
     const std::string global_offset_label = format_offset_label(settings_.global_note_offset_ms);
-    const ui::row_state offset_row = ui::draw_row(settings::kGeneralRows[3], g_theme->row, g_theme->row_hover, g_theme->border);
+    const ui::row_state offset_row = ui::draw_row(settings::kGeneralRows[4], g_theme->row, g_theme->row_hover, g_theme->border);
     const Rectangle content = ui::inset(offset_row.visual, ui::edge_insets::symmetric(0.0f, 18.0f));
     const ui::rect_pair columns = ui::split_columns(content, 200.0f);
     const Rectangle button_group = ui::place(columns.second, settings::kArrowButtonSize * 4.0f + 30.0f,
@@ -106,10 +116,10 @@ void settings_gameplay_page::draw() const {
 
     ui::draw_text_in_rect("Global Offset", 22, columns.first, g_theme->text, ui::text_align::left);
     ui::draw_text_in_rect(global_offset_label.c_str(), 22, value_rect, g_theme->text_dim, ui::text_align::right);
-    ui::draw_button(settings::double_arrow_left_rect(settings::kGeneralRows[3]), "<<", 22);
-    ui::draw_button(settings::single_arrow_left_rect(settings::kGeneralRows[3]), "<", 22);
-    ui::draw_button(settings::single_arrow_right_rect(settings::kGeneralRows[3]), ">", 22);
-    ui::draw_button(settings::double_arrow_right_rect(settings::kGeneralRows[3]), ">>", 22);
+    ui::draw_button(settings::double_arrow_left_rect(settings::kGeneralRows[4]), "<<", 22);
+    ui::draw_button(settings::single_arrow_left_rect(settings::kGeneralRows[4]), "<", 22);
+    ui::draw_button(settings::single_arrow_right_rect(settings::kGeneralRows[4]), ">", 22);
+    ui::draw_button(settings::double_arrow_right_rect(settings::kGeneralRows[4]), ">>", 22);
 }
 
 settings_audio_page::settings_audio_page(game_settings& settings, const settings_runtime_applier& runtime_applier)

--- a/src/scenes/settings/settings_pages.h
+++ b/src/scenes/settings/settings_pages.h
@@ -13,7 +13,7 @@ public:
     void draw() const;
 
 private:
-    enum class slider { none, note_speed, camera_angle, lane_width };
+    enum class slider { none, note_speed, camera_angle, lane_width, note_height };
 
     game_settings& settings_;
     slider active_slider_ = slider::none;

--- a/src/tests/settings_io_smoke.cpp
+++ b/src/tests/settings_io_smoke.cpp
@@ -76,6 +76,7 @@ int main() {
 
         game_settings defaults;
         defaults.camera_angle_degrees = 30.0f;
+        defaults.note_height = 1.4f;
         defaults.target_fps = 240;
         defaults.fullscreen = true;
         defaults.dark_mode = true;
@@ -91,6 +92,9 @@ int main() {
         load_settings(loaded);
         expect(std::fabs(loaded.camera_angle_degrees - defaults.camera_angle_degrees) < 0.001f,
                "Expected default camera angle to be written to settings.json.",
+               ok);
+        expect(std::fabs(loaded.note_height - defaults.note_height) < 0.001f,
+               "Expected default note height to be written to settings.json.",
                ok);
         expect(loaded.target_fps == defaults.target_fps,
                "Expected default target FPS to be written to settings.json.",


### PR DESCRIPTION
## 概要
- ノーツ縦幅を設定から調整できるようにした
- Gameplay 設定ページに Note Height スライダーを追加
- settings.json の保存/読込と設定 smoke test を更新

## 確認
- ビルドは未実施
