### PR TITLE
曲0件でも New Song ボタンを表示

### DIFF
--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -407,9 +407,11 @@ void song_select_scene::draw() {
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, theme.bg, theme.bg_alt);
     ui::begin_draw_queue();
     song_select::draw_frame();
+    song_select::draw_song_list(state_);
 
     if (state_.songs.empty()) {
         song_select::draw_empty_state(state_);
+        song_select::draw_status_message(state_);
         ui::flush_draw_queue();
         virtual_screen::end();
         ClearBackground(BLACK);
@@ -418,7 +420,6 @@ void song_select_scene::draw() {
     }
 
     song_select::draw_song_details(state_, preview_controller_);
-    song_select::draw_song_list(state_);
     song_select::draw_status_message(state_);
     apply_context_menu_command(song_select::draw_context_menu(state_));
     apply_confirmation_command(song_select::draw_confirmation_dialog(state_));


### PR DESCRIPTION
## 概要
- 曲が0件のときも song select のリスト領域を描画するよう修正
- empty state でも右上の NEW SONG ボタンとステータスメッセージが表示されるよう調整

## 確認
- cmake --build cmake-build-codex --target raythm -j 2

Closes #117