### PR TITLE
起動時のWindowsコンソール表示をなくす

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ if(WIN32)
             "${RAYTHM_APP_ICON_RC}" @ONLY)
 endif()
 
-add_executable(raythm src/main.cpp
+add_executable(raythm WIN32 src/main.cpp
         src/audio/audio.cpp
         src/audio/audio.h
         src/audio/audio_manager.cpp


### PR DESCRIPTION
## 概要
- Windows で 
raythm を GUI サブシステムとしてビルドするよう変更
- .exe 直接起動時に黒いコンソールウィンドウが出ないように修正

## 確認
- ビルド未実施

Closes #135