### PR TITLE
フェードイン・アウト処理を共通化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -200,6 +200,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/play/play_session_types.h
         src/scenes/result_scene.cpp
         src/scenes/result_scene.h
+        src/scenes/shared/scene_fade.cpp
+        src/scenes/shared/scene_fade.h
         src/scenes/settings/settings_key_config_state.cpp
         src/scenes/settings/settings_key_config_state.h
         src/scenes/settings/settings_layout.h

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -86,7 +86,7 @@ void result_scene::return_to_song_select() const {
 }
 
 void result_scene::update(float dt) {
-    fade_in_timer_ = std::max(0.0f, fade_in_timer_ - dt);
+    fade_in_.update(dt);
 
     if (IsKeyPressed(KEY_ENTER)) {
         return_to_song_select();
@@ -209,10 +209,7 @@ void result_scene::draw() {
     }
 
     // フェードイン（暗い状態から明るくなる）
-    if (fade_in_timer_ > 0.0f) {
-        const unsigned char alpha = static_cast<unsigned char>(std::min(fade_in_timer_, 1.0f) * 0.65f * 255.0f);
-        DrawRectangle(0, 0, kScreenWidth, kScreenHeight, {0, 0, 0, alpha});
-    }
+    fade_in_.draw();
 
     virtual_screen::end();
     ClearBackground(BLACK);

--- a/src/scenes/result_scene.h
+++ b/src/scenes/result_scene.h
@@ -5,6 +5,7 @@
 #include "data_models.h"
 #include "scene.h"
 #include "score_system.h"
+#include "shared/scene_fade.h"
 
 // リザルト画面。プレイ終了後のスコア・ランク・判定内訳を表示する。
 class result_scene final : public scene {
@@ -24,5 +25,5 @@ private:
     std::string chart_path_;
     chart_meta chart_;
     int key_count_ = 4;
-    float fade_in_timer_ = 1.0f;
+    scene_fade fade_in_{scene_fade::direction::in, 1.0f, 0.65f};
 };

--- a/src/scenes/shared/scene_fade.cpp
+++ b/src/scenes/shared/scene_fade.cpp
@@ -1,0 +1,55 @@
+#include "shared/scene_fade.h"
+
+scene_fade::scene_fade(direction mode, float duration_seconds, float max_alpha) {
+    restart(mode, duration_seconds, max_alpha);
+}
+
+void scene_fade::restart(direction mode, float duration_seconds, float max_alpha) {
+    mode_ = mode;
+    duration_seconds_ = std::max(0.0f, duration_seconds);
+    elapsed_seconds_ = 0.0f;
+    max_alpha_ = std::clamp(max_alpha, 0.0f, 1.0f);
+}
+
+void scene_fade::update(float dt) {
+    elapsed_seconds_ = std::min(duration_seconds_, elapsed_seconds_ + std::max(0.0f, dt));
+}
+
+bool scene_fade::active() const {
+    return alpha_scale() > 0.0f;
+}
+
+bool scene_fade::complete() const {
+    return elapsed_seconds_ >= duration_seconds_;
+}
+
+float scene_fade::progress() const {
+    if (duration_seconds_ <= 0.0f) {
+        return 1.0f;
+    }
+    return std::clamp(elapsed_seconds_ / duration_seconds_, 0.0f, 1.0f);
+}
+
+float scene_fade::alpha_scale() const {
+    const float fade_progress = progress();
+    if (mode_ == direction::in) {
+        return std::max(0.0f, (1.0f - fade_progress) * max_alpha_);
+    }
+    return std::min(1.0f, fade_progress * max_alpha_);
+}
+
+Color scene_fade::overlay_color() const {
+    return {
+        0,
+        0,
+        0,
+        static_cast<unsigned char>(std::clamp(alpha_scale(), 0.0f, 1.0f) * 255.0f)
+    };
+}
+
+void scene_fade::draw() const {
+    if (!active()) {
+        return;
+    }
+    ui::draw_fullscreen_overlay(overlay_color());
+}

--- a/src/scenes/shared/scene_fade.h
+++ b/src/scenes/shared/scene_fade.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <algorithm>
+
+#include "raylib.h"
+#include "ui_draw.h"
+
+class scene_fade final {
+public:
+    enum class direction {
+        in,
+        out,
+    };
+
+    scene_fade() = default;
+    scene_fade(direction mode, float duration_seconds, float max_alpha = 0.65f);
+
+    void restart(direction mode, float duration_seconds, float max_alpha = 0.65f);
+    void update(float dt);
+
+    [[nodiscard]] bool active() const;
+    [[nodiscard]] bool complete() const;
+    [[nodiscard]] float progress() const;
+    [[nodiscard]] float alpha_scale() const;
+    [[nodiscard]] Color overlay_color() const;
+
+    void draw() const;
+
+private:
+    direction mode_ = direction::in;
+    float duration_seconds_ = 0.0f;
+    float elapsed_seconds_ = 0.0f;
+    float max_alpha_ = 0.65f;
+};

--- a/src/scenes/song_select/song_select_state.cpp
+++ b/src/scenes/song_select/song_select_state.cpp
@@ -45,7 +45,7 @@ void reset_for_enter(state& state) {
     state.scroll_y = 0.0f;
     state.scroll_y_target = 0.0f;
     state.song_change_anim_t = 1.0f;
-    state.scene_fade_in_t = 1.0f;
+    state.scene_fade_in.restart(scene_fade::direction::in, 0.3f, 0.65f);
     state.scrollbar_dragging = false;
     state.scrollbar_drag_offset = 0.0f;
     state.context_menu = {};
@@ -57,7 +57,7 @@ void reset_for_enter(state& state) {
 
 void tick_animations(state& state, float dt) {
     state.song_change_anim_t = std::max(0.0f, state.song_change_anim_t - dt * 4.0f);
-    state.scene_fade_in_t = std::max(0.0f, state.scene_fade_in_t - dt / 0.3f);
+    state.scene_fade_in.update(dt);
 }
 
 void apply_catalog(state& state, catalog_data catalog,

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -6,6 +6,7 @@
 
 #include "data_models.h"
 #include "raylib.h"
+#include "shared/scene_fade.h"
 
 namespace song_select {
 
@@ -69,7 +70,7 @@ struct state {
     float scroll_y = 0.0f;
     float scroll_y_target = 0.0f;
     float song_change_anim_t = 0.0f;
-    float scene_fade_in_t = 1.0f;
+    scene_fade scene_fade_in{scene_fade::direction::in, 0.3f, 0.65f};
     bool scrollbar_dragging = false;
     float scrollbar_drag_offset = 0.0f;
     context_menu_state context_menu;

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -425,10 +425,7 @@ void song_select_scene::draw() {
     apply_confirmation_command(song_select::draw_confirmation_dialog(state_));
     ui::flush_draw_queue();
 
-    if (state_.scene_fade_in_t > 0.0f) {
-        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
-                      Color{0, 0, 0, static_cast<unsigned char>(state_.scene_fade_in_t * 0.65f * 255.0f)});
-    }
+    state_.scene_fade_in.draw();
 
     virtual_screen::end();
 

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -50,16 +50,16 @@ void title_scene::update(float dt) {
     spectrum_visualizer_.update();
 
     if (transitioning_to_song_select_) {
-        transition_fade_t_ = std::min(1.0f, transition_fade_t_ + dt / 0.3f);
-        if (transition_fade_t_ >= 1.0f) {
+        transition_fade_.update(dt);
+        if (transition_fade_.complete()) {
             manager_.change_scene(std::make_unique<song_select_scene>(manager_));
         }
         return;
     }
 
     if (quitting_) {
-        quit_fade_t_ = std::min(1.0f, quit_fade_t_ + dt / 1.5f);
-        if (quit_fade_t_ >= 1.0f) {
+        quit_fade_.update(dt);
+        if (quit_fade_.complete()) {
             CloseWindow();
         }
         return;
@@ -67,7 +67,7 @@ void title_scene::update(float dt) {
 
     if (IsKeyPressed(KEY_ENTER)) {
         transitioning_to_song_select_ = true;
-        transition_fade_t_ = 0.0f;
+        transition_fade_.restart(scene_fade::direction::out, 0.3f, 0.65f);
         return;
     }
 
@@ -76,7 +76,7 @@ void title_scene::update(float dt) {
         if (esc_hold_t_ >= 0.3f) {
             esc_hold_t_ = 0.0f;
             quitting_ = true;
-            quit_fade_t_ = 0.0f;
+            quit_fade_.restart(scene_fade::direction::out, 1.5f, 1.0f);
         }
     } else {
         esc_hold_t_ = 0.0f;
@@ -98,12 +98,10 @@ void title_scene::draw() {
     ui::draw_text_in_rect("ENTER: Song Select", 22, hint_rows[0], t.text_muted, ui::text_align::left);
     ui::draw_text_in_rect("ESC: Quit", 22, hint_rows[1], t.text_muted, ui::text_align::left);
     if (transitioning_to_song_select_) {
-        ui::draw_fullscreen_overlay(
-            Color{0, 0, 0, static_cast<unsigned char>(std::min(0.65f, transition_fade_t_ * 0.65f) * 255.0f)});
+        transition_fade_.draw();
     }
     if (quitting_) {
-        ui::draw_fullscreen_overlay(
-            Color{0, 0, 0, static_cast<unsigned char>(std::min(1.0f, quit_fade_t_) * 255.0f)});
+        quit_fade_.draw();
     }
     virtual_screen::end();
 

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "scene.h"
+#include "shared/scene_fade.h"
 #include "title/title_bgm_controller.h"
 #include "title/title_spectrum_visualizer.h"
 
@@ -16,10 +17,10 @@ public:
 
 private:
     bool quitting_ = false;
-    float quit_fade_t_ = 0.0f;
+    scene_fade quit_fade_{scene_fade::direction::out, 1.5f, 1.0f};
     float esc_hold_t_ = 0.0f;
     bool transitioning_to_song_select_ = false;
-    float transition_fade_t_ = 0.0f;
+    scene_fade transition_fade_{scene_fade::direction::out, 0.3f, 0.65f};
     title_bgm_controller bgm_controller_;
     title_spectrum_visualizer spectrum_visualizer_;
 };


### PR DESCRIPTION
## 概要
- scene 用の黒フェードを scene_fade コンポーネントとして追加
- 	itle_scene の遷移フェードと終了フェードを共通化
- song_select_scene と esult_scene のフェードインを共通化

## 確認
- cmake --build cmake-build-codex --target raythm -j 2

## 補足
- play_scene の intro / failure / result 演出フェードは用途が別なので今回は対象外

Closes #154