### PR TITLE
Add song後はそのままエディタへ入れるようにする

### DIFF
--- a/src/scenes/song_create_scene.cpp
+++ b/src/scenes/song_create_scene.cpp
@@ -110,7 +110,6 @@ void song_create_scene::update(float dt) {
     switch (current_step_) {
         case step::song_metadata: update_song_metadata(); break;
         case step::song_saved: update_song_saved(); break;
-        case step::chart_metadata: update_chart_metadata(); break;
     }
 }
 
@@ -124,10 +123,6 @@ void song_create_scene::draw() {
         case step::song_saved:
             content_title = "Song Created";
             content_subtitle = "Choose the next action";
-            break;
-        case step::chart_metadata:
-            content_title = "New Chart";
-            content_subtitle = "Enter chart metadata";
             break;
     }
 
@@ -144,10 +139,6 @@ void song_create_scene::draw() {
         case step::song_saved:
             ui::draw_section(kDecisionCardRect);
             draw_song_saved();
-            break;
-        case step::chart_metadata:
-            ui::draw_section(kChartCardRect);
-            draw_chart_metadata();
             break;
     }
 
@@ -168,13 +159,6 @@ void song_create_scene::update_song_saved() {
     if (IsKeyPressed(KEY_ESCAPE)) {
         go_back_to_song_select(created_song_.meta.song_id);
         return;
-    }
-}
-
-void song_create_scene::update_chart_metadata() {
-    if (IsKeyPressed(KEY_ESCAPE)) {
-        current_step_ = step::song_saved;
-        error_.clear();
     }
 }
 
@@ -289,51 +273,6 @@ void song_create_scene::draw_song_saved() {
     }
 }
 
-void song_create_scene::draw_chart_metadata() {
-    int row = 0;
-
-    ui::draw_text_input(make_row(row++), difficulty_input_, "Difficulty", "Normal",
-                        "Normal", kLayer, 16, 32, wide_text_filter, 120.0f);
-
-    {
-        const Rectangle key_row = make_row(row++);
-        const ui::selector_state sel = ui::draw_value_selector(
-            key_row, "Key Mode", key_count_label(chart_key_count_).c_str(),
-            16, 26.0f, 120.0f, 12.0f);
-
-        if (sel.left.clicked || sel.right.clicked) {
-            chart_key_count_ = (chart_key_count_ == 4) ? 6 : 4;
-        }
-    }
-
-    ui::draw_text_input(make_row(row++), level_input_, "Level", "0.0",
-                        "0.0", kLayer, 16, 4, numeric_filter, 120.0f);
-
-    ui::draw_text_input(make_row(row++), chart_author_input_, "Author", "Your name",
-                        nullptr, kLayer, 16, 64, wide_text_filter, 120.0f);
-
-    const float button_y = kFormStartY + static_cast<float>(row) * (kRowHeight + kRowGap) + 16.0f;
-    constexpr float kButtonWidth = 220.0f;
-    constexpr float kButtonHeight = 44.0f;
-    const Rectangle create_rect = {kFormX + kFormWidth - kButtonWidth, button_y, kButtonWidth, kButtonHeight};
-    const Rectangle back_rect = {kFormX + kFormWidth - kButtonWidth * 2.0f - 12.0f, button_y, kButtonWidth, kButtonHeight};
-
-    if (ui::draw_button(create_rect, "CREATE & OPEN EDITOR", 14).clicked) {
-        if (create_chart_and_open_editor()) {
-            return;
-        }
-    }
-
-    if (ui::draw_button(back_rect, "BACK", 16).clicked) {
-        current_step_ = step::song_saved;
-        error_.clear();
-    }
-
-    if (!error_.empty()) {
-        const Rectangle error_rect = {kFormX, button_y + kButtonHeight + 12.0f, kFormWidth, 24.0f};
-        ui::draw_text_in_rect(error_.c_str(), 14, error_rect, g_theme->error, ui::text_align::left);
-    }
-}
 
 bool song_create_scene::create_song() {
     if (title_input_.value.empty()) {
@@ -540,38 +479,6 @@ bool song_create_scene::save_song_edits() {
     created_song_ = *editing_song_;
     error_.clear();
     go_back_to_song_select(meta.song_id);
-    return true;
-}
-
-bool song_create_scene::create_chart_and_open_editor() {
-    if (difficulty_input_.value.empty()) {
-        error_ = "Difficulty is required.";
-        return false;
-    }
-
-    float level = 0.0f;
-    if (!level_input_.value.empty()) {
-        try {
-            level = std::stof(level_input_.value);
-        } catch (...) {
-            error_ = "Invalid level value.";
-            return false;
-        }
-    }
-
-    chart_meta meta;
-    meta.chart_id = generate_uuid();
-    meta.song_id = created_song_.meta.song_id;
-    meta.key_count = chart_key_count_;
-    meta.difficulty = difficulty_input_.value;
-    meta.level = level;
-    meta.chart_author = chart_author_input_.value;
-    meta.is_public = false;
-    meta.format_version = 3;
-    meta.resolution = 1920;
-    meta.offset = 0;
-
-    manager_.change_scene(std::make_unique<editor_scene>(manager_, created_song_, meta));
     return true;
 }
 

--- a/src/scenes/song_create_scene.h
+++ b/src/scenes/song_create_scene.h
@@ -17,19 +17,16 @@ public:
     void draw() override;
 
 private:
-    enum class step { song_metadata, song_saved, chart_metadata };
+    enum class step { song_metadata, song_saved };
 
     void update_song_metadata();
     void update_song_saved();
-    void update_chart_metadata();
 
     void draw_song_metadata();
     void draw_song_saved();
-    void draw_chart_metadata();
 
     bool create_song();
     bool save_song_edits();
-    bool create_chart_and_open_editor();
     void go_back_to_song_select(const std::string& preferred_song_id = "");
     bool is_edit_mode() const;
 
@@ -45,12 +42,6 @@ private:
     ui::text_input_state sns_youtube_input_;
     ui::text_input_state sns_niconico_input_;
     ui::text_input_state sns_x_input_;
-
-    // Chart metadata inputs
-    ui::text_input_state difficulty_input_;
-    ui::text_input_state level_input_;
-    ui::text_input_state chart_author_input_;
-    int chart_key_count_ = 4;
 
     // Created song data (stored after song creation)
     song_data created_song_;


### PR DESCRIPTION
## 概要
- Add song 完了後の ADD CHART で新規エディタを直接開くよう変更
- 使われなくなった chart metadata 作成ステップと関連 UI を削除

Closes #116