### PR TITLE
フルスクリーン中でもBrowseダイアログを前面表示できるようにする

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,8 @@ add_executable(raythm src/main.cpp
         src/core/app_paths.h
         src/core/file_dialog.cpp
         src/core/file_dialog.h
+        src/core/window_dialog_support.cpp
+        src/core/window_dialog_support.h
         src/core/scene.cpp
         src/core/scene.h
         src/core/scene_manager.cpp

--- a/src/core/file_dialog.cpp
+++ b/src/core/file_dialog.cpp
@@ -1,7 +1,7 @@
 #include "file_dialog.h"
 
-#include "raylib.h"
 #include "path_utils.h"
+#include "window_dialog_support.h"
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -24,15 +24,15 @@ namespace {
 
 class fullscreen_dialog_guard {
 public:
-    fullscreen_dialog_guard() : was_fullscreen_(IsWindowFullscreen()) {
+    fullscreen_dialog_guard() : was_fullscreen_(window_dialog_support::is_fullscreen()) {
         if (was_fullscreen_) {
-            ToggleFullscreen();
+            window_dialog_support::toggle_fullscreen();
         }
     }
 
     ~fullscreen_dialog_guard() {
         if (was_fullscreen_) {
-            ToggleFullscreen();
+            window_dialog_support::toggle_fullscreen();
         }
     }
 
@@ -46,7 +46,7 @@ std::string open_file_dialog(const wchar_t* filter, const wchar_t* title) {
 
     OPENFILENAMEW ofn = {};
     ofn.lStructSize = sizeof(ofn);
-    ofn.hwndOwner = static_cast<HWND>(GetWindowHandle());
+    ofn.hwndOwner = static_cast<HWND>(window_dialog_support::native_window_handle());
     ofn.lpstrFilter = filter;
     ofn.lpstrFile = file_name;
     ofn.nMaxFile = MAX_PATH;

--- a/src/core/window_dialog_support.cpp
+++ b/src/core/window_dialog_support.cpp
@@ -1,0 +1,19 @@
+#include "window_dialog_support.h"
+
+#include "raylib.h"
+
+namespace window_dialog_support {
+
+bool is_fullscreen() {
+    return IsWindowFullscreen();
+}
+
+void toggle_fullscreen() {
+    ToggleFullscreen();
+}
+
+void* native_window_handle() {
+    return GetWindowHandle();
+}
+
+}  // namespace window_dialog_support

--- a/src/core/window_dialog_support.h
+++ b/src/core/window_dialog_support.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace window_dialog_support {
+
+bool is_fullscreen();
+void toggle_fullscreen();
+void* native_window_handle();
+
+}  // namespace window_dialog_support


### PR DESCRIPTION
## 概要
- Windows のファイルダイアログをゲームウィンドウの owner 付きで開くよう修正
- フルスクリーン中はダイアログ表示前後だけ一時的にウィンドウモードへ戻すよう変更
- 曲追加フローの Browse ダイアログが背面に隠れないように改善

Closes #118