### PR TITLE
スコア計算にコンボ重みを導入

### DIFF
--- a/src/gameplay/score_system.cpp
+++ b/src/gameplay/score_system.cpp
@@ -43,11 +43,32 @@ int base_score(judge_result result) {
 
     return 0;
 }
+
+double combo_score_multiplier(int combo, int total_notes) {
+    if (total_notes <= 0) {
+        return 1.0;
+    }
+
+    const double progress = std::clamp(static_cast<double>(combo) / static_cast<double>(total_notes), 0.0, 1.0);
+    return progress * progress;
+}
+
+double max_raw_score_for_total_notes(int total_notes) {
+    if (total_notes <= 0) {
+        return 0.0;
+    }
+
+    double max_score = 0.0;
+    for (int combo = 1; combo <= total_notes; ++combo) {
+        max_score += static_cast<double>(kPerfectBase) * combo_score_multiplier(combo, total_notes);
+    }
+    return max_score;
+}
 }
 
 void score_system::init(int total_notes) {
     total_notes_ = std::max(total_notes, 0);
-    score_ = 0;
+    raw_score_ = 0.0;
     combo_ = 0;
     max_combo_ = 0;
     judge_counts_.fill(0);
@@ -76,12 +97,11 @@ void score_system::on_judge(const judge_event& event) {
     }
 
     const int raw = base_score(event.result);
-    const double combo_bonus = 1.0 + std::min(combo_, 100) * 0.002;
-    score_ += static_cast<int>(raw * combo_bonus);
+    raw_score_ += static_cast<double>(raw) * combo_score_multiplier(combo_, total_notes_);
 }
 
 int score_system::get_score() const {
-    return score_;
+    return normalized_score();
 }
 
 int score_system::get_combo() const {
@@ -104,7 +124,7 @@ float score_system::get_live_accuracy() const {
 
 result_data score_system::get_result_data() const {
     result_data result;
-    result.score = score_;
+    result.score = normalized_score();
     result.judge_counts = judge_counts_;
     result.max_combo = max_combo_;
     result.avg_offset = judged_notes_ > 0 ? static_cast<float>(offset_sum_ / static_cast<double>(judged_notes_)) : 0.0f;
@@ -130,13 +150,17 @@ result_data score_system::get_result_data() const {
         result.clear_rank = rank::f;
     }
 
-    if (total_notes_ > 0) {
-        const double normalized = static_cast<double>(score_) /
-                                  static_cast<double>(total_notes_ * static_cast<int>(kPerfectBase * 1.2));
-        result.score = static_cast<int>(std::clamp(normalized, 0.0, 1.0) * kMaxScore);
+    return result;
+}
+
+int score_system::normalized_score() const {
+    const double max_raw_score = max_raw_score_for_total_notes(total_notes_);
+    if (max_raw_score <= 0.0) {
+        return 0;
     }
 
-    return result;
+    const double normalized = raw_score_ / max_raw_score;
+    return static_cast<int>(std::clamp(normalized, 0.0, 1.0) * kMaxScore);
 }
 
 void gauge::on_judge(judge_result result) {

--- a/src/gameplay/score_system.h
+++ b/src/gameplay/score_system.h
@@ -14,7 +14,9 @@ public:
     result_data get_result_data() const;
 
 private:
-    int score_ = 0;
+    int normalized_score() const;
+
+    double raw_score_ = 0.0;
     int combo_ = 0;
     int max_combo_ = 0;
     std::array<int, 5> judge_counts_ = {};

--- a/src/tests/score_system_smoke.cpp
+++ b/src/tests/score_system_smoke.cpp
@@ -67,10 +67,12 @@ int main() {
 
     score_system fc_s_rank;
     fc_s_rank.init(20);
-    for (int i = 0; i < 19; ++i) {
+    for (int i = 0; i < 16; ++i) {
         fc_s_rank.on_judge({judge_result::perfect, 0.0, 0});
     }
-    fc_s_rank.on_judge({judge_result::great, 0.0, 0});
+    for (int i = 0; i < 4; ++i) {
+        fc_s_rank.on_judge({judge_result::great, 0.0, 0});
+    }
     if (fc_s_rank.get_result_data().clear_rank != rank::s) {
         std::cerr << "Full combo 95%+ should be rank S\n";
         return EXIT_FAILURE;
@@ -78,13 +80,31 @@ int main() {
 
     score_system non_fc_high_accuracy;
     non_fc_high_accuracy.init(100);
-    for (int i = 0; i < 99; ++i) {
+    for (int i = 0; i < 50; ++i) {
         non_fc_high_accuracy.on_judge({judge_result::perfect, 0.0, 0});
     }
     non_fc_high_accuracy.on_judge({judge_result::miss, 0.0, 0});
+    for (int i = 0; i < 49; ++i) {
+        non_fc_high_accuracy.on_judge({judge_result::perfect, 0.0, 0});
+    }
     const result_data non_fc_result = non_fc_high_accuracy.get_result_data();
     if (non_fc_result.accuracy < 99.0f || non_fc_result.is_full_combo || non_fc_result.clear_rank != rank::a) {
         std::cerr << "99% without full combo should be rank A\n";
+        return EXIT_FAILURE;
+    }
+
+    score_system fc_lower_accuracy;
+    fc_lower_accuracy.init(100);
+    for (int i = 0; i < 80; ++i) {
+        fc_lower_accuracy.on_judge({judge_result::perfect, 0.0, 0});
+    }
+    for (int i = 0; i < 20; ++i) {
+        fc_lower_accuracy.on_judge({judge_result::great, 0.0, 0});
+    }
+
+    if (!(fc_lower_accuracy.get_live_accuracy() < non_fc_high_accuracy.get_live_accuracy()) ||
+        !(fc_lower_accuracy.get_score() > non_fc_high_accuracy.get_score())) {
+        std::cerr << "Score should reward sustained combo more than raw accuracy alone\n";
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
## Summary
- make score depend much more heavily on sustained combo than raw judge accuracy alone
- keep accuracy as a pure judge-based metric while normalizing score against an ideal full-combo run
- add smoke coverage for the new combo-weighted score behavior and current rank expectations

## Testing
- `cmake --build cmake-build-codex --target score_system_smoke raythm -j 2`
- `score_system_smoke.exe`