### PR TITLE
MV機能実装の第1段を追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,17 @@ add_executable(raythm WIN32 src/main.cpp
         src/mv/lang/mv_vm.h
         src/mv/lang/mv_sandbox.cpp
         src/mv/lang/mv_sandbox.h
+        src/mv/api/mv_scene.h
+        src/mv/api/mv_context.cpp
+        src/mv/api/mv_context.h
+        src/mv/api/mv_builtins.cpp
+        src/mv/api/mv_builtins.h
+        src/mv/render/mv_renderer.cpp
+        src/mv/render/mv_renderer.h
+        src/mv/render/mv_validator.cpp
+        src/mv/render/mv_validator.h
+        src/mv/mv_runtime.cpp
+        src/mv/mv_runtime.h
         src/audio/audio_waveform.cpp
         src/audio/audio_waveform.h
         src/scenes/editor/editor_command.h
@@ -559,6 +570,30 @@ add_executable(mv_lang_smoke
         src/mv/lang/mv_sandbox.h
         src/tests/mv_lang_smoke.cpp)
 
+add_executable(mv_api_smoke
+        src/mv/lang/mv_lexer.cpp
+        src/mv/lang/mv_lexer.h
+        src/mv/lang/mv_ast.h
+        src/mv/lang/mv_parser.cpp
+        src/mv/lang/mv_parser.h
+        src/mv/lang/mv_bytecode.h
+        src/mv/lang/mv_compiler.cpp
+        src/mv/lang/mv_compiler.h
+        src/mv/lang/mv_vm.cpp
+        src/mv/lang/mv_vm.h
+        src/mv/lang/mv_sandbox.cpp
+        src/mv/lang/mv_sandbox.h
+        src/mv/api/mv_scene.h
+        src/mv/api/mv_context.cpp
+        src/mv/api/mv_context.h
+        src/mv/api/mv_builtins.cpp
+        src/mv/api/mv_builtins.h
+        src/mv/render/mv_validator.cpp
+        src/mv/render/mv_validator.h
+        src/mv/mv_runtime.cpp
+        src/mv/mv_runtime.h
+        src/tests/mv_api_smoke.cpp)
+
 set(RAYTHM_INCLUDE_DIRS
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_SOURCE_DIR}/src/audio
@@ -598,6 +633,7 @@ target_include_directories(editor_panel_controller_smoke PRIVATE ${RAYTHM_INCLUD
 target_include_directories(audio_manager_smoke PRIVATE ${RAYTHM_BASS_DIR} ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(update_version_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_lang_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(mv_api_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32 crypt32)
 target_link_libraries(raythm_launcher PRIVATE winhttp)
 target_link_libraries(raythm_updater PRIVATE winhttp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,11 @@ add_executable(raythm WIN32 src/main.cpp
         src/ui/ui_hit.h
         src/ui/ui_draw.h
         src/ui/ui_clip.cpp
-        src/ui/ui_clip.h)
+        src/ui/ui_clip.h
+        src/ui/ui_text_editor.cpp
+        src/ui/ui_text_editor.h
+        src/scenes/editor/editor_mv_script_panel.cpp
+        src/scenes/editor/editor_mv_script_panel.h)
 
 add_executable(raythm_launcher
         src/launcher_main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/title/title_bgm_controller.h
         src/scenes/title/title_spectrum_visualizer.cpp
         src/scenes/title/title_spectrum_visualizer.h
+        src/scenes/mv_editor_scene.cpp
+        src/scenes/mv_editor_scene.h
         src/scenes/song_create_scene.cpp
         src/scenes/song_create_scene.h
         src/scenes/song_select/song_catalog_service.cpp
@@ -651,6 +653,8 @@ target_link_libraries(play_flow_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_timeline_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_panel_controller_smoke PRIVATE raylib)
 target_link_libraries(audio_manager_smoke PRIVATE ${RAYTHM_BASS_IMPORT_LIB})
+target_link_libraries(mv_lang_smoke PRIVATE raylib)
+target_link_libraries(mv_api_smoke PRIVATE raylib)
 target_compile_definitions(raythm_launcher PRIVATE RAYTHM_PACKAGE_VERSION_STRING="${RAYTHM_PACKAGE_VERSION}")
 
 set(RAYTHM_RUNTIME_DLLS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,18 @@ add_executable(raythm WIN32 src/main.cpp
         src/audio/audio.h
         src/audio/audio_manager.cpp
         src/audio/audio_manager.h
+        src/mv/lang/mv_lexer.cpp
+        src/mv/lang/mv_lexer.h
+        src/mv/lang/mv_ast.h
+        src/mv/lang/mv_parser.cpp
+        src/mv/lang/mv_parser.h
+        src/mv/lang/mv_bytecode.h
+        src/mv/lang/mv_compiler.cpp
+        src/mv/lang/mv_compiler.h
+        src/mv/lang/mv_vm.cpp
+        src/mv/lang/mv_vm.h
+        src/mv/lang/mv_sandbox.cpp
+        src/mv/lang/mv_sandbox.h
         src/audio/audio_waveform.cpp
         src/audio/audio_waveform.h
         src/scenes/editor/editor_command.h
@@ -532,6 +544,21 @@ add_executable(update_version_smoke
         src/updater/update_workflow.h
         src/tests/update_version_smoke.cpp)
 
+add_executable(mv_lang_smoke
+        src/mv/lang/mv_lexer.cpp
+        src/mv/lang/mv_lexer.h
+        src/mv/lang/mv_ast.h
+        src/mv/lang/mv_parser.cpp
+        src/mv/lang/mv_parser.h
+        src/mv/lang/mv_bytecode.h
+        src/mv/lang/mv_compiler.cpp
+        src/mv/lang/mv_compiler.h
+        src/mv/lang/mv_vm.cpp
+        src/mv/lang/mv_vm.h
+        src/mv/lang/mv_sandbox.cpp
+        src/mv/lang/mv_sandbox.h
+        src/tests/mv_lang_smoke.cpp)
+
 set(RAYTHM_INCLUDE_DIRS
         ${CMAKE_SOURCE_DIR}/src
         ${CMAKE_SOURCE_DIR}/src/audio
@@ -570,6 +597,7 @@ target_include_directories(editor_timeline_controller_smoke PRIVATE ${RAYTHM_INC
 target_include_directories(editor_panel_controller_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(audio_manager_smoke PRIVATE ${RAYTHM_BASS_DIR} ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(update_version_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(mv_lang_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32 crypt32)
 target_link_libraries(raythm_launcher PRIVATE winhttp)
 target_link_libraries(raythm_updater PRIVATE winhttp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,6 +88,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/mv/render/mv_validator.h
         src/mv/mv_runtime.cpp
         src/mv/mv_runtime.h
+        src/mv/mv_script_editor_style.cpp
+        src/mv/mv_script_editor_style.h
         src/audio/audio_waveform.cpp
         src/audio/audio_waveform.h
         src/scenes/editor/editor_command.h
@@ -260,8 +262,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/ui/ui_clip.h
         src/ui/ui_text_editor.cpp
         src/ui/ui_text_editor.h
-        src/scenes/editor/editor_mv_script_panel.cpp
-        src/scenes/editor/editor_mv_script_panel.h)
+        src/mv/mv_script_panel.cpp
+        src/mv/mv_script_panel.h)
 
 add_executable(raythm_launcher
         src/launcher_main.cpp

--- a/documents/mv-script-samples.rmv
+++ b/documents/mv-script-samples.rmv
@@ -15,7 +15,10 @@
 #     ctx.time.ms, ctx.time.sec, ctx.time.length_ms,
 #     ctx.time.bpm, ctx.time.beat, ctx.time.beat_phase,
 #     ctx.time.progress
-#     ctx.audio.spectrum, ctx.audio.spectrum_size
+#     ctx.audio.spectrum, ctx.audio.spectrum_size,
+#     ctx.audio.waveform, ctx.audio.waveform_size,
+#     ctx.audio.waveform_index, ctx.audio.level,
+#     ctx.audio.oscilloscope, ctx.audio.oscilloscope_size
 #     ctx.chart.total_notes, ctx.chart.combo,
 #     ctx.chart.accuracy, ctx.chart.key_count
 #     ctx.screen.w, ctx.screen.h
@@ -220,3 +223,80 @@ def draw(ctx):
   filled = bar_w * ctx.time.progress
   Rect(x=140, y=700, w=bar_w, h=4, fill="#222222")
   Rect(x=140, y=700, w=filled, h=4, fill="#44ddff")
+
+
+# --------------------------------------------------
+# Sample 11: Syzygy Drift
+#   Slow-evolving orbit lines with a restrained spectrum crown.
+# --------------------------------------------------
+def draw(ctx):
+  t = ctx.time.sec
+  phase = ctx.time.beat_phase
+
+  cx = ctx.screen.w * 0.5
+  cy = ctx.screen.h * 0.5
+
+  Background(fill="#060913")
+
+  glow = 0.05 + 0.03 * sin(t * 0.22)
+  Rect(x=0, y=0, w=ctx.screen.w, h=ctx.screen.h, fill="#d8f6ff", rotation=0, opacity=glow)
+
+  outer = []
+  inner = []
+  core = []
+
+  segments = 56
+  for i in range(segments + 1):
+    p = i / segments
+    a = p * 2 * pi()
+
+    outer_r = 250 + 18 * sin(a * 3 + t * 0.34) + 10 * sin(a * 7 - t * 0.18)
+    outer_x = cx + cos(a + t * 0.09) * outer_r
+    outer_y = cy + sin(a + t * 0.09) * outer_r
+    outer.append(Point(x=outer_x, y=outer_y))
+
+    inner_r = 156 + 12 * sin(a * 4 - t * 0.41) + 8 * sin(a * 9 + t * 0.15)
+    inner_x = cx + cos(a - t * 0.12) * inner_r
+    inner_y = cy + sin(a - t * 0.12) * inner_r
+    inner.append(Point(x=inner_x, y=inner_y))
+
+    core_r = 86 + 8 * sin(a * 5 + t * 0.8 + phase * 2 * pi())
+    core_x = cx + cos(a + t * 0.16) * core_r
+    core_y = cy + sin(a + t * 0.16) * core_r
+    core.append(Point(x=core_x, y=core_y))
+
+  Polyline(points=outer, stroke="#c8f4ff", thickness=2.0, opacity=0.34)
+  Polyline(points=inner, stroke="#8ddfff", thickness=1.6, opacity=0.46)
+  Polyline(points=core, stroke="#ffffff", thickness=1.0, opacity=0.28)
+
+  bridge_count = 10
+  for i in range(bridge_count):
+    a = (i / bridge_count) * 2 * pi() + t * 0.11
+    r1 = 110 + 8 * sin(t * 0.7 + i)
+    r2 = 235 + 14 * sin(t * 0.23 + i * 0.6)
+    x1 = cx + cos(a) * r1
+    y1 = cy + sin(a) * r1
+    x2 = cx + cos(a + 0.55 * sin(t * 0.17 + i)) * r2
+    y2 = cy + sin(a + 0.55 * sin(t * 0.17 + i)) * r2
+    Line(x1=x1, y1=y1, x2=x2, y2=y2, stroke="#ffffff", thickness=1.0, opacity=0.14)
+
+  count = min(ctx.audio.spectrum_size, 36)
+  if count > 0:
+    for i in range(count):
+      amp = ctx.audio.spectrum[i]
+      band = amp * amp
+      a = (i / count) * 2 * pi() - t * 0.18
+      base_r = 185 + 10 * sin(t * 0.33 + i * 0.15)
+      h = 90 * band * (0.72 + 0.28 * sin(t * 0.9 + i * 0.12))
+      x1 = cx + cos(a) * base_r
+      y1 = cy + sin(a) * base_r
+      x2 = cx + cos(a) * (base_r + h)
+      y2 = cy + sin(a) * (base_r + h)
+      thick = 1.0 + 1.8 * band
+      Line(x1=x1, y1=y1, x2=x2, y2=y2, stroke="#b4efff", thickness=thick, opacity=0.52)
+
+  beat_ring = 100 + 22 * (1 - phase)
+  Circle(cx=cx, cy=cy, radius=beat_ring, fill="#ffffff", opacity=0.05)
+  Circle(cx=cx, cy=cy, radius=52 + 6 * sin(t * 0.8), fill="#0b1320", opacity=0.96)
+
+  Text(text="SYZYGY DRIFT", x=cx - 118, y=cy + 242, font_size=22, fill="#f4fbff", opacity=0.44)

--- a/documents/mv-script-samples.rmv
+++ b/documents/mv-script-samples.rmv
@@ -1,0 +1,206 @@
+# ============================================================
+# raythm MV Script (.rmv) Samples
+# ============================================================
+#
+# MV Script Reference
+# --------------------
+# - draw(ctx) function is called every frame.
+# - Must return a Scene([...]) containing node objects.
+# - ctx fields:
+#     ctx.time.ms, ctx.time.sec, ctx.time.length_ms,
+#     ctx.time.bpm, ctx.time.beat, ctx.time.beat_phase,
+#     ctx.time.progress
+#     ctx.audio.spectrum, ctx.audio.spectrum_size
+#     ctx.chart.total_notes, ctx.chart.combo,
+#     ctx.chart.accuracy, ctx.chart.key_count
+#     ctx.screen.w, ctx.screen.h
+#
+# - Node types:
+#     Background(fill, opacity)
+#     Rect(x, y, w, h, fill, rotation, opacity)
+#     Circle(cx, cy, radius, fill, opacity)
+#     Line(x1, y1, x2, y2, stroke, thickness, opacity)
+#     Text(text, x, y, font_size, fill, opacity)
+#     SpectrumBar(x, y, w, h, bar_count, fill, opacity)
+#     BeatGrid(x, y, w, h, stroke, thickness, beat_phase, opacity)
+#     PulseRing(cx, cy, radius, stroke, thickness, beat_phase, opacity)
+#
+# - Built-in functions:
+#     sin, cos, abs, floor, ceil, sqrt, min, max,
+#     clamp, lerp, smoothstep, pi,
+#     int, float, str, len, range, rgb
+# ============================================================
+
+
+# --------------------------------------------------
+# Sample 1: Minimal (what "New MV" generates)
+# --------------------------------------------------
+def draw(ctx):
+  return Scene([])
+
+
+# --------------------------------------------------
+# Sample 2: Beat Pulse
+#   Center circle that scales up on each beat.
+# --------------------------------------------------
+def draw(ctx):
+  p = ctx.time.beat_phase
+  r = lerp(120.0, 60.0, p)
+  a = lerp(0.9, 0.2, p)
+  circle = Circle(cx=640, cy=360, radius=r, fill="#00ccff", opacity=a)
+  return Scene([Background(fill="#0a0a1a"), circle])
+
+
+# --------------------------------------------------
+# Sample 3: Spectrum + Beat Grid
+#   Audio-reactive bars with a subtle beat grid.
+# --------------------------------------------------
+def draw(ctx):
+  bg = Background(fill="#0b0f18")
+  spec = SpectrumBar(x=140, y=520, w=1000, h=180, bar_count=48, fill="#64c8ff", opacity=0.7)
+  grid = BeatGrid(stroke="#ffffff1e", thickness=1.0, beat_phase=ctx.time.beat_phase, opacity=0.4)
+  return Scene([bg, grid, spec])
+
+
+# --------------------------------------------------
+# Sample 4: Combo Fireworks
+#   Circles that fan out when combo is high.
+# --------------------------------------------------
+def draw(ctx):
+  nodes = [Background(fill="#111111")]
+
+  combo = ctx.chart.combo
+  count = min(int(combo / 10), 12)
+
+  for i in range(count):
+    angle = pi() * 2.0 * i / max(count, 1)
+    dist = 80.0 + combo * 0.3
+    cx = 640 + cos(angle) * dist
+    cy = 360 + sin(angle) * dist
+    r = 10.0 + sin(ctx.time.ms * 0.005 + i) * 6.0
+    nodes = nodes + [Circle(cx=cx, cy=cy, radius=r, fill="#ff6644", opacity=0.8)]
+
+  label = Text(text=str(int(combo)), x=600, y=330, font_size=48, fill="#ffffff")
+  nodes = nodes + [label]
+  return Scene(nodes)
+
+
+# --------------------------------------------------
+# Sample 5: Progress Bar + Song Info
+#   A simple HUD overlay.
+# --------------------------------------------------
+def draw(ctx):
+  nodes = []
+
+  bar_w = ctx.screen.w - 100
+  filled = bar_w * ctx.time.progress
+  nodes = nodes + [Rect(x=50, y=680, w=bar_w, h=6, fill="#333333")]
+  nodes = nodes + [Rect(x=50, y=680, w=filled, h=6, fill="#00ff88")]
+
+  pct = str(int(ctx.time.progress * 100)) + "%"
+  nodes = nodes + [Text(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")]
+
+  return Scene(nodes)
+
+
+# --------------------------------------------------
+# Sample 6: Rotating Squares
+#   Four squares rotating around the center.
+# --------------------------------------------------
+def draw(ctx):
+  nodes = [Background(fill="#1a0a2e")]
+
+  t = ctx.time.sec
+  for i in range(4):
+    angle = t * 0.8 + pi() * 0.5 * i
+    cx = 640 + cos(angle) * 200
+    cy = 360 + sin(angle) * 200
+    rot = t * 60 + i * 90
+    color = "#ff44cc"
+    if i % 2 == 0:
+      color = "#44ccff"
+    nodes = nodes + [Rect(x=cx - 40, y=cy - 40, w=80, h=80, fill=color, rotation=rot, opacity=0.75)]
+
+  return Scene(nodes)
+
+
+# --------------------------------------------------
+# Sample 7: Pulse Rings + Spectrum
+#   Layered rings that expand on beat with spectrum.
+# --------------------------------------------------
+def draw(ctx):
+  nodes = [Background(fill="#050510")]
+  bp = ctx.time.beat_phase
+
+  for i in range(3):
+    r = 100 + i * 80
+    a = lerp(0.6, 0.1, bp) - i * 0.15
+    a = max(a, 0.0)
+    nodes = nodes + [PulseRing(cx=640, cy=360, radius=r, stroke="#8866ff", thickness=2.0, beat_phase=bp, opacity=a)]
+
+  nodes = nodes + [SpectrumBar(x=340, y=560, w=600, h=120, bar_count=32, fill="#8866ff", opacity=0.5)]
+  return Scene(nodes)
+
+
+# --------------------------------------------------
+# Sample 8: Accuracy Color Bar
+#   Top bar changes color based on accuracy.
+# --------------------------------------------------
+def draw(ctx):
+  acc = ctx.chart.accuracy
+  color = "#ff3333"
+  if acc > 0.95:
+    color = "#33ff88"
+  elif acc > 0.85:
+    color = "#ffee33"
+  elif acc > 0.70:
+    color = "#ff8833"
+
+  bar = Rect(x=0, y=0, w=ctx.screen.w, h=8, fill=color, opacity=0.9)
+  label = Text(text=str(int(acc * 100)) + "%", x=20, y=16, font_size=20, fill=color, opacity=0.7)
+  return Scene([bar, label])
+
+
+# --------------------------------------------------
+# Sample 9: Waveform Lines
+#   Animated wave using sin() across the screen.
+# --------------------------------------------------
+def draw(ctx):
+  nodes = [Background(fill="#0d0d1a")]
+  t = ctx.time.ms * 0.002
+
+  for i in range(40):
+    x = i * 32.0
+    y1 = 360 + sin(t + i * 0.3) * 100
+    y2 = 360 + sin(t + (i + 1) * 0.3) * 100
+    x2 = (i + 1) * 32.0
+    a = 0.3 + sin(t + i * 0.5) * 0.2
+    nodes = nodes + [Line(x1=x, y1=y1, x2=x2, y2=y2, stroke="#22ddaa", thickness=2.0, opacity=a)]
+
+  return Scene(nodes)
+
+
+# --------------------------------------------------
+# Sample 10: Full Production MV
+#   Combines beat grid, spectrum, pulse, combo, progress.
+# --------------------------------------------------
+def draw(ctx):
+  nodes = [Background(fill="#080812")]
+  bp = ctx.time.beat_phase
+
+  nodes = nodes + [BeatGrid(stroke="#ffffff10", thickness=1.0, beat_phase=bp, opacity=0.3)]
+  nodes = nodes + [PulseRing(cx=640, cy=340, radius=160, stroke="#ff66aa", thickness=2.5, beat_phase=bp, opacity=0.5)]
+  nodes = nodes + [SpectrumBar(x=90, y=540, w=1100, h=160, bar_count=64, fill="#4488ff", opacity=0.45)]
+
+  combo = ctx.chart.combo
+  if combo >= 10:
+    scale = min(combo * 0.5, 40.0)
+    glow = Circle(cx=640, cy=340, radius=60 + scale, fill="#ff66aa", opacity=lerp(0.3, 0.05, bp))
+    nodes = nodes + [glow]
+
+  bar_w = 1000
+  filled = bar_w * ctx.time.progress
+  nodes = nodes + [Rect(x=140, y=700, w=bar_w, h=4, fill="#222222")]
+  nodes = nodes + [Rect(x=140, y=700, w=filled, h=4, fill="#44ddff")]
+
+  return Scene(nodes)

--- a/documents/mv-script-samples.rmv
+++ b/documents/mv-script-samples.rmv
@@ -5,7 +5,12 @@
 # MV Script Reference
 # --------------------
 # - draw(ctx) function is called every frame.
-# - Must return a Scene([...]) containing node objects.
+# - You can write in two styles:
+#     1. Imperative: just place node constructors in draw(ctx)
+#     2. Explicit: return Scene([...])
+# - In imperative style, node calls are collected automatically.
+# - SpectrumBar / BeatGrid / PulseRing are deprecated compatibility helpers.
+#   They still work, but new scripts should prefer composing effects from primitives.
 # - ctx fields:
 #     ctx.time.ms, ctx.time.sec, ctx.time.length_ms,
 #     ctx.time.bpm, ctx.time.beat, ctx.time.beat_phase,
@@ -16,14 +21,13 @@
 #     ctx.screen.w, ctx.screen.h
 #
 # - Node types:
+#     Point(x, y)
 #     Background(fill, opacity)
 #     Rect(x, y, w, h, fill, rotation, opacity)
 #     Circle(cx, cy, radius, fill, opacity)
 #     Line(x1, y1, x2, y2, stroke, thickness, opacity)
+#     Polyline(points, stroke, thickness, opacity)
 #     Text(text, x, y, font_size, fill, opacity)
-#     SpectrumBar(x, y, w, h, bar_count, fill, opacity)
-#     BeatGrid(x, y, w, h, stroke, thickness, beat_phase, opacity)
-#     PulseRing(cx, cy, radius, stroke, thickness, beat_phase, opacity)
 #
 # - Built-in functions:
 #     sin, cos, abs, floor, ceil, sqrt, min, max,
@@ -47,19 +51,30 @@ def draw(ctx):
   p = ctx.time.beat_phase
   r = lerp(120.0, 60.0, p)
   a = lerp(0.9, 0.2, p)
-  circle = Circle(cx=640, cy=360, radius=r, fill="#00ccff", opacity=a)
-  return Scene([Background(fill="#0a0a1a"), circle])
+  Background(fill="#0a0a1a")
+  Circle(cx=640, cy=360, radius=r, fill="#00ccff", opacity=a)
 
 
 # --------------------------------------------------
-# Sample 3: Spectrum + Beat Grid
-#   Audio-reactive bars with a subtle beat grid.
+# Sample 3: Spectrum + Grid
+#   Audio-reactive bars built from Rect + Line.
 # --------------------------------------------------
 def draw(ctx):
-  bg = Background(fill="#0b0f18")
-  spec = SpectrumBar(x=140, y=520, w=1000, h=180, bar_count=48, fill="#64c8ff", opacity=0.7)
-  grid = BeatGrid(stroke="#ffffff1e", thickness=1.0, beat_phase=ctx.time.beat_phase, opacity=0.4)
-  return Scene([bg, grid, spec])
+  Background(fill="#0b0f18")
+
+  spacing = 40
+  offset = ctx.time.beat_phase * spacing
+  for i in range(19):
+    y = i * spacing - offset
+    Line(x1=0, y1=y, x2=1280, y2=y, stroke="#ffffff1e", thickness=1.0, opacity=0.4)
+
+  count = min(len(ctx.audio.spectrum), 48)
+  if count > 0:
+    bar_w = 1000 / count
+    for i in range(count):
+      amp = ctx.audio.spectrum[i]
+      h = 180 * amp
+      Rect(x=140 + i * bar_w, y=700 - h, w=bar_w - 2, h=h, fill="#64c8ff", opacity=0.7)
 
 
 # --------------------------------------------------
@@ -67,7 +82,7 @@ def draw(ctx):
 #   Circles that fan out when combo is high.
 # --------------------------------------------------
 def draw(ctx):
-  nodes = [Background(fill="#111111")]
+  Background(fill="#111111")
 
   combo = ctx.chart.combo
   count = min(int(combo / 10), 12)
@@ -78,11 +93,9 @@ def draw(ctx):
     cx = 640 + cos(angle) * dist
     cy = 360 + sin(angle) * dist
     r = 10.0 + sin(ctx.time.ms * 0.005 + i) * 6.0
-    nodes = nodes + [Circle(cx=cx, cy=cy, radius=r, fill="#ff6644", opacity=0.8)]
+    Circle(cx=cx, cy=cy, radius=r, fill="#ff6644", opacity=0.8)
 
-  label = Text(text=str(int(combo)), x=600, y=330, font_size=48, fill="#ffffff")
-  nodes = nodes + [label]
-  return Scene(nodes)
+  Text(text=str(int(combo)), x=600, y=330, font_size=48, fill="#ffffff")
 
 
 # --------------------------------------------------
@@ -90,17 +103,13 @@ def draw(ctx):
 #   A simple HUD overlay.
 # --------------------------------------------------
 def draw(ctx):
-  nodes = []
-
   bar_w = ctx.screen.w - 100
   filled = bar_w * ctx.time.progress
-  nodes = nodes + [Rect(x=50, y=680, w=bar_w, h=6, fill="#333333")]
-  nodes = nodes + [Rect(x=50, y=680, w=filled, h=6, fill="#00ff88")]
+  Rect(x=50, y=680, w=bar_w, h=6, fill="#333333")
+  Rect(x=50, y=680, w=filled, h=6, fill="#00ff88")
 
   pct = str(int(ctx.time.progress * 100)) + "%"
-  nodes = nodes + [Text(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")]
-
-  return Scene(nodes)
+  Text(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")
 
 
 # --------------------------------------------------
@@ -108,7 +117,7 @@ def draw(ctx):
 #   Four squares rotating around the center.
 # --------------------------------------------------
 def draw(ctx):
-  nodes = [Background(fill="#1a0a2e")]
+  Background(fill="#1a0a2e")
 
   t = ctx.time.sec
   for i in range(4):
@@ -119,27 +128,30 @@ def draw(ctx):
     color = "#ff44cc"
     if i % 2 == 0:
       color = "#44ccff"
-    nodes = nodes + [Rect(x=cx - 40, y=cy - 40, w=80, h=80, fill=color, rotation=rot, opacity=0.75)]
-
-  return Scene(nodes)
+    Rect(x=cx - 40, y=cy - 40, w=80, h=80, fill=color, rotation=rot, opacity=0.75)
 
 
 # --------------------------------------------------
-# Sample 7: Pulse Rings + Spectrum
-#   Layered rings that expand on beat with spectrum.
+# Sample 7: Manual Pulse Rings + Spectrum
+#   Rings and bars composed from Circle + Rect.
 # --------------------------------------------------
 def draw(ctx):
-  nodes = [Background(fill="#050510")]
+  Background(fill="#050510")
   bp = ctx.time.beat_phase
 
   for i in range(3):
     r = 100 + i * 80
     a = lerp(0.6, 0.1, bp) - i * 0.15
     a = max(a, 0.0)
-    nodes = nodes + [PulseRing(cx=640, cy=360, radius=r, stroke="#8866ff", thickness=2.0, beat_phase=bp, opacity=a)]
+    Circle(cx=640, cy=360, radius=r + bp * 30, fill="#8866ff", opacity=a * 0.15)
 
-  nodes = nodes + [SpectrumBar(x=340, y=560, w=600, h=120, bar_count=32, fill="#8866ff", opacity=0.5)]
-  return Scene(nodes)
+  count = min(len(ctx.audio.spectrum), 32)
+  if count > 0:
+    bar_w = 600 / count
+    for i in range(count):
+      amp = ctx.audio.spectrum[i]
+      h = 120 * amp
+      Rect(x=340 + i * bar_w, y=680 - h, w=bar_w - 2, h=h, fill="#8866ff", opacity=0.5)
 
 
 # --------------------------------------------------
@@ -156,51 +168,55 @@ def draw(ctx):
   elif acc > 0.70:
     color = "#ff8833"
 
-  bar = Rect(x=0, y=0, w=ctx.screen.w, h=8, fill=color, opacity=0.9)
-  label = Text(text=str(int(acc * 100)) + "%", x=20, y=16, font_size=20, fill=color, opacity=0.7)
-  return Scene([bar, label])
+  Rect(x=0, y=0, w=ctx.screen.w, h=8, fill=color, opacity=0.9)
+  Text(text=str(int(acc * 100)) + "%", x=20, y=16, font_size=20, fill=color, opacity=0.7)
 
 
 # --------------------------------------------------
-# Sample 9: Waveform Lines
-#   Animated wave using sin() across the screen.
+# Sample 9: Waveform Polyline
+#   Animated wave using Point + Polyline.
 # --------------------------------------------------
 def draw(ctx):
-  nodes = [Background(fill="#0d0d1a")]
+  Background(fill="#0d0d1a")
   t = ctx.time.ms * 0.002
+  points = []
 
-  for i in range(40):
+  for i in range(41):
     x = i * 32.0
-    y1 = 360 + sin(t + i * 0.3) * 100
-    y2 = 360 + sin(t + (i + 1) * 0.3) * 100
-    x2 = (i + 1) * 32.0
-    a = 0.3 + sin(t + i * 0.5) * 0.2
-    nodes = nodes + [Line(x1=x, y1=y1, x2=x2, y2=y2, stroke="#22ddaa", thickness=2.0, opacity=a)]
+    y = 360 + sin(t + i * 0.3) * 100
+    points = points + [Point(x=x, y=y)]
 
-  return Scene(nodes)
+  Polyline(points=points, stroke="#22ddaa", thickness=2.0, opacity=0.5)
 
 
 # --------------------------------------------------
 # Sample 10: Full Production MV
-#   Combines beat grid, spectrum, pulse, combo, progress.
+#   Combines primitive-built grid, pulse glow, combo, progress.
 # --------------------------------------------------
 def draw(ctx):
-  nodes = [Background(fill="#080812")]
+  Background(fill="#080812")
   bp = ctx.time.beat_phase
 
-  nodes = nodes + [BeatGrid(stroke="#ffffff10", thickness=1.0, beat_phase=bp, opacity=0.3)]
-  nodes = nodes + [PulseRing(cx=640, cy=340, radius=160, stroke="#ff66aa", thickness=2.5, beat_phase=bp, opacity=0.5)]
-  nodes = nodes + [SpectrumBar(x=90, y=540, w=1100, h=160, bar_count=64, fill="#4488ff", opacity=0.45)]
+  for i in range(19):
+    y = i * 40 - bp * 40
+    Line(x1=0, y1=y, x2=1280, y2=y, stroke="#ffffff10", thickness=1.0, opacity=0.3)
+
+  Circle(cx=640, cy=340, radius=160 + bp * 24, fill="#ff66aa", opacity=0.08)
+
+  count = min(len(ctx.audio.spectrum), 64)
+  if count > 0:
+    bar_w = 1100 / count
+    for i in range(count):
+      amp = ctx.audio.spectrum[i]
+      h = 160 * amp
+      Rect(x=90 + i * bar_w, y=700 - h, w=bar_w - 2, h=h, fill="#4488ff", opacity=0.45)
 
   combo = ctx.chart.combo
   if combo >= 10:
     scale = min(combo * 0.5, 40.0)
-    glow = Circle(cx=640, cy=340, radius=60 + scale, fill="#ff66aa", opacity=lerp(0.3, 0.05, bp))
-    nodes = nodes + [glow]
+    Circle(cx=640, cy=340, radius=60 + scale, fill="#ff66aa", opacity=lerp(0.3, 0.05, bp))
 
   bar_w = 1000
   filled = bar_w * ctx.time.progress
-  nodes = nodes + [Rect(x=140, y=700, w=bar_w, h=4, fill="#222222")]
-  nodes = nodes + [Rect(x=140, y=700, w=filled, h=4, fill="#44ddff")]
-
-  return Scene(nodes)
+  Rect(x=140, y=700, w=bar_w, h=4, fill="#222222")
+  Rect(x=140, y=700, w=filled, h=4, fill="#44ddff")

--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <algorithm>
 #include <unordered_map>
+#include <vector>
 
 #include "bass.h"
 
@@ -137,6 +138,43 @@ bool audio_manager::get_bgm_fft256(std::array<float, 128>& spectrum) const {
 
     return BASS_ChannelGetData(bgm_handle_, spectrum.data(),
                                BASS_DATA_FFT256 | BASS_DATA_FFT_REMOVEDC) != static_cast<DWORD>(-1);
+}
+
+bool audio_manager::get_bgm_oscilloscope256(std::array<float, 256>& samples) const {
+    samples.fill(0.0f);
+    if (!is_voice_loaded(bgm_handle_)) {
+        return false;
+    }
+
+    BASS_CHANNELINFO info = {};
+    if (BASS_ChannelGetInfo(bgm_handle_, &info) == FALSE || info.chans <= 0) {
+        return false;
+    }
+
+    const std::size_t channels = static_cast<std::size_t>(info.chans);
+    std::vector<float> interleaved(samples.size() * channels, 0.0f);
+    const DWORD requested_bytes =
+        static_cast<DWORD>(interleaved.size() * sizeof(float)) | BASS_DATA_FLOAT;
+    const DWORD bytes_read = BASS_ChannelGetData(bgm_handle_, interleaved.data(), requested_bytes);
+    if (bytes_read == static_cast<DWORD>(-1) || bytes_read == 0) {
+        return false;
+    }
+
+    const std::size_t samples_read = bytes_read / sizeof(float);
+    const std::size_t frames_read = std::min(samples.size(), samples_read / channels);
+    if (frames_read == 0) {
+        return false;
+    }
+
+    for (std::size_t frame = 0; frame < frames_read; ++frame) {
+        float mono = 0.0f;
+        const std::size_t base = frame * channels;
+        for (std::size_t channel = 0; channel < channels; ++channel) {
+            mono += interleaved[base + channel];
+        }
+        samples[frame] = std::clamp(mono / static_cast<float>(channels), -1.0f, 1.0f);
+    }
+    return true;
 }
 
 double audio_manager::get_output_latency_seconds() const {

--- a/src/audio/audio_manager.h
+++ b/src/audio/audio_manager.h
@@ -38,6 +38,7 @@ public:
     double get_bgm_length_seconds() const;
     audio_clock_snapshot get_bgm_clock() const;
     bool get_bgm_fft256(std::array<float, 128>& spectrum) const;
+    bool get_bgm_oscilloscope256(std::array<float, 256>& samples) const;
     double get_output_latency_seconds() const;
     double get_output_buffer_seconds() const;
 

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -110,6 +110,14 @@ std::filesystem::path chart_offsets_path() {
     return app_data_root() / "chart_offsets.txt";
 }
 
+std::filesystem::path scripts_root() {
+    return app_data_root() / "scripts";
+}
+
+std::filesystem::path script_path(const std::string& song_id) {
+    return scripts_root() / (song_id + ".rmv");
+}
+
 void ensure_directories() {
     std::error_code ec;
     std::filesystem::create_directories(app_data_root(), ec);
@@ -119,6 +127,7 @@ void ensure_directories() {
     std::filesystem::create_directories(official_root(), ec);
     std::filesystem::create_directories(official_songs_root(), ec);
     std::filesystem::create_directories(official_charts_root(), ec);
+    std::filesystem::create_directories(scripts_root(), ec);
 }
 
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -53,6 +53,12 @@ std::filesystem::path settings_path();
 // AppData/Local/raythm/chart_offsets.txt
 std::filesystem::path chart_offsets_path();
 
+// AppData/Local/raythm/scripts/
+std::filesystem::path scripts_root();
+
+// AppData/Local/raythm/scripts/{song_id}.rmv
+std::filesystem::path script_path(const std::string& song_id);
+
 // Create songs/ and charts/ directories if they don't exist.
 void ensure_directories();
 

--- a/src/core/file_dialog.cpp
+++ b/src/core/file_dialog.cpp
@@ -141,6 +141,14 @@ std::string save_song_package_file(const std::string& default_file_name) {
         default_file_name);
 }
 
+std::string save_mv_script_file(const std::string& default_file_name) {
+    return save_file_dialog(
+        L"raythm MV Script (*.rmv)\0*.rmv\0All Files (*.*)\0*.*\0",
+        L"Export MV Script",
+        L"rmv",
+        default_file_name);
+}
+
 bool confirm_yes_no(const std::string& title, const std::string& message) {
     fullscreen_dialog_guard fullscreen_guard;
     const int result = MessageBoxW(static_cast<HWND>(window_dialog_support::native_window_handle()),
@@ -158,6 +166,7 @@ std::string open_chart_package_file() { return {}; }
 std::string open_song_package_file() { return {}; }
 std::string save_chart_package_file(const std::string&) { return {}; }
 std::string save_song_package_file(const std::string&) { return {}; }
+std::string save_mv_script_file(const std::string&) { return {}; }
 bool confirm_yes_no(const std::string&, const std::string&) { return false; }
 
 #endif

--- a/src/core/file_dialog.h
+++ b/src/core/file_dialog.h
@@ -22,6 +22,9 @@ std::string save_chart_package_file(const std::string& default_file_name);
 // Open a save file dialog for saving an .rpack file. Returns empty string if cancelled.
 std::string save_song_package_file(const std::string& default_file_name);
 
+// Open a save file dialog for saving an .rmv file. Returns empty string if cancelled.
+std::string save_mv_script_file(const std::string& default_file_name);
+
 // Show a yes/no confirmation dialog. Returns true when the user accepts.
 bool confirm_yes_no(const std::string& title, const std::string& message);
 

--- a/src/gameplay/judge_system.h
+++ b/src/gameplay/judge_system.h
@@ -11,10 +11,10 @@
 class judge_system {
 public:
     static constexpr int kMaxLanes = 6;
-    static constexpr double kPerfectWindowMs = 25.0;
-    static constexpr double kGreatWindowMs = 50.0;
-    static constexpr double kGoodWindowMs = 90.0;
-    static constexpr double kBadWindowMs = 130.0;
+    static constexpr double kPerfectWindowMs = 40.0;
+    static constexpr double kGreatWindowMs = 80.0;
+    static constexpr double kGoodWindowMs = 120.0;
+    static constexpr double kBadWindowMs = 160.0;
 
     void init(const std::vector<note_data>& notes, const timing_engine& engine);
     void update(double current_ms, const input_handler& input);

--- a/src/mv/api/mv_builtins.cpp
+++ b/src/mv/api/mv_builtins.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <cmath>
 #include <sstream>
+#include <unordered_set>
+
+#include "raylib.h"
 
 namespace mv {
 
@@ -168,6 +171,41 @@ circle_node extract_circle(const std::shared_ptr<mv_object>& obj) {
     return n;
 }
 
+polyline_node extract_polyline(const std::shared_ptr<mv_object>& obj) {
+    polyline_node n;
+    n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 2));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto stroke_val = obj->get_attr("stroke");
+    if (auto* s = std::get_if<std::string>(&stroke_val)) n.stroke = parse_color(*s);
+    else if (auto so = as_object(stroke_val)) {
+        if (so->type_name == "Color") {
+            n.stroke = {
+                static_cast<uint8_t>(as_number(so->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("a"), 255))
+            };
+        }
+    }
+
+    auto points_val = obj->get_attr("points");
+    if (auto points = as_list(points_val)) {
+        n.points.reserve(points->elements.size());
+        for (const auto& point_val : points->elements) {
+            auto point_obj = as_object(point_val);
+            if (!point_obj || point_obj->type_name != "Point") {
+                continue;
+            }
+            n.points.push_back({
+                static_cast<float>(as_number(point_obj->get_attr("x"))),
+                static_cast<float>(as_number(point_obj->get_attr("y")))
+            });
+        }
+    }
+
+    return n;
+}
+
 spectrum_bar_node extract_spectrum_bar(const std::shared_ptr<mv_object>& obj) {
     spectrum_bar_node n;
     n.x = static_cast<float>(as_number(obj->get_attr("x")));
@@ -267,6 +305,7 @@ std::optional<scene_node> convert_node(const mv_value& val) {
     if (type == "Line")         return extract_line(obj);
     if (type == "Text")         return extract_text(obj);
     if (type == "Circle")       return extract_circle(obj);
+    if (type == "Polyline")     return extract_polyline(obj);
     if (type == "SpectrumBar")  return extract_spectrum_bar(obj);
     if (type == "BeatGrid")     return extract_beat_grid(obj);
     if (type == "PulseRing")    return extract_pulse_ring(obj);
@@ -458,14 +497,23 @@ void register_builtins_impl(Host& host) {
     auto make_node_ctor = [](const std::string& type_name) -> native_kwargs_function {
         return [type_name](const std::vector<mv_value>& args,
                           const std::vector<std::pair<std::string, mv_value>>& kwargs) -> mv_value {
+            static std::unordered_set<std::string> warned_types;
+            if ((type_name == "SpectrumBar" || type_name == "BeatGrid" || type_name == "PulseRing") &&
+                warned_types.insert(type_name).second) {
+                TraceLog(LOG_WARNING,
+                         "MV: %s is deprecated; prefer composing effects from Rect/Line/Circle/Text/Polyline",
+                         type_name.c_str());
+            }
             return make_node_kwargs(type_name, args, kwargs);
         };
     };
 
+    host.register_native_kwargs("Point", make_node_ctor("Point"));
     host.register_native_kwargs("Rect", make_node_ctor("Rect"));
     host.register_native_kwargs("Line", make_node_ctor("Line"));
     host.register_native_kwargs("Text", make_node_ctor("Text"));
     host.register_native_kwargs("Circle", make_node_ctor("Circle"));
+    host.register_native_kwargs("Polyline", make_node_ctor("Polyline"));
     host.register_native_kwargs("SpectrumBar", make_node_ctor("SpectrumBar"));
     host.register_native_kwargs("BeatGrid", make_node_ctor("BeatGrid"));
     host.register_native_kwargs("PulseRing", make_node_ctor("PulseRing"));

--- a/src/mv/api/mv_builtins.cpp
+++ b/src/mv/api/mv_builtins.cpp
@@ -18,9 +18,17 @@ double as_number(const mv_value& v, double fallback = 0.0) {
     return fallback;
 }
 
+double as_number(const mv_value* v, double fallback = 0.0) {
+    return v ? as_number(*v, fallback) : fallback;
+}
+
 std::string as_string(const mv_value& v, const std::string& fallback = "") {
     if (auto* s = std::get_if<std::string>(&v)) return *s;
     return fallback;
+}
+
+std::string as_string(const mv_value* v, const std::string& fallback = "") {
+    return v ? as_string(*v, fallback) : fallback;
 }
 
 std::shared_ptr<mv_object> as_object(const mv_value& v) {
@@ -28,9 +36,17 @@ std::shared_ptr<mv_object> as_object(const mv_value& v) {
     return nullptr;
 }
 
+std::shared_ptr<mv_object> as_object(const mv_value* v) {
+    return v ? as_object(*v) : nullptr;
+}
+
 std::shared_ptr<mv_list> as_list(const mv_value& v) {
     if (auto* l = std::get_if<std::shared_ptr<mv_list>>(&v)) return *l;
     return nullptr;
+}
+
+std::shared_ptr<mv_list> as_list(const mv_value* v) {
+    return v ? as_list(*v) : nullptr;
 }
 
 // Find kwarg by name
@@ -77,27 +93,147 @@ color color_from_kwarg(const std::vector<std::pair<std::string, mv_value>>& kwar
     return fallback;
 }
 
+std::optional<vec2> build_cached_point_from_kwargs(
+    const std::vector<std::pair<std::string, mv_value>>& kwargs) {
+    return vec2{
+        static_cast<float>(kwarg_number(kwargs, "x", 0.0)),
+        static_cast<float>(kwarg_number(kwargs, "y", 0.0))
+    };
+}
+
+std::optional<scene_node> build_cached_scene_node_from_kwargs(
+    const std::string& type_name,
+    const std::vector<std::pair<std::string, mv_value>>& kwargs) {
+    if (type_name == "Rect") {
+        rect_node n;
+        n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
+        n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
+        n.w = static_cast<float>(kwarg_number(kwargs, "w", 100.0));
+        n.h = static_cast<float>(kwarg_number(kwargs, "h", 100.0));
+        n.rotation = static_cast<float>(kwarg_number(kwargs, "rotation", 0.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.fill = color_from_kwarg(kwargs, "fill", n.fill);
+        return scene_node{n};
+    }
+    if (type_name == "Line") {
+        line_node n;
+        n.x1 = static_cast<float>(kwarg_number(kwargs, "x1", 0.0));
+        n.y1 = static_cast<float>(kwarg_number(kwargs, "y1", 0.0));
+        n.x2 = static_cast<float>(kwarg_number(kwargs, "x2", 100.0));
+        n.y2 = static_cast<float>(kwarg_number(kwargs, "y2", 100.0));
+        n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 2.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
+        return scene_node{n};
+    }
+    if (type_name == "Text") {
+        text_node n;
+        n.text = kwarg_string(kwargs, "text", "");
+        n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
+        n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
+        n.font_size = static_cast<int>(kwarg_number(kwargs, "font_size", 20.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.fill = color_from_kwarg(kwargs, "fill", n.fill);
+        return scene_node{n};
+    }
+    if (type_name == "Circle") {
+        circle_node n;
+        n.cx = static_cast<float>(kwarg_number(kwargs, "cx", 0.0));
+        n.cy = static_cast<float>(kwarg_number(kwargs, "cy", 0.0));
+        n.radius = static_cast<float>(kwarg_number(kwargs, "radius", 50.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.fill = color_from_kwarg(kwargs, "fill", n.fill);
+        return scene_node{n};
+    }
+    if (type_name == "Polyline") {
+        polyline_node n;
+        n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 2.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
+        if (const mv_value* points_val = find_kwarg(kwargs, "points")) {
+            if (auto points = as_list(*points_val)) {
+                n.points.reserve(points->elements.size());
+                for (const auto& point_val : points->elements) {
+                    auto point_obj = as_object(point_val);
+                    if (!point_obj || point_obj->type_name != "Point") {
+                        continue;
+                    }
+                    if (point_obj->cached_point.has_value()) {
+                        n.points.push_back(*point_obj->cached_point);
+                    } else {
+                        n.points.push_back({
+                            static_cast<float>(as_number(point_obj->find_attr("x"))),
+                            static_cast<float>(as_number(point_obj->find_attr("y")))
+                        });
+                    }
+                }
+            }
+        }
+        return scene_node{n};
+    }
+    if (type_name == "SpectrumBar") {
+        spectrum_bar_node n;
+        n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
+        n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
+        n.w = static_cast<float>(kwarg_number(kwargs, "w", 400.0));
+        n.h = static_cast<float>(kwarg_number(kwargs, "h", 200.0));
+        n.bar_count = static_cast<int>(kwarg_number(kwargs, "bar_count", 32.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.fill = color_from_kwarg(kwargs, "fill", n.fill);
+        return scene_node{n};
+    }
+    if (type_name == "BeatGrid") {
+        beat_grid_node n;
+        n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
+        n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
+        n.w = static_cast<float>(kwarg_number(kwargs, "w", 1280.0));
+        n.h = static_cast<float>(kwarg_number(kwargs, "h", 720.0));
+        n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 1.0));
+        n.beat_phase = static_cast<float>(kwarg_number(kwargs, "beat_phase", 0.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
+        return scene_node{n};
+    }
+    if (type_name == "PulseRing") {
+        pulse_ring_node n;
+        n.cx = static_cast<float>(kwarg_number(kwargs, "cx", 640.0));
+        n.cy = static_cast<float>(kwarg_number(kwargs, "cy", 360.0));
+        n.radius = static_cast<float>(kwarg_number(kwargs, "radius", 100.0));
+        n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 3.0));
+        n.beat_phase = static_cast<float>(kwarg_number(kwargs, "beat_phase", 0.0));
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
+        return scene_node{n};
+    }
+    if (type_name == "Background") {
+        background_node n;
+        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
+        n.fill = color_from_kwarg(kwargs, "fill", n.fill);
+        return scene_node{n};
+    }
+    return std::nullopt;
+}
+
 // ---- Node extraction helpers ----
 
 rect_node extract_rect(const std::shared_ptr<mv_object>& obj) {
     rect_node n;
-    n.x = static_cast<float>(as_number(obj->get_attr("x")));
-    n.y = static_cast<float>(as_number(obj->get_attr("y")));
-    n.w = static_cast<float>(as_number(obj->get_attr("w"), 100));
-    n.h = static_cast<float>(as_number(obj->get_attr("h"), 100));
-    n.rotation = static_cast<float>(as_number(obj->get_attr("rotation")));
-    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    n.x = static_cast<float>(as_number(obj->find_attr("x")));
+    n.y = static_cast<float>(as_number(obj->find_attr("y")));
+    n.w = static_cast<float>(as_number(obj->find_attr("w"), 100));
+    n.h = static_cast<float>(as_number(obj->find_attr("h"), 100));
+    n.rotation = static_cast<float>(as_number(obj->find_attr("rotation")));
+    n.opacity = static_cast<float>(as_number(obj->find_attr("opacity"), 1.0));
     // fill
-    auto fill_val = obj->get_attr("fill");
-    if (!std::holds_alternative<std::monostate>(fill_val)) {
-        if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    if (const mv_value* fill_val = obj->find_attr("fill")) {
+        if (auto* s = std::get_if<std::string>(fill_val)) n.fill = parse_color(*s);
         else if (auto fo = as_object(fill_val)) {
             if (fo->type_name == "Color") {
                 n.fill = {
-                    static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
-                    static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
-                    static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
-                    static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+                    static_cast<uint8_t>(as_number(fo->find_attr("r"), 255)),
+                    static_cast<uint8_t>(as_number(fo->find_attr("g"), 255)),
+                    static_cast<uint8_t>(as_number(fo->find_attr("b"), 255)),
+                    static_cast<uint8_t>(as_number(fo->find_attr("a"), 255))
                 };
             }
         }
@@ -107,99 +243,106 @@ rect_node extract_rect(const std::shared_ptr<mv_object>& obj) {
 
 line_node extract_line(const std::shared_ptr<mv_object>& obj) {
     line_node n;
-    n.x1 = static_cast<float>(as_number(obj->get_attr("x1")));
-    n.y1 = static_cast<float>(as_number(obj->get_attr("y1")));
-    n.x2 = static_cast<float>(as_number(obj->get_attr("x2"), 100));
-    n.y2 = static_cast<float>(as_number(obj->get_attr("y2"), 100));
-    n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 2));
-    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
-    auto stroke_val = obj->get_attr("stroke");
-    if (auto* s = std::get_if<std::string>(&stroke_val)) n.stroke = parse_color(*s);
+    n.x1 = static_cast<float>(as_number(obj->find_attr("x1")));
+    n.y1 = static_cast<float>(as_number(obj->find_attr("y1")));
+    n.x2 = static_cast<float>(as_number(obj->find_attr("x2"), 100));
+    n.y2 = static_cast<float>(as_number(obj->find_attr("y2"), 100));
+    n.thickness = static_cast<float>(as_number(obj->find_attr("thickness"), 2));
+    n.opacity = static_cast<float>(as_number(obj->find_attr("opacity"), 1.0));
+    if (const mv_value* stroke_val = obj->find_attr("stroke"); stroke_val != nullptr) {
+    if (auto* s = std::get_if<std::string>(stroke_val)) n.stroke = parse_color(*s);
     else if (auto so = as_object(stroke_val)) {
         if (so->type_name == "Color") {
             n.stroke = {
-                static_cast<uint8_t>(as_number(so->get_attr("r"), 255)),
-                static_cast<uint8_t>(as_number(so->get_attr("g"), 255)),
-                static_cast<uint8_t>(as_number(so->get_attr("b"), 255)),
-                static_cast<uint8_t>(as_number(so->get_attr("a"), 255))
+                static_cast<uint8_t>(as_number(so->find_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(so->find_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(so->find_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(so->find_attr("a"), 255))
             };
         }
+    }
     }
     return n;
 }
 
 text_node extract_text(const std::shared_ptr<mv_object>& obj) {
     text_node n;
-    n.text = as_string(obj->get_attr("text"));
-    n.x = static_cast<float>(as_number(obj->get_attr("x")));
-    n.y = static_cast<float>(as_number(obj->get_attr("y")));
-    n.font_size = static_cast<int>(as_number(obj->get_attr("font_size"), 20));
-    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
-    auto fill_val = obj->get_attr("fill");
-    if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    n.text = as_string(obj->find_attr("text"));
+    n.x = static_cast<float>(as_number(obj->find_attr("x")));
+    n.y = static_cast<float>(as_number(obj->find_attr("y")));
+    n.font_size = static_cast<int>(as_number(obj->find_attr("font_size"), 20));
+    n.opacity = static_cast<float>(as_number(obj->find_attr("opacity"), 1.0));
+    if (const mv_value* fill_val = obj->find_attr("fill"); fill_val != nullptr) {
+    if (auto* s = std::get_if<std::string>(fill_val)) n.fill = parse_color(*s);
     else if (auto fo = as_object(fill_val)) {
         if (fo->type_name == "Color") {
             n.fill = {
-                static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
-                static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
-                static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
-                static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+                static_cast<uint8_t>(as_number(fo->find_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(fo->find_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(fo->find_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(fo->find_attr("a"), 255))
             };
         }
+    }
     }
     return n;
 }
 
 circle_node extract_circle(const std::shared_ptr<mv_object>& obj) {
     circle_node n;
-    n.cx = static_cast<float>(as_number(obj->get_attr("cx")));
-    n.cy = static_cast<float>(as_number(obj->get_attr("cy")));
-    n.radius = static_cast<float>(as_number(obj->get_attr("radius"), 50));
-    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
-    auto fill_val = obj->get_attr("fill");
-    if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    n.cx = static_cast<float>(as_number(obj->find_attr("cx")));
+    n.cy = static_cast<float>(as_number(obj->find_attr("cy")));
+    n.radius = static_cast<float>(as_number(obj->find_attr("radius"), 50));
+    n.opacity = static_cast<float>(as_number(obj->find_attr("opacity"), 1.0));
+    if (const mv_value* fill_val = obj->find_attr("fill"); fill_val != nullptr) {
+    if (auto* s = std::get_if<std::string>(fill_val)) n.fill = parse_color(*s);
     else if (auto fo = as_object(fill_val)) {
         if (fo->type_name == "Color") {
             n.fill = {
-                static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
-                static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
-                static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
-                static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+                static_cast<uint8_t>(as_number(fo->find_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(fo->find_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(fo->find_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(fo->find_attr("a"), 255))
             };
         }
+    }
     }
     return n;
 }
 
 polyline_node extract_polyline(const std::shared_ptr<mv_object>& obj) {
     polyline_node n;
-    n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 2));
-    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
-    auto stroke_val = obj->get_attr("stroke");
-    if (auto* s = std::get_if<std::string>(&stroke_val)) n.stroke = parse_color(*s);
+    n.thickness = static_cast<float>(as_number(obj->find_attr("thickness"), 2));
+    n.opacity = static_cast<float>(as_number(obj->find_attr("opacity"), 1.0));
+    if (const mv_value* stroke_val = obj->find_attr("stroke"); stroke_val != nullptr) {
+    if (auto* s = std::get_if<std::string>(stroke_val)) n.stroke = parse_color(*s);
     else if (auto so = as_object(stroke_val)) {
         if (so->type_name == "Color") {
             n.stroke = {
-                static_cast<uint8_t>(as_number(so->get_attr("r"), 255)),
-                static_cast<uint8_t>(as_number(so->get_attr("g"), 255)),
-                static_cast<uint8_t>(as_number(so->get_attr("b"), 255)),
-                static_cast<uint8_t>(as_number(so->get_attr("a"), 255))
+                static_cast<uint8_t>(as_number(so->find_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(so->find_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(so->find_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(so->find_attr("a"), 255))
             };
         }
     }
+    }
 
-    auto points_val = obj->get_attr("points");
-    if (auto points = as_list(points_val)) {
+    if (auto points = as_list(obj->find_attr("points"))) {
         n.points.reserve(points->elements.size());
         for (const auto& point_val : points->elements) {
             auto point_obj = as_object(point_val);
             if (!point_obj || point_obj->type_name != "Point") {
                 continue;
             }
-            n.points.push_back({
-                static_cast<float>(as_number(point_obj->get_attr("x"))),
-                static_cast<float>(as_number(point_obj->get_attr("y")))
-            });
+            if (point_obj->cached_point.has_value()) {
+                n.points.push_back(*point_obj->cached_point);
+            } else {
+                n.points.push_back({
+                    static_cast<float>(as_number(point_obj->find_attr("x"))),
+                    static_cast<float>(as_number(point_obj->find_attr("y")))
+                });
+            }
         }
     }
 
@@ -299,6 +442,9 @@ background_node extract_background(const std::shared_ptr<mv_object>& obj) {
 std::optional<scene_node> convert_node(const mv_value& val) {
     auto obj = as_object(val);
     if (!obj) return std::nullopt;
+    if (obj->cached_scene_node.has_value()) {
+        return *obj->cached_scene_node;
+    }
 
     const auto& type = obj->type_name;
     if (type == "Rect")         return extract_rect(obj);
@@ -321,8 +467,16 @@ mv_value make_node_kwargs(const std::string& type_name,
                           const std::vector<std::pair<std::string, mv_value>>& kwargs) {
     auto obj = std::make_shared<mv_object>();
     obj->type_name = type_name;
+    obj->reserve_attrs(kwargs.size() + 2);
     for (auto& [k, v] : kwargs) {
         obj->set_attr(k, v);
+    }
+    if (type_name == "Point") {
+        if (auto point = build_cached_point_from_kwargs(kwargs)) {
+            obj->set_cached_point(*point);
+        }
+    } else if (auto cached_node = build_cached_scene_node_from_kwargs(type_name, kwargs)) {
+        obj->set_cached_scene_node(std::move(*cached_node));
     }
     return mv_value{obj};
 }

--- a/src/mv/api/mv_builtins.cpp
+++ b/src/mv/api/mv_builtins.cpp
@@ -1,0 +1,517 @@
+#include "mv_builtins.h"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+namespace mv {
+
+namespace {
+
+// ---- Helpers ----
+
+double as_number(const mv_value& v, double fallback = 0.0) {
+    if (auto* d = std::get_if<double>(&v)) return *d;
+    return fallback;
+}
+
+std::string as_string(const mv_value& v, const std::string& fallback = "") {
+    if (auto* s = std::get_if<std::string>(&v)) return *s;
+    return fallback;
+}
+
+std::shared_ptr<mv_object> as_object(const mv_value& v) {
+    if (auto* o = std::get_if<std::shared_ptr<mv_object>>(&v)) return *o;
+    return nullptr;
+}
+
+std::shared_ptr<mv_list> as_list(const mv_value& v) {
+    if (auto* l = std::get_if<std::shared_ptr<mv_list>>(&v)) return *l;
+    return nullptr;
+}
+
+// Find kwarg by name
+const mv_value* find_kwarg(const std::vector<std::pair<std::string, mv_value>>& kwargs,
+                           const std::string& name) {
+    for (auto& [k, v] : kwargs) {
+        if (k == name) return &v;
+    }
+    return nullptr;
+}
+
+double kwarg_number(const std::vector<std::pair<std::string, mv_value>>& kwargs,
+                    const std::string& name, double fallback) {
+    auto* v = find_kwarg(kwargs, name);
+    return v ? as_number(*v, fallback) : fallback;
+}
+
+std::string kwarg_string(const std::vector<std::pair<std::string, mv_value>>& kwargs,
+                         const std::string& name, const std::string& fallback) {
+    auto* v = find_kwarg(kwargs, name);
+    return v ? as_string(*v, fallback) : fallback;
+}
+
+// ---- Color helpers ----
+
+color color_from_kwarg(const std::vector<std::pair<std::string, mv_value>>& kwargs,
+                       const std::string& name, color fallback) {
+    auto* v = find_kwarg(kwargs, name);
+    if (!v) return fallback;
+    // Could be a string "#rrggbb" or an object from rgb()
+    if (auto* s = std::get_if<std::string>(v)) {
+        return parse_color(*s);
+    }
+    if (auto obj = as_object(*v)) {
+        if (obj->type_name == "Color") {
+            return {
+                static_cast<uint8_t>(as_number(obj->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(obj->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(obj->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(obj->get_attr("a"), 255))
+            };
+        }
+    }
+    return fallback;
+}
+
+// ---- Node extraction helpers ----
+
+rect_node extract_rect(const std::shared_ptr<mv_object>& obj) {
+    rect_node n;
+    n.x = static_cast<float>(as_number(obj->get_attr("x")));
+    n.y = static_cast<float>(as_number(obj->get_attr("y")));
+    n.w = static_cast<float>(as_number(obj->get_attr("w"), 100));
+    n.h = static_cast<float>(as_number(obj->get_attr("h"), 100));
+    n.rotation = static_cast<float>(as_number(obj->get_attr("rotation")));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    // fill
+    auto fill_val = obj->get_attr("fill");
+    if (!std::holds_alternative<std::monostate>(fill_val)) {
+        if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+        else if (auto fo = as_object(fill_val)) {
+            if (fo->type_name == "Color") {
+                n.fill = {
+                    static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
+                    static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
+                    static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
+                    static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+                };
+            }
+        }
+    }
+    return n;
+}
+
+line_node extract_line(const std::shared_ptr<mv_object>& obj) {
+    line_node n;
+    n.x1 = static_cast<float>(as_number(obj->get_attr("x1")));
+    n.y1 = static_cast<float>(as_number(obj->get_attr("y1")));
+    n.x2 = static_cast<float>(as_number(obj->get_attr("x2"), 100));
+    n.y2 = static_cast<float>(as_number(obj->get_attr("y2"), 100));
+    n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 2));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto stroke_val = obj->get_attr("stroke");
+    if (auto* s = std::get_if<std::string>(&stroke_val)) n.stroke = parse_color(*s);
+    else if (auto so = as_object(stroke_val)) {
+        if (so->type_name == "Color") {
+            n.stroke = {
+                static_cast<uint8_t>(as_number(so->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("a"), 255))
+            };
+        }
+    }
+    return n;
+}
+
+text_node extract_text(const std::shared_ptr<mv_object>& obj) {
+    text_node n;
+    n.text = as_string(obj->get_attr("text"));
+    n.x = static_cast<float>(as_number(obj->get_attr("x")));
+    n.y = static_cast<float>(as_number(obj->get_attr("y")));
+    n.font_size = static_cast<int>(as_number(obj->get_attr("font_size"), 20));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto fill_val = obj->get_attr("fill");
+    if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    else if (auto fo = as_object(fill_val)) {
+        if (fo->type_name == "Color") {
+            n.fill = {
+                static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+            };
+        }
+    }
+    return n;
+}
+
+circle_node extract_circle(const std::shared_ptr<mv_object>& obj) {
+    circle_node n;
+    n.cx = static_cast<float>(as_number(obj->get_attr("cx")));
+    n.cy = static_cast<float>(as_number(obj->get_attr("cy")));
+    n.radius = static_cast<float>(as_number(obj->get_attr("radius"), 50));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto fill_val = obj->get_attr("fill");
+    if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    else if (auto fo = as_object(fill_val)) {
+        if (fo->type_name == "Color") {
+            n.fill = {
+                static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+            };
+        }
+    }
+    return n;
+}
+
+spectrum_bar_node extract_spectrum_bar(const std::shared_ptr<mv_object>& obj) {
+    spectrum_bar_node n;
+    n.x = static_cast<float>(as_number(obj->get_attr("x")));
+    n.y = static_cast<float>(as_number(obj->get_attr("y")));
+    n.w = static_cast<float>(as_number(obj->get_attr("w"), 400));
+    n.h = static_cast<float>(as_number(obj->get_attr("h"), 200));
+    n.bar_count = static_cast<int>(as_number(obj->get_attr("bar_count"), 32));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto fill_val = obj->get_attr("fill");
+    if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    else if (auto fo = as_object(fill_val)) {
+        if (fo->type_name == "Color") {
+            n.fill = {
+                static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+            };
+        }
+    }
+    // spectrum data is injected by runtime, not user
+    return n;
+}
+
+beat_grid_node extract_beat_grid(const std::shared_ptr<mv_object>& obj) {
+    beat_grid_node n;
+    n.x = static_cast<float>(as_number(obj->get_attr("x")));
+    n.y = static_cast<float>(as_number(obj->get_attr("y")));
+    n.w = static_cast<float>(as_number(obj->get_attr("w"), 1280));
+    n.h = static_cast<float>(as_number(obj->get_attr("h"), 720));
+    n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 1));
+    n.beat_phase = static_cast<float>(as_number(obj->get_attr("beat_phase")));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto stroke_val = obj->get_attr("stroke");
+    if (auto* s = std::get_if<std::string>(&stroke_val)) n.stroke = parse_color(*s);
+    else if (auto so = as_object(stroke_val)) {
+        if (so->type_name == "Color") {
+            n.stroke = {
+                static_cast<uint8_t>(as_number(so->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("a"), 255))
+            };
+        }
+    }
+    return n;
+}
+
+pulse_ring_node extract_pulse_ring(const std::shared_ptr<mv_object>& obj) {
+    pulse_ring_node n;
+    n.cx = static_cast<float>(as_number(obj->get_attr("cx"), 640));
+    n.cy = static_cast<float>(as_number(obj->get_attr("cy"), 360));
+    n.radius = static_cast<float>(as_number(obj->get_attr("radius"), 100));
+    n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 3));
+    n.beat_phase = static_cast<float>(as_number(obj->get_attr("beat_phase")));
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto stroke_val = obj->get_attr("stroke");
+    if (auto* s = std::get_if<std::string>(&stroke_val)) n.stroke = parse_color(*s);
+    else if (auto so = as_object(stroke_val)) {
+        if (so->type_name == "Color") {
+            n.stroke = {
+                static_cast<uint8_t>(as_number(so->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(so->get_attr("a"), 255))
+            };
+        }
+    }
+    return n;
+}
+
+background_node extract_background(const std::shared_ptr<mv_object>& obj) {
+    background_node n;
+    n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
+    auto fill_val = obj->get_attr("fill");
+    if (auto* s = std::get_if<std::string>(&fill_val)) n.fill = parse_color(*s);
+    else if (auto fo = as_object(fill_val)) {
+        if (fo->type_name == "Color") {
+            n.fill = {
+                static_cast<uint8_t>(as_number(fo->get_attr("r"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("g"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("b"), 255)),
+                static_cast<uint8_t>(as_number(fo->get_attr("a"), 255))
+            };
+        }
+    }
+    return n;
+}
+
+// Convert a node mv_object to a scene_node
+std::optional<scene_node> convert_node(const mv_value& val) {
+    auto obj = as_object(val);
+    if (!obj) return std::nullopt;
+
+    const auto& type = obj->type_name;
+    if (type == "Rect")         return extract_rect(obj);
+    if (type == "Line")         return extract_line(obj);
+    if (type == "Text")         return extract_text(obj);
+    if (type == "Circle")       return extract_circle(obj);
+    if (type == "SpectrumBar")  return extract_spectrum_bar(obj);
+    if (type == "BeatGrid")     return extract_beat_grid(obj);
+    if (type == "PulseRing")    return extract_pulse_ring(obj);
+    if (type == "Background")   return extract_background(obj);
+    return std::nullopt;
+}
+
+// ---- Native function builders ----
+
+// Helper: create a node object from kwargs, setting all kwargs as attrs
+mv_value make_node_kwargs(const std::string& type_name,
+                          const std::vector<mv_value>& /*args*/,
+                          const std::vector<std::pair<std::string, mv_value>>& kwargs) {
+    auto obj = std::make_shared<mv_object>();
+    obj->type_name = type_name;
+    for (auto& [k, v] : kwargs) {
+        obj->set_attr(k, v);
+    }
+    return mv_value{obj};
+}
+
+} // anonymous namespace
+
+// ---- Color parsing ----
+
+color parse_color(const std::string& hex) {
+    if (hex.empty() || hex[0] != '#') return {255, 255, 255, 255};
+    auto parse_byte = [&](size_t pos) -> uint8_t {
+        if (pos + 1 >= hex.size()) return 0;
+        auto from_hex = [](char c) -> int {
+            if (c >= '0' && c <= '9') return c - '0';
+            if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+            if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+            return 0;
+        };
+        return static_cast<uint8_t>(from_hex(hex[pos]) * 16 + from_hex(hex[pos + 1]));
+    };
+
+    color c;
+    if (hex.size() >= 7) {
+        c.r = parse_byte(1);
+        c.g = parse_byte(3);
+        c.b = parse_byte(5);
+    }
+    c.a = (hex.size() >= 9) ? parse_byte(7) : 255;
+    return c;
+}
+
+// ---- Register builtins (generic, works with vm or sandbox) ----
+
+template<typename Host>
+void register_builtins_impl(Host& host) {
+    // Math functions
+    host.register_native("sin", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::sin(as_number(args[0]));
+    });
+    host.register_native("cos", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::cos(as_number(args[0]));
+    });
+    host.register_native("abs", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::abs(as_number(args[0]));
+    });
+    host.register_native("floor", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::floor(as_number(args[0]));
+    });
+    host.register_native("ceil", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::ceil(as_number(args[0]));
+    });
+    host.register_native("sqrt", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::sqrt(as_number(args[0]));
+    });
+    host.register_native("min", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.size() < 2) return 0.0;
+        return std::min(as_number(args[0]), as_number(args[1]));
+    });
+    host.register_native("max", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.size() < 2) return 0.0;
+        return std::max(as_number(args[0]), as_number(args[1]));
+    });
+    host.register_native("clamp", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.size() < 3) return 0.0;
+        double val = as_number(args[0]);
+        double lo = as_number(args[1]);
+        double hi = as_number(args[2]);
+        return std::clamp(val, lo, hi);
+    });
+    host.register_native("lerp", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.size() < 3) return 0.0;
+        double a = as_number(args[0]);
+        double b = as_number(args[1]);
+        double t = as_number(args[2]);
+        return a + (b - a) * t;
+    });
+    host.register_native("smoothstep", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.size() < 3) return 0.0;
+        double edge0 = as_number(args[0]);
+        double edge1 = as_number(args[1]);
+        double x = as_number(args[2]);
+        double t = std::clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0);
+        return t * t * (3.0 - 2.0 * t);
+    });
+
+    // Color constructor: rgb(r, g, b) or rgba(r, g, b, a)
+    host.register_native("rgb", [](const std::vector<mv_value>& args) -> mv_value {
+        auto obj = std::make_shared<mv_object>();
+        obj->type_name = "Color";
+        obj->set_attr("r", args.size() > 0 ? as_number(args[0]) : 255.0);
+        obj->set_attr("g", args.size() > 1 ? as_number(args[1]) : 255.0);
+        obj->set_attr("b", args.size() > 2 ? as_number(args[2]) : 255.0);
+        obj->set_attr("a", args.size() > 3 ? as_number(args[3]) : 255.0);
+        return mv_value{obj};
+    });
+
+    // Utility
+    host.register_native("len", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        if (auto l = as_list(args[0])) return static_cast<double>(l->elements.size());
+        if (auto* s = std::get_if<std::string>(&args[0])) return static_cast<double>(s->size());
+        return 0.0;
+    });
+    host.register_native("range", [](const std::vector<mv_value>& args) -> mv_value {
+        auto list = std::make_shared<mv_list>();
+        int start = 0, end = 0, step = 1;
+        if (args.size() == 1) { end = static_cast<int>(as_number(args[0])); }
+        else if (args.size() >= 2) {
+            start = static_cast<int>(as_number(args[0]));
+            end = static_cast<int>(as_number(args[1]));
+            if (args.size() >= 3) step = static_cast<int>(as_number(args[2]));
+        }
+        if (step == 0) step = 1;
+        if (step > 0) {
+            for (int i = start; i < end && list->elements.size() < 1024; i += step)
+                list->elements.push_back(static_cast<double>(i));
+        } else {
+            for (int i = start; i > end && list->elements.size() < 1024; i += step)
+                list->elements.push_back(static_cast<double>(i));
+        }
+        return mv_value{list};
+    });
+    host.register_native("str", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return std::string("");
+        return mv_value{value_to_string(args[0])};
+    });
+    host.register_native("int", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return std::floor(as_number(args[0]));
+    });
+    host.register_native("float", [](const std::vector<mv_value>& args) -> mv_value {
+        if (args.empty()) return 0.0;
+        return as_number(args[0]);
+    });
+
+    // Pi constant via function
+    host.register_native("pi", [](const std::vector<mv_value>&) -> mv_value {
+        return 3.14159265358979323846;
+    });
+
+    // ---- Scene/Node constructors (kwargs) ----
+
+    host.register_native_kwargs("Scene", [](const std::vector<mv_value>& args,
+                                          const std::vector<std::pair<std::string, mv_value>>& kwargs) -> mv_value {
+        auto obj = std::make_shared<mv_object>();
+        obj->type_name = "Scene";
+        // nodes from first positional arg (list) or default empty
+        if (!args.empty()) {
+            obj->set_attr("nodes", args[0]);
+        } else {
+            auto* v = find_kwarg(kwargs, "nodes");
+            if (v) obj->set_attr("nodes", *v);
+            else obj->set_attr("nodes", mv_value{std::make_shared<mv_list>()});
+        }
+        // clear_color
+        auto cc = kwarg_string(kwargs, "clear_color", "");
+        if (!cc.empty()) obj->set_attr("clear_color", mv_value{cc});
+        auto* cc_obj = find_kwarg(kwargs, "clear_color");
+        if (cc_obj && std::holds_alternative<std::shared_ptr<mv_object>>(*cc_obj)) {
+            obj->set_attr("clear_color", *cc_obj);
+        }
+        return mv_value{obj};
+    });
+
+    // Node constructors: all kwargs
+    auto make_node_ctor = [](const std::string& type_name) -> native_kwargs_function {
+        return [type_name](const std::vector<mv_value>& args,
+                          const std::vector<std::pair<std::string, mv_value>>& kwargs) -> mv_value {
+            return make_node_kwargs(type_name, args, kwargs);
+        };
+    };
+
+    host.register_native_kwargs("Rect", make_node_ctor("Rect"));
+    host.register_native_kwargs("Line", make_node_ctor("Line"));
+    host.register_native_kwargs("Text", make_node_ctor("Text"));
+    host.register_native_kwargs("Circle", make_node_ctor("Circle"));
+    host.register_native_kwargs("SpectrumBar", make_node_ctor("SpectrumBar"));
+    host.register_native_kwargs("BeatGrid", make_node_ctor("BeatGrid"));
+    host.register_native_kwargs("PulseRing", make_node_ctor("PulseRing"));
+    host.register_native_kwargs("Background", make_node_ctor("Background"));
+}
+
+void register_builtins(vm& v) { register_builtins_impl(v); }
+void register_builtins_to_sandbox(sandbox& sb) { register_builtins_impl(sb); }
+
+// ---- extract_scene ----
+
+std::optional<scene> extract_scene(const mv_value& val) {
+    auto obj = as_object(val);
+    if (!obj || obj->type_name != "Scene") return std::nullopt;
+
+    scene sc;
+
+    // clear_color
+    auto cc_val = obj->get_attr("clear_color");
+    if (auto* s = std::get_if<std::string>(&cc_val)) {
+        sc.clear_color = parse_color(*s);
+    } else if (auto cc_obj = as_object(cc_val)) {
+        if (cc_obj->type_name == "Color") {
+            sc.clear_color = {
+                static_cast<uint8_t>(as_number(cc_obj->get_attr("r"), 0)),
+                static_cast<uint8_t>(as_number(cc_obj->get_attr("g"), 0)),
+                static_cast<uint8_t>(as_number(cc_obj->get_attr("b"), 0)),
+                static_cast<uint8_t>(as_number(cc_obj->get_attr("a"), 0))
+            };
+        }
+    }
+
+    // nodes
+    auto nodes_val = obj->get_attr("nodes");
+    auto nodes_list = as_list(nodes_val);
+    if (nodes_list) {
+        sc.nodes.reserve(nodes_list->elements.size());
+        for (auto& elem : nodes_list->elements) {
+            auto node = convert_node(elem);
+            if (node.has_value()) {
+                sc.nodes.push_back(std::move(*node));
+            }
+        }
+    }
+
+    return sc;
+}
+
+} // namespace mv

--- a/src/mv/api/mv_builtins.h
+++ b/src/mv/api/mv_builtins.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "../lang/mv_sandbox.h"
+#include "../lang/mv_vm.h"
+#include "mv_scene.h"
+
+namespace mv {
+
+// Register all builtin functions (math, color, Scene/Node constructors) into the VM.
+void register_builtins(vm& vm);
+
+// Register all builtins into a sandbox (same functions, sandbox API).
+void register_builtins_to_sandbox(sandbox& sb);
+
+// Convert a VM mv_value (expected to be a Scene mv_object) into a C++ scene struct.
+// Returns nullopt if the value is not a valid scene.
+std::optional<scene> extract_scene(const mv_value& val);
+
+} // namespace mv

--- a/src/mv/api/mv_context.cpp
+++ b/src/mv/api/mv_context.cpp
@@ -1,0 +1,61 @@
+#include "mv_context.h"
+
+namespace mv {
+
+namespace {
+
+std::shared_ptr<mv_object> make_obj(const std::string& type) {
+    auto o = std::make_shared<mv_object>();
+    o->type_name = type;
+    return o;
+}
+
+} // anonymous namespace
+
+std::shared_ptr<mv_object> build_context(const context_input& input) {
+    auto ctx = make_obj("ctx");
+
+    // ctx.time
+    auto time = make_obj("time");
+    time->set_attr("ms", input.current_ms);
+    time->set_attr("sec", input.current_ms / 1000.0);
+    time->set_attr("length_ms", input.song_length_ms);
+    time->set_attr("bpm", static_cast<double>(input.bpm));
+    time->set_attr("beat", static_cast<double>(input.beat_number));
+    time->set_attr("beat_phase", static_cast<double>(input.beat_phase));
+    // normalized progress 0..1
+    double progress = (input.song_length_ms > 0)
+        ? input.current_ms / input.song_length_ms
+        : 0.0;
+    time->set_attr("progress", progress);
+    ctx->set_attr("time", mv_value{time});
+
+    // ctx.audio
+    auto audio = make_obj("audio");
+    auto spec_list = std::make_shared<mv_list>();
+    spec_list->elements.reserve(input.spectrum.size());
+    for (float v : input.spectrum) {
+        spec_list->elements.push_back(static_cast<double>(v));
+    }
+    audio->set_attr("spectrum", mv_value{spec_list});
+    audio->set_attr("spectrum_size", static_cast<double>(input.spectrum.size()));
+    ctx->set_attr("audio", mv_value{audio});
+
+    // ctx.chart
+    auto chart = make_obj("chart");
+    chart->set_attr("total_notes", static_cast<double>(input.total_notes));
+    chart->set_attr("combo", static_cast<double>(input.combo));
+    chart->set_attr("accuracy", static_cast<double>(input.accuracy));
+    chart->set_attr("key_count", static_cast<double>(input.key_count));
+    ctx->set_attr("chart", mv_value{chart});
+
+    // ctx.screen
+    auto screen = make_obj("screen");
+    screen->set_attr("w", static_cast<double>(input.screen_w));
+    screen->set_attr("h", static_cast<double>(input.screen_h));
+    ctx->set_attr("screen", mv_value{screen});
+
+    return ctx;
+}
+
+} // namespace mv

--- a/src/mv/api/mv_context.cpp
+++ b/src/mv/api/mv_context.cpp
@@ -7,55 +7,90 @@ namespace {
 std::shared_ptr<mv_object> make_obj(const std::string& type) {
     auto o = std::make_shared<mv_object>();
     o->type_name = type;
+    o->reserve_attrs(8);
     return o;
 }
 
 } // anonymous namespace
 
-std::shared_ptr<mv_object> build_context(const context_input& input) {
-    auto ctx = make_obj("ctx");
+context_builder::context_builder()
+    : ctx_(make_obj("ctx")),
+      time_(make_obj("time")),
+      audio_(make_obj("audio")),
+      chart_(make_obj("chart")),
+      screen_(make_obj("screen")),
+      spectrum_(std::make_shared<mv_list>()),
+      waveform_(std::make_shared<mv_list>()),
+      oscilloscope_(std::make_shared<mv_list>()) {
+    ctx_->set_attr("time", mv_value{time_});
+    ctx_->set_attr("audio", mv_value{audio_});
+    ctx_->set_attr("chart", mv_value{chart_});
+    ctx_->set_attr("screen", mv_value{screen_});
+    audio_->set_attr("spectrum", mv_value{spectrum_});
+    audio_->set_attr("waveform", mv_value{waveform_});
+    audio_->set_attr("oscilloscope", mv_value{oscilloscope_});
+}
 
-    // ctx.time
-    auto time = make_obj("time");
-    time->set_attr("ms", input.current_ms);
-    time->set_attr("sec", input.current_ms / 1000.0);
-    time->set_attr("length_ms", input.song_length_ms);
-    time->set_attr("bpm", static_cast<double>(input.bpm));
-    time->set_attr("beat", static_cast<double>(input.beat_number));
-    time->set_attr("beat_phase", static_cast<double>(input.beat_phase));
-    // normalized progress 0..1
-    double progress = (input.song_length_ms > 0)
+std::shared_ptr<mv_object> context_builder::build(const context_input& input) {
+    time_->set_attr("ms", input.current_ms);
+    time_->set_attr("sec", input.current_ms / 1000.0);
+    time_->set_attr("length_ms", input.song_length_ms);
+    time_->set_attr("bpm", static_cast<double>(input.bpm));
+    time_->set_attr("beat", static_cast<double>(input.beat_number));
+    time_->set_attr("beat_phase", static_cast<double>(input.beat_phase));
+
+    const double progress = (input.song_length_ms > 0)
         ? input.current_ms / input.song_length_ms
         : 0.0;
-    time->set_attr("progress", progress);
-    ctx->set_attr("time", mv_value{time});
+    time_->set_attr("progress", progress);
 
-    // ctx.audio
-    auto audio = make_obj("audio");
-    auto spec_list = std::make_shared<mv_list>();
-    spec_list->elements.reserve(input.spectrum.size());
+    spectrum_->elements.clear();
+    spectrum_->elements.reserve(input.spectrum.size());
     for (float v : input.spectrum) {
-        spec_list->elements.push_back(static_cast<double>(v));
+        spectrum_->elements.push_back(static_cast<double>(v));
     }
-    audio->set_attr("spectrum", mv_value{spec_list});
-    audio->set_attr("spectrum_size", static_cast<double>(input.spectrum.size()));
-    ctx->set_attr("audio", mv_value{audio});
+    audio_->set_attr("spectrum_size", static_cast<double>(input.spectrum.size()));
+    audio_->set_attr("level", static_cast<double>(input.level));
 
-    // ctx.chart
-    auto chart = make_obj("chart");
-    chart->set_attr("total_notes", static_cast<double>(input.total_notes));
-    chart->set_attr("combo", static_cast<double>(input.combo));
-    chart->set_attr("accuracy", static_cast<double>(input.accuracy));
-    chart->set_attr("key_count", static_cast<double>(input.key_count));
-    ctx->set_attr("chart", mv_value{chart});
+    const std::vector<float>* waveform_source = input.waveform;
+    if (waveform_source_ != waveform_source) {
+        waveform_source_ = waveform_source;
+        waveform_->elements.clear();
+        if (waveform_source != nullptr) {
+            waveform_->elements.reserve(waveform_source->size());
+            for (float v : *waveform_source) {
+                waveform_->elements.push_back(static_cast<double>(v));
+            }
+        }
+    }
+    audio_->set_attr("waveform_size", static_cast<double>(waveform_source != nullptr ? waveform_source->size() : 0));
+    audio_->set_attr("waveform_index", static_cast<double>(input.waveform_index));
 
-    // ctx.screen
-    auto screen = make_obj("screen");
-    screen->set_attr("w", static_cast<double>(input.screen_w));
-    screen->set_attr("h", static_cast<double>(input.screen_h));
-    ctx->set_attr("screen", mv_value{screen});
+    oscilloscope_->elements.clear();
+    if (input.oscilloscope != nullptr) {
+        oscilloscope_->elements.reserve(input.oscilloscope->size());
+        for (float v : *input.oscilloscope) {
+            oscilloscope_->elements.push_back(static_cast<double>(v));
+        }
+        audio_->set_attr("oscilloscope_size", static_cast<double>(input.oscilloscope->size()));
+    } else {
+        audio_->set_attr("oscilloscope_size", 0.0);
+    }
 
-    return ctx;
+    chart_->set_attr("total_notes", static_cast<double>(input.total_notes));
+    chart_->set_attr("combo", static_cast<double>(input.combo));
+    chart_->set_attr("accuracy", static_cast<double>(input.accuracy));
+    chart_->set_attr("key_count", static_cast<double>(input.key_count));
+
+    screen_->set_attr("w", static_cast<double>(input.screen_w));
+    screen_->set_attr("h", static_cast<double>(input.screen_h));
+
+    return ctx_;
+}
+
+std::shared_ptr<mv_object> build_context(const context_input& input) {
+    context_builder builder;
+    return builder.build(input);
 }
 
 } // namespace mv

--- a/src/mv/api/mv_context.h
+++ b/src/mv/api/mv_context.h
@@ -18,6 +18,10 @@ struct context_input {
 
     // audio
     std::vector<float> spectrum; // normalized 0..1, arbitrary bin count
+    const std::vector<float>* waveform = nullptr; // normalized 0..1, precomputed song-wide envelope
+    const std::vector<float>* oscilloscope = nullptr; // live PCM-ish mono samples, normalized -1..1
+    float level = 0.0f;      // current song amplitude sampled from waveform/envelope
+    int waveform_index = 0;  // current position inside waveform/envelope
 
     // chart
     int total_notes = 0;
@@ -33,5 +37,23 @@ struct context_input {
 // Build the ctx mv_object from context_input.
 // The returned object has sub-objects: ctx.time, ctx.audio, ctx.chart, ctx.screen
 std::shared_ptr<mv_object> build_context(const context_input& input);
+
+class context_builder {
+public:
+    context_builder();
+
+    std::shared_ptr<mv_object> build(const context_input& input);
+
+private:
+    std::shared_ptr<mv_object> ctx_;
+    std::shared_ptr<mv_object> time_;
+    std::shared_ptr<mv_object> audio_;
+    std::shared_ptr<mv_object> chart_;
+    std::shared_ptr<mv_object> screen_;
+    std::shared_ptr<mv_list> spectrum_;
+    std::shared_ptr<mv_list> waveform_;
+    std::shared_ptr<mv_list> oscilloscope_;
+    const std::vector<float>* waveform_source_ = nullptr;
+};
 
 } // namespace mv

--- a/src/mv/api/mv_context.h
+++ b/src/mv/api/mv_context.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "../lang/mv_vm.h"
+
+#include <vector>
+
+namespace mv {
+
+// Data fed into context builder each frame.
+// Decoupled from game types so mv/ stays independent.
+struct context_input {
+    // time
+    double current_ms = 0;
+    double song_length_ms = 0;
+    float bpm = 120.0f;
+    int beat_number = 0;      // absolute beat count from song start
+    float beat_phase = 0;     // 0..1 fraction within current beat
+
+    // audio
+    std::vector<float> spectrum; // normalized 0..1, arbitrary bin count
+
+    // chart
+    int total_notes = 0;
+    int combo = 0;
+    float accuracy = 0;       // 0..1
+    int key_count = 4;
+
+    // screen
+    float screen_w = 1280;
+    float screen_h = 720;
+};
+
+// Build the ctx mv_object from context_input.
+// The returned object has sub-objects: ctx.time, ctx.audio, ctx.chart, ctx.screen
+std::shared_ptr<mv_object> build_context(const context_input& input);
+
+} // namespace mv

--- a/src/mv/api/mv_scene.h
+++ b/src/mv/api/mv_scene.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace mv {
+
+// Color stored as RGBA (0-255 each)
+struct color {
+    uint8_t r = 255, g = 255, b = 255, a = 255;
+};
+
+// Parse "#rrggbb" or "#rrggbbaa"; returns white on failure
+color parse_color(const std::string& hex);
+
+// ---- Node types ----
+
+struct vec2 { float x = 0, y = 0; };
+
+struct rect_node {
+    float x = 0, y = 0, w = 100, h = 100;
+    color fill{255, 255, 255, 255};
+    float rotation = 0; // degrees
+    float opacity = 1.0f;
+};
+
+struct line_node {
+    float x1 = 0, y1 = 0, x2 = 100, y2 = 100;
+    color stroke{255, 255, 255, 255};
+    float thickness = 2.0f;
+    float opacity = 1.0f;
+};
+
+struct text_node {
+    std::string text;
+    float x = 0, y = 0;
+    int font_size = 20;
+    color fill{255, 255, 255, 255};
+    float opacity = 1.0f;
+};
+
+struct circle_node {
+    float cx = 0, cy = 0, radius = 50;
+    color fill{255, 255, 255, 255};
+    float opacity = 1.0f;
+};
+
+struct polyline_node {
+    std::vector<vec2> points;
+    color stroke{255, 255, 255, 255};
+    float thickness = 2.0f;
+    float opacity = 1.0f;
+};
+
+struct spectrum_bar_node {
+    float x = 0, y = 0, w = 400, h = 200;
+    int bar_count = 32;
+    color fill{100, 200, 255, 255};
+    float opacity = 1.0f;
+    std::vector<float> spectrum; // amplitude values 0..1, filled by ctx
+};
+
+struct beat_grid_node {
+    float x = 0, y = 0, w = 1280, h = 720;
+    color stroke{255, 255, 255, 60};
+    float thickness = 1.0f;
+    float beat_phase = 0; // 0..1, fraction within current beat
+    float opacity = 1.0f;
+};
+
+struct pulse_ring_node {
+    float cx = 640, cy = 360, radius = 100;
+    color stroke{255, 255, 255, 255};
+    float thickness = 3.0f;
+    float beat_phase = 0; // drives expansion/fade
+    float opacity = 1.0f;
+};
+
+struct background_node {
+    color fill{0, 0, 0, 255};
+    float opacity = 1.0f;
+};
+
+// Variant of all node types
+using scene_node = std::variant<
+    rect_node,
+    line_node,
+    text_node,
+    circle_node,
+    polyline_node,
+    spectrum_bar_node,
+    beat_grid_node,
+    pulse_ring_node,
+    background_node
+>;
+
+// A complete scene returned by draw(ctx)
+struct scene {
+    color clear_color{0, 0, 0, 0}; // transparent by default (no clear)
+    std::vector<scene_node> nodes;  // rendered front-to-back (later = on top)
+};
+
+} // namespace mv

--- a/src/mv/lang/mv_ast.h
+++ b/src/mv/lang/mv_ast.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace mv {
+
+struct source_location {
+    int line = 0;
+    int column = 0;
+};
+
+// Forward declarations
+struct expr;
+struct stmt;
+
+using expr_ptr = std::unique_ptr<expr>;
+using stmt_ptr = std::unique_ptr<stmt>;
+
+// ---- Expressions ----
+
+enum class binary_op {
+    add, sub, mul, div, mod, power,
+    eq, ne, lt, gt, le, ge,
+    logical_and, logical_or,
+};
+
+enum class unary_op {
+    negate, logical_not,
+};
+
+struct number_literal {
+    double value;
+};
+
+struct bool_literal {
+    bool value;
+};
+
+struct string_literal {
+    std::string value;
+};
+
+struct none_literal {};
+
+struct identifier {
+    std::string name;
+};
+
+struct binary_expr {
+    binary_op op;
+    expr_ptr left;
+    expr_ptr right;
+};
+
+struct unary_expr {
+    unary_op op;
+    expr_ptr operand;
+};
+
+struct call_expr {
+    expr_ptr callee;
+    std::vector<expr_ptr> args;
+};
+
+struct attr_expr {
+    expr_ptr object;
+    std::string attr;
+};
+
+struct index_expr {
+    expr_ptr object;
+    expr_ptr index;
+};
+
+struct list_expr {
+    std::vector<expr_ptr> elements;
+};
+
+struct keyword_arg {
+    std::string name;
+    expr_ptr value;
+};
+
+struct call_with_kwargs_expr {
+    expr_ptr callee;
+    std::vector<expr_ptr> positional_args;
+    std::vector<keyword_arg> keyword_args;
+};
+
+struct expr {
+    source_location loc;
+    std::variant<
+        number_literal,
+        bool_literal,
+        string_literal,
+        none_literal,
+        identifier,
+        binary_expr,
+        unary_expr,
+        call_expr,
+        attr_expr,
+        index_expr,
+        list_expr,
+        call_with_kwargs_expr
+    > kind;
+};
+
+// ---- Statements ----
+
+struct expr_stmt {
+    expr_ptr expression;
+};
+
+struct assign_stmt {
+    std::string name;
+    expr_ptr value;
+};
+
+struct attr_assign_stmt {
+    expr_ptr object;
+    std::string attr;
+    expr_ptr value;
+};
+
+struct index_assign_stmt {
+    expr_ptr object;
+    expr_ptr index;
+    expr_ptr value;
+};
+
+struct return_stmt {
+    std::optional<expr_ptr> value;
+};
+
+struct if_branch {
+    expr_ptr condition;
+    std::vector<stmt_ptr> body;
+};
+
+struct if_stmt {
+    if_branch main;
+    std::vector<if_branch> elifs;
+    std::vector<stmt_ptr> else_body;
+};
+
+struct for_stmt {
+    std::string var_name;
+    expr_ptr iterable;
+    std::vector<stmt_ptr> body;
+};
+
+struct func_def {
+    std::string name;
+    std::vector<std::string> params;
+    std::vector<stmt_ptr> body;
+};
+
+struct augmented_assign_stmt {
+    std::string name;
+    binary_op op; // add, sub, mul, div, mod
+    expr_ptr value;
+};
+
+struct stmt {
+    source_location loc;
+    std::variant<
+        expr_stmt,
+        assign_stmt,
+        attr_assign_stmt,
+        index_assign_stmt,
+        return_stmt,
+        if_stmt,
+        for_stmt,
+        func_def,
+        augmented_assign_stmt
+    > kind;
+};
+
+// ---- Program ----
+
+struct program {
+    std::vector<stmt_ptr> statements;
+};
+
+// ---- Helpers ----
+
+template<typename T, typename... Args>
+expr_ptr make_expr(source_location loc, Args&&... args) {
+    auto e = std::make_unique<expr>();
+    e->loc = loc;
+    e->kind = T{std::forward<Args>(args)...};
+    return e;
+}
+
+template<typename T, typename... Args>
+stmt_ptr make_stmt(source_location loc, Args&&... args) {
+    auto s = std::make_unique<stmt>();
+    s->loc = loc;
+    s->kind = T{std::forward<Args>(args)...};
+    return s;
+}
+
+} // namespace mv

--- a/src/mv/lang/mv_bytecode.h
+++ b/src/mv/lang/mv_bytecode.h
@@ -57,6 +57,7 @@ enum class opcode : uint8_t {
 
     // Lists
     build_list,       // arg: element count
+    append_list,      // pops list and value, appends value in place, pushes None
     load_index,
     store_index,
 

--- a/src/mv/lang/mv_bytecode.h
+++ b/src/mv/lang/mv_bytecode.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace mv {
+
+enum class opcode : uint8_t {
+    // Stack
+    load_const,       // arg: constant index
+    load_none,
+    load_true,
+    load_false,
+    pop,
+
+    // Variables
+    load_local,       // arg: local slot
+    store_local,      // arg: local slot
+    load_global,      // arg: name index in constant pool (string)
+    store_global,     // arg: name index
+
+    // Arithmetic
+    add,
+    sub,
+    mul,
+    div_op,
+    mod,
+    power,
+    negate,
+
+    // Comparison
+    cmp_eq,
+    cmp_ne,
+    cmp_lt,
+    cmp_gt,
+    cmp_le,
+    cmp_ge,
+
+    // Logic
+    logical_not,
+
+    // Control flow
+    jump,             // arg: absolute offset
+    jump_if_false,    // arg: absolute offset
+    jump_if_true,     // arg: absolute offset
+
+    // Functions
+    call,             // arg: arg count
+    return_op,
+
+    // Objects
+    load_attr,        // arg: name index
+    store_attr,       // arg: name index
+
+    // Lists
+    build_list,       // arg: element count
+    load_index,
+    store_index,
+
+    // Kwargs call
+    call_kwargs,      // arg: positional count, followed by kwarg count instruction
+    kwarg_count,      // arg: kwarg count (always follows call_kwargs)
+    load_kwarg_name,  // arg: name index (emitted before each kwarg value)
+};
+
+struct instruction {
+    opcode op;
+    uint32_t arg = 0;
+    int source_line = 0;
+};
+
+using constant_value = std::variant<double, bool, std::string>;
+
+struct function_chunk {
+    std::string name;
+    int param_count = 0;
+    int local_count = 0;
+    std::vector<instruction> code;
+};
+
+struct compiled_program {
+    std::vector<constant_value> constants;
+    std::vector<function_chunk> functions;      // index 0 = top-level (implicit __main__)
+    std::unordered_map<std::string, int> function_map; // name → function index
+};
+
+} // namespace mv

--- a/src/mv/lang/mv_compiler.cpp
+++ b/src/mv/lang/mv_compiler.cpp
@@ -1,6 +1,7 @@
 #include "mv_compiler.h"
 
 #include <algorithm>
+#include <array>
 #include <sstream>
 
 namespace mv {
@@ -16,6 +17,8 @@ struct compiler_state {
     int current_func_idx = -1;
     std::vector<std::pair<std::string, int>> locals; // name -> slot
     int scope_depth = 0;
+    std::string current_func_name;
+    int draw_nodes_slot = -1;
 
     function_chunk& current_chunk() { return output.functions[current_func_idx]; }
 
@@ -70,6 +73,64 @@ struct compiler_state {
             current_chunk().local_count = slot + 1;
         }
         return slot;
+    }
+
+    bool in_draw_function() const {
+        return current_func_name == "draw" && draw_nodes_slot >= 0;
+    }
+
+    bool is_named_identifier(const expr& e, const std::string& name) const {
+        if (auto* id = std::get_if<identifier>(&e.kind)) {
+            return id->name == name;
+        }
+        return false;
+    }
+
+    bool is_named_call(const expr& e, const std::vector<std::string>& names) const {
+        return std::visit([&](const auto& node) -> bool {
+            using T = std::decay_t<decltype(node)>;
+            if constexpr (std::is_same_v<T, call_expr>) {
+                return std::any_of(names.begin(), names.end(), [&](const std::string& name) {
+                    return is_named_identifier(*node.callee, name);
+                });
+            }
+            else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
+                return std::any_of(names.begin(), names.end(), [&](const std::string& name) {
+                    return is_named_identifier(*node.callee, name);
+                });
+            }
+            return false;
+        }, e.kind);
+    }
+
+    bool is_draw_node_expr(const expr& e) const {
+        static const std::vector<std::string> kNodeNames = {
+            "Background", "Rect", "Circle", "Line", "Text", "Polyline",
+            "SpectrumBar", "BeatGrid", "PulseRing"
+        };
+        return is_named_call(e, kNodeNames);
+    }
+
+    void compile_draw_node_append(const expr& e, int line) {
+        emit(opcode::load_local, draw_nodes_slot, line);
+        compile_expr(e);
+        emit(opcode::append_list, line);
+    }
+
+    bool is_append_call(const call_expr& node) const {
+        if (node.args.size() != 1) {
+            return false;
+        }
+        const auto* attr = std::get_if<attr_expr>(&node.callee->kind);
+        return attr != nullptr && attr->attr == "append";
+    }
+
+    void compile_append_call_expr(const call_expr& node, int line) {
+        const auto* attr = std::get_if<attr_expr>(&node.callee->kind);
+        compile_expr(*attr->object);
+        compile_expr(*node.args[0]);
+        emit(opcode::append_list, line);
+        emit(opcode::load_none, line);
     }
 
     // ---- Compile expressions ----
@@ -149,11 +210,15 @@ struct compiler_state {
                 }
             }
             else if constexpr (std::is_same_v<T, call_expr>) {
-                compile_expr(*node.callee);
-                for (auto& arg : node.args) {
-                    compile_expr(*arg);
+                if (is_append_call(node)) {
+                    compile_append_call_expr(node, line);
+                } else {
+                    compile_expr(*node.callee);
+                    for (auto& arg : node.args) {
+                        compile_expr(*arg);
+                    }
+                    emit(opcode::call, static_cast<uint32_t>(node.args.size()), line);
                 }
-                emit(opcode::call, static_cast<uint32_t>(node.args.size()), line);
             }
             else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
                 compile_expr(*node.callee);
@@ -196,8 +261,12 @@ struct compiler_state {
             using T = std::decay_t<decltype(node)>;
 
             if constexpr (std::is_same_v<T, expr_stmt>) {
-                compile_expr(*node.expression);
-                emit(opcode::pop, line);
+                if (in_draw_function() && is_draw_node_expr(*node.expression)) {
+                    compile_draw_node_append(*node.expression, line);
+                } else {
+                    compile_expr(*node.expression);
+                    emit(opcode::pop, line);
+                }
             }
             else if constexpr (std::is_same_v<T, assign_stmt>) {
                 compile_expr(*node.value);
@@ -322,6 +391,8 @@ struct compiler_state {
                 int prev_func_idx = current_func_idx;
                 auto prev_locals = std::move(locals);
                 auto prev_depth = scope_depth;
+                auto prev_func_name = current_func_name;
+                int prev_draw_nodes_slot = draw_nodes_slot;
 
                 // Create new function chunk
                 int func_idx = static_cast<int>(output.functions.size());
@@ -335,10 +406,18 @@ struct compiler_state {
                 current_func_idx = func_idx;
                 locals.clear();
                 scope_depth = 0;
+                current_func_name = node.name;
+                draw_nodes_slot = -1;
 
                 // Declare params as locals
                 for (auto& param : node.params) {
                     declare_local(param);
+                }
+
+                if (current_func_name == "draw") {
+                    draw_nodes_slot = declare_local("__draw_nodes__");
+                    emit(opcode::build_list, 0, line);
+                    emit(opcode::store_local, draw_nodes_slot, line);
                 }
 
                 // Compile body
@@ -346,14 +425,23 @@ struct compiler_state {
                     compile_stmt(*stmt);
                 }
 
-                // Implicit return None
-                emit(opcode::load_none, line);
+                // Implicit return Scene(collected_nodes) for draw(), otherwise None
+                if (current_func_name == "draw") {
+                    int scene_name_idx = add_string_constant("Scene");
+                    emit(opcode::load_global, scene_name_idx, line);
+                    emit(opcode::load_local, draw_nodes_slot, line);
+                    emit(opcode::call, 1, line);
+                } else {
+                    emit(opcode::load_none, line);
+                }
                 emit(opcode::return_op, line);
 
                 // Restore state
                 current_func_idx = prev_func_idx;
                 locals = std::move(prev_locals);
                 scope_depth = prev_depth;
+                current_func_name = std::move(prev_func_name);
+                draw_nodes_slot = prev_draw_nodes_slot;
             }
             else if constexpr (std::is_same_v<T, augmented_assign_stmt>) {
                 int slot = resolve_local(node.name);

--- a/src/mv/lang/mv_compiler.cpp
+++ b/src/mv/lang/mv_compiler.cpp
@@ -1,0 +1,405 @@
+#include "mv_compiler.h"
+
+#include <algorithm>
+#include <sstream>
+
+namespace mv {
+
+namespace {
+
+struct compiler_state {
+    compiled_program output;
+    std::vector<std::string> errors;
+    bool had_error = false;
+
+    // Current function being compiled (index into output.functions)
+    int current_func_idx = -1;
+    std::vector<std::pair<std::string, int>> locals; // name -> slot
+    int scope_depth = 0;
+
+    function_chunk& current_chunk() { return output.functions[current_func_idx]; }
+
+    void error(int line, const std::string& msg) {
+        std::ostringstream oss;
+        oss << "compile error line " << line << ": " << msg;
+        errors.push_back(oss.str());
+        had_error = true;
+    }
+
+    int add_constant(const constant_value& val) {
+        auto& consts = output.constants;
+        for (int i = 0; i < static_cast<int>(consts.size()); i++) {
+            if (consts[i] == val) return i;
+        }
+        consts.push_back(val);
+        return static_cast<int>(consts.size()) - 1;
+    }
+
+    int add_string_constant(const std::string& s) {
+        return add_constant(constant_value{s});
+    }
+
+    void emit(opcode op, uint32_t arg, int line) {
+        current_chunk().code.push_back({op, arg, line});
+    }
+
+    void emit(opcode op, int line) {
+        current_chunk().code.push_back({op, 0, line});
+    }
+
+    int emit_jump(opcode op, int line) {
+        current_chunk().code.push_back({op, 0, line});
+        return static_cast<int>(current_chunk().code.size()) - 1;
+    }
+
+    void patch_jump(int offset) {
+        current_chunk().code[offset].arg = static_cast<uint32_t>(current_chunk().code.size());
+    }
+
+    int resolve_local(const std::string& name) {
+        for (int i = static_cast<int>(locals.size()) - 1; i >= 0; i--) {
+            if (locals[i].first == name) return locals[i].second;
+        }
+        return -1;
+    }
+
+    int declare_local(const std::string& name) {
+        int slot = static_cast<int>(locals.size());
+        locals.push_back({name, slot});
+        if (slot + 1 > current_chunk().local_count) {
+            current_chunk().local_count = slot + 1;
+        }
+        return slot;
+    }
+
+    // ---- Compile expressions ----
+
+    void compile_expr(const expr& e) {
+        int line = e.loc.line;
+
+        std::visit([&](const auto& node) {
+            using T = std::decay_t<decltype(node)>;
+
+            if constexpr (std::is_same_v<T, number_literal>) {
+                int idx = add_constant(node.value);
+                emit(opcode::load_const, idx, line);
+            }
+            else if constexpr (std::is_same_v<T, bool_literal>) {
+                emit(node.value ? opcode::load_true : opcode::load_false, line);
+            }
+            else if constexpr (std::is_same_v<T, string_literal>) {
+                int idx = add_constant(constant_value{node.value});
+                emit(opcode::load_const, idx, line);
+            }
+            else if constexpr (std::is_same_v<T, none_literal>) {
+                emit(opcode::load_none, line);
+            }
+            else if constexpr (std::is_same_v<T, identifier>) {
+                int slot = resolve_local(node.name);
+                if (slot >= 0) {
+                    emit(opcode::load_local, slot, line);
+                } else {
+                    int name_idx = add_string_constant(node.name);
+                    emit(opcode::load_global, name_idx, line);
+                }
+            }
+            else if constexpr (std::is_same_v<T, binary_expr>) {
+                // Short-circuit for and/or
+                if (node.op == binary_op::logical_and) {
+                    compile_expr(*node.left);
+                    int jump = emit_jump(opcode::jump_if_false, line);
+                    emit(opcode::pop, line);
+                    compile_expr(*node.right);
+                    patch_jump(jump);
+                    return;
+                }
+                if (node.op == binary_op::logical_or) {
+                    compile_expr(*node.left);
+                    int jump = emit_jump(opcode::jump_if_true, line);
+                    emit(opcode::pop, line);
+                    compile_expr(*node.right);
+                    patch_jump(jump);
+                    return;
+                }
+
+                compile_expr(*node.left);
+                compile_expr(*node.right);
+
+                switch (node.op) {
+                    case binary_op::add: emit(opcode::add, line); break;
+                    case binary_op::sub: emit(opcode::sub, line); break;
+                    case binary_op::mul: emit(opcode::mul, line); break;
+                    case binary_op::div: emit(opcode::div_op, line); break;
+                    case binary_op::mod: emit(opcode::mod, line); break;
+                    case binary_op::power: emit(opcode::power, line); break;
+                    case binary_op::eq: emit(opcode::cmp_eq, line); break;
+                    case binary_op::ne: emit(opcode::cmp_ne, line); break;
+                    case binary_op::lt: emit(opcode::cmp_lt, line); break;
+                    case binary_op::gt: emit(opcode::cmp_gt, line); break;
+                    case binary_op::le: emit(opcode::cmp_le, line); break;
+                    case binary_op::ge: emit(opcode::cmp_ge, line); break;
+                    default: break;
+                }
+            }
+            else if constexpr (std::is_same_v<T, unary_expr>) {
+                compile_expr(*node.operand);
+                switch (node.op) {
+                    case unary_op::negate: emit(opcode::negate, line); break;
+                    case unary_op::logical_not: emit(opcode::logical_not, line); break;
+                }
+            }
+            else if constexpr (std::is_same_v<T, call_expr>) {
+                compile_expr(*node.callee);
+                for (auto& arg : node.args) {
+                    compile_expr(*arg);
+                }
+                emit(opcode::call, static_cast<uint32_t>(node.args.size()), line);
+            }
+            else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
+                compile_expr(*node.callee);
+                for (auto& arg : node.positional_args) {
+                    compile_expr(*arg);
+                }
+                for (auto& kw : node.keyword_args) {
+                    int name_idx = add_string_constant(kw.name);
+                    emit(opcode::load_kwarg_name, name_idx, line);
+                    compile_expr(*kw.value);
+                }
+                emit(opcode::call_kwargs, static_cast<uint32_t>(node.positional_args.size()), line);
+                emit(opcode::kwarg_count, static_cast<uint32_t>(node.keyword_args.size()), line);
+            }
+            else if constexpr (std::is_same_v<T, attr_expr>) {
+                compile_expr(*node.object);
+                int name_idx = add_string_constant(node.attr);
+                emit(opcode::load_attr, name_idx, line);
+            }
+            else if constexpr (std::is_same_v<T, index_expr>) {
+                compile_expr(*node.object);
+                compile_expr(*node.index);
+                emit(opcode::load_index, line);
+            }
+            else if constexpr (std::is_same_v<T, list_expr>) {
+                for (auto& elem : node.elements) {
+                    compile_expr(*elem);
+                }
+                emit(opcode::build_list, static_cast<uint32_t>(node.elements.size()), line);
+            }
+        }, e.kind);
+    }
+
+    // ---- Compile statements ----
+
+    void compile_stmt(const stmt& s) {
+        int line = s.loc.line;
+
+        std::visit([&](const auto& node) {
+            using T = std::decay_t<decltype(node)>;
+
+            if constexpr (std::is_same_v<T, expr_stmt>) {
+                compile_expr(*node.expression);
+                emit(opcode::pop, line);
+            }
+            else if constexpr (std::is_same_v<T, assign_stmt>) {
+                compile_expr(*node.value);
+                int slot = resolve_local(node.name);
+                if (slot < 0) {
+                    slot = declare_local(node.name);
+                }
+                emit(opcode::store_local, slot, line);
+            }
+            else if constexpr (std::is_same_v<T, attr_assign_stmt>) {
+                compile_expr(*node.object);
+                compile_expr(*node.value);
+                int name_idx = add_string_constant(node.attr);
+                emit(opcode::store_attr, name_idx, line);
+            }
+            else if constexpr (std::is_same_v<T, index_assign_stmt>) {
+                compile_expr(*node.object);
+                compile_expr(*node.index);
+                compile_expr(*node.value);
+                emit(opcode::store_index, line);
+            }
+            else if constexpr (std::is_same_v<T, return_stmt>) {
+                if (node.value.has_value()) {
+                    compile_expr(*node.value.value());
+                } else {
+                    emit(opcode::load_none, line);
+                }
+                emit(opcode::return_op, line);
+            }
+            else if constexpr (std::is_same_v<T, if_stmt>) {
+                compile_expr(*node.main.condition);
+                int false_jump = emit_jump(opcode::jump_if_false, line);
+                emit(opcode::pop, line);
+
+                for (auto& stmt : node.main.body) {
+                    compile_stmt(*stmt);
+                }
+
+                std::vector<int> end_jumps;
+                end_jumps.push_back(emit_jump(opcode::jump, line));
+
+                patch_jump(false_jump);
+                emit(opcode::pop, line);
+
+                for (auto& elif : node.elifs) {
+                    compile_expr(*elif.condition);
+                    int elif_false = emit_jump(opcode::jump_if_false, elif.condition->loc.line);
+                    emit(opcode::pop, elif.condition->loc.line);
+
+                    for (auto& stmt : elif.body) {
+                        compile_stmt(*stmt);
+                    }
+                    end_jumps.push_back(emit_jump(opcode::jump, line));
+
+                    patch_jump(elif_false);
+                    emit(opcode::pop, line);
+                }
+
+                for (auto& stmt : node.else_body) {
+                    compile_stmt(*stmt);
+                }
+
+                for (int j : end_jumps) {
+                    patch_jump(j);
+                }
+            }
+            else if constexpr (std::is_same_v<T, for_stmt>) {
+                // Evaluate iterable
+                compile_expr(*node.iterable);
+                int list_slot = declare_local("__for_list__");
+                emit(opcode::store_local, list_slot, line);
+
+                // Iterator index = 0
+                int idx_const = add_constant(0.0);
+                emit(opcode::load_const, idx_const, line);
+                int idx_slot = declare_local("__for_idx__");
+                emit(opcode::store_local, idx_slot, line);
+
+                // Loop variable
+                int var_slot = resolve_local(node.var_name);
+                if (var_slot < 0) var_slot = declare_local(node.var_name);
+
+                // Loop start
+                int loop_start = static_cast<int>(current_chunk().code.size());
+
+                // load list, load idx, index -> if out of bounds VM returns None
+                emit(opcode::load_local, list_slot, line);
+                emit(opcode::load_local, idx_slot, line);
+                emit(opcode::load_index, line);
+
+                // If None (out of bounds), exit loop
+                emit(opcode::load_none, line);
+                emit(opcode::cmp_eq, line);
+                int exit_jump = emit_jump(opcode::jump_if_true, line);
+                emit(opcode::pop, line); // pop comparison result
+
+                // Re-load the actual value
+                emit(opcode::load_local, list_slot, line);
+                emit(opcode::load_local, idx_slot, line);
+                emit(opcode::load_index, line);
+                emit(opcode::store_local, var_slot, line);
+
+                // Body
+                for (auto& stmt : node.body) {
+                    compile_stmt(*stmt);
+                }
+
+                // Increment index
+                emit(opcode::load_local, idx_slot, line);
+                int one_const = add_constant(1.0);
+                emit(opcode::load_const, one_const, line);
+                emit(opcode::add, line);
+                emit(opcode::store_local, idx_slot, line);
+
+                // Jump back
+                emit(opcode::jump, static_cast<uint32_t>(loop_start), line);
+                patch_jump(exit_jump);
+                emit(opcode::pop, line); // pop comparison result
+            }
+            else if constexpr (std::is_same_v<T, func_def>) {
+                // Save state
+                int prev_func_idx = current_func_idx;
+                auto prev_locals = std::move(locals);
+                auto prev_depth = scope_depth;
+
+                // Create new function chunk
+                int func_idx = static_cast<int>(output.functions.size());
+                output.function_map[node.name] = func_idx;
+
+                function_chunk chunk;
+                chunk.name = node.name;
+                chunk.param_count = static_cast<int>(node.params.size());
+                output.functions.push_back(std::move(chunk));
+
+                current_func_idx = func_idx;
+                locals.clear();
+                scope_depth = 0;
+
+                // Declare params as locals
+                for (auto& param : node.params) {
+                    declare_local(param);
+                }
+
+                // Compile body
+                for (auto& stmt : node.body) {
+                    compile_stmt(*stmt);
+                }
+
+                // Implicit return None
+                emit(opcode::load_none, line);
+                emit(opcode::return_op, line);
+
+                // Restore state
+                current_func_idx = prev_func_idx;
+                locals = std::move(prev_locals);
+                scope_depth = prev_depth;
+            }
+            else if constexpr (std::is_same_v<T, augmented_assign_stmt>) {
+                int slot = resolve_local(node.name);
+                if (slot < 0) {
+                    error(line, "variable '" + node.name + "' used before assignment");
+                    return;
+                }
+                emit(opcode::load_local, slot, line);
+                compile_expr(*node.value);
+                switch (node.op) {
+                    case binary_op::add: emit(opcode::add, line); break;
+                    case binary_op::sub: emit(opcode::sub, line); break;
+                    case binary_op::mul: emit(opcode::mul, line); break;
+                    case binary_op::div: emit(opcode::div_op, line); break;
+                    case binary_op::mod: emit(opcode::mod, line); break;
+                    default: break;
+                }
+                emit(opcode::store_local, slot, line);
+            }
+        }, s.kind);
+    }
+
+    void compile_program(const program& ast) {
+        // Create top-level chunk (__main__)
+        function_chunk main_chunk;
+        main_chunk.name = "__main__";
+        output.functions.push_back(std::move(main_chunk));
+        output.function_map["__main__"] = 0;
+        current_func_idx = 0;
+
+        for (auto& s : ast.statements) {
+            compile_stmt(*s);
+        }
+
+        // Top-level implicit return None
+        emit(opcode::load_none, 0);
+        emit(opcode::return_op, 0);
+    }
+};
+
+} // anonymous namespace
+
+compile_result compile(const program& ast) {
+    compiler_state state;
+    state.compile_program(ast);
+    return {std::move(state.output), std::move(state.errors), !state.had_error};
+}
+
+} // namespace mv

--- a/src/mv/lang/mv_compiler.h
+++ b/src/mv/lang/mv_compiler.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "mv_ast.h"
+#include "mv_bytecode.h"
+
+#include <string>
+#include <vector>
+
+namespace mv {
+
+struct compile_result {
+    compiled_program program;
+    std::vector<std::string> errors;
+    bool success = true;
+};
+
+compile_result compile(const program& ast);
+
+} // namespace mv

--- a/src/mv/lang/mv_lexer.cpp
+++ b/src/mv/lang/mv_lexer.cpp
@@ -1,0 +1,263 @@
+#include "mv_lexer.h"
+
+#include <algorithm>
+#include <sstream>
+
+namespace mv {
+
+namespace {
+
+bool is_alpha(char c) { return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_'; }
+bool is_digit(char c) { return c >= '0' && c <= '9'; }
+bool is_alnum(char c) { return is_alpha(c) || is_digit(c); }
+
+struct lexer_state {
+    const std::string& source;
+    int pos = 0;
+    int line = 1;
+    int column = 1;
+    std::vector<int> indent_stack = {0};
+    std::vector<token> tokens;
+    std::vector<std::string> errors;
+    bool at_line_start = true;
+    bool has_error = false;
+
+    char peek() const { return pos < static_cast<int>(source.size()) ? source[pos] : '\0'; }
+    char peek_next() const { return pos + 1 < static_cast<int>(source.size()) ? source[pos + 1] : '\0'; }
+    bool at_end() const { return pos >= static_cast<int>(source.size()); }
+
+    char advance() {
+        char c = source[pos++];
+        if (c == '\n') { line++; column = 1; }
+        else { column++; }
+        return c;
+    }
+
+    void emit(token_type type, const std::string& text, int tok_line, int tok_col) {
+        tokens.push_back({type, text, tok_line, tok_col});
+    }
+
+    void error(const std::string& msg) {
+        std::ostringstream oss;
+        oss << "line " << line << ":" << column << ": " << msg;
+        errors.push_back(oss.str());
+        has_error = true;
+    }
+
+    void skip_comment() {
+        while (!at_end() && peek() != '\n') advance();
+    }
+
+    void process_indent() {
+        int spaces = 0;
+        while (!at_end() && peek() == ' ') {
+            advance();
+            spaces++;
+        }
+        // Tabs: treat each as 4 spaces
+        while (!at_end() && peek() == '\t') {
+            advance();
+            spaces += 4;
+        }
+
+        // Skip blank lines and comment-only lines
+        if (at_end() || peek() == '\n' || peek() == '#') return;
+
+        int current_indent = indent_stack.back();
+        if (spaces > current_indent) {
+            indent_stack.push_back(spaces);
+            emit(token_type::indent, "", line, 1);
+        } else {
+            while (spaces < indent_stack.back()) {
+                indent_stack.pop_back();
+                emit(token_type::dedent, "", line, 1);
+            }
+            if (spaces != indent_stack.back()) {
+                error("inconsistent indentation");
+            }
+        }
+    }
+
+    token_type keyword_or_ident(const std::string& text) {
+        if (text == "def") return token_type::kw_def;
+        if (text == "return") return token_type::kw_return;
+        if (text == "if") return token_type::kw_if;
+        if (text == "elif") return token_type::kw_elif;
+        if (text == "else") return token_type::kw_else;
+        if (text == "for") return token_type::kw_for;
+        if (text == "in") return token_type::kw_in;
+        if (text == "and") return token_type::kw_and;
+        if (text == "or") return token_type::kw_or;
+        if (text == "not") return token_type::kw_not;
+        if (text == "True") return token_type::true_lit;
+        if (text == "False") return token_type::false_lit;
+        if (text == "None") return token_type::none_lit;
+        return token_type::ident;
+    }
+
+    bool is_forbidden_keyword(const std::string& text) {
+        return text == "import" || text == "class" || text == "eval" ||
+               text == "exec" || text == "global" || text == "nonlocal" ||
+               text == "open" || text == "from" || text == "with" ||
+               text == "yield" || text == "async" || text == "await" ||
+               text == "lambda" || text == "del" || text == "raise" ||
+               text == "try" || text == "except" || text == "finally";
+    }
+
+    void lex_number() {
+        int tok_line = line, tok_col = column;
+        int start = pos;
+        while (!at_end() && is_digit(peek())) advance();
+        if (!at_end() && peek() == '.' && is_digit(peek_next())) {
+            advance(); // consume '.'
+            while (!at_end() && is_digit(peek())) advance();
+        }
+        emit(token_type::number, source.substr(start, pos - start), tok_line, tok_col);
+    }
+
+    void lex_string(char quote) {
+        int tok_line = line, tok_col = column;
+        advance(); // consume opening quote
+        std::string value;
+        while (!at_end() && peek() != quote && peek() != '\n') {
+            if (peek() == '\\') {
+                advance();
+                if (at_end()) break;
+                char escaped = advance();
+                switch (escaped) {
+                    case 'n': value += '\n'; break;
+                    case 't': value += '\t'; break;
+                    case '\\': value += '\\'; break;
+                    case '\'': value += '\''; break;
+                    case '"': value += '"'; break;
+                    default: value += '\\'; value += escaped; break;
+                }
+            } else {
+                value += advance();
+            }
+        }
+        if (at_end() || peek() == '\n') {
+            error("unterminated string literal");
+            return;
+        }
+        advance(); // consume closing quote
+        emit(token_type::string_lit, value, tok_line, tok_col);
+    }
+
+    void lex_identifier() {
+        int tok_line = line, tok_col = column;
+        int start = pos;
+        while (!at_end() && is_alnum(peek())) advance();
+        std::string text = source.substr(start, pos - start);
+
+        if (is_forbidden_keyword(text)) {
+            error("'" + text + "' is not allowed in MV scripts");
+            return;
+        }
+
+        token_type type = keyword_or_ident(text);
+        emit(type, text, tok_line, tok_col);
+    }
+
+    void lex_all() {
+        while (!at_end()) {
+            if (has_error && errors.size() > 10) break;
+
+            if (at_line_start) {
+                at_line_start = false;
+                process_indent();
+                if (at_end()) break;
+            }
+
+            char c = peek();
+
+            if (c == '\n') {
+                // Only emit newline if last token is meaningful
+                if (!tokens.empty()) {
+                    auto last = tokens.back().type;
+                    if (last != token_type::newline && last != token_type::indent &&
+                        last != token_type::dedent) {
+                        emit(token_type::newline, "", line, column);
+                    }
+                }
+                advance();
+                at_line_start = true;
+                continue;
+            }
+
+            if (c == '#') {
+                skip_comment();
+                continue;
+            }
+
+            if (c == ' ' || c == '\t' || c == '\r') {
+                advance();
+                continue;
+            }
+
+            if (is_digit(c)) { lex_number(); continue; }
+            if (c == '"' || c == '\'') { lex_string(c); continue; }
+            if (is_alpha(c)) { lex_identifier(); continue; }
+
+            int tok_line = line, tok_col = column;
+
+            // Two-character operators
+            if (c == '*' && peek_next() == '*') { advance(); advance(); emit(token_type::power, "**", tok_line, tok_col); continue; }
+            if (c == '=' && peek_next() == '=') { advance(); advance(); emit(token_type::eq, "==", tok_line, tok_col); continue; }
+            if (c == '!' && peek_next() == '=') { advance(); advance(); emit(token_type::ne, "!=", tok_line, tok_col); continue; }
+            if (c == '<' && peek_next() == '=') { advance(); advance(); emit(token_type::le, "<=", tok_line, tok_col); continue; }
+            if (c == '>' && peek_next() == '=') { advance(); advance(); emit(token_type::ge, ">=", tok_line, tok_col); continue; }
+            if (c == '+' && peek_next() == '=') { advance(); advance(); emit(token_type::plus_assign, "+=", tok_line, tok_col); continue; }
+            if (c == '-' && peek_next() == '=') { advance(); advance(); emit(token_type::minus_assign, "-=", tok_line, tok_col); continue; }
+            if (c == '*' && peek_next() == '=') { advance(); advance(); emit(token_type::star_assign, "*=", tok_line, tok_col); continue; }
+            if (c == '/' && peek_next() == '=') { advance(); advance(); emit(token_type::slash_assign, "/=", tok_line, tok_col); continue; }
+            if (c == '%' && peek_next() == '=') { advance(); advance(); emit(token_type::percent_assign, "%=", tok_line, tok_col); continue; }
+
+            // Single-character operators and delimiters
+            advance();
+            switch (c) {
+                case '+': emit(token_type::plus, "+", tok_line, tok_col); break;
+                case '-': emit(token_type::minus, "-", tok_line, tok_col); break;
+                case '*': emit(token_type::star, "*", tok_line, tok_col); break;
+                case '/': emit(token_type::slash, "/", tok_line, tok_col); break;
+                case '%': emit(token_type::percent, "%", tok_line, tok_col); break;
+                case '=': emit(token_type::assign, "=", tok_line, tok_col); break;
+                case '<': emit(token_type::lt, "<", tok_line, tok_col); break;
+                case '>': emit(token_type::gt, ">", tok_line, tok_col); break;
+                case '(': emit(token_type::lparen, "(", tok_line, tok_col); break;
+                case ')': emit(token_type::rparen, ")", tok_line, tok_col); break;
+                case '[': emit(token_type::lbracket, "[", tok_line, tok_col); break;
+                case ']': emit(token_type::rbracket, "]", tok_line, tok_col); break;
+                case ',': emit(token_type::comma, ",", tok_line, tok_col); break;
+                case ':': emit(token_type::colon, ":", tok_line, tok_col); break;
+                case '.': emit(token_type::dot, ".", tok_line, tok_col); break;
+                default:
+                    error(std::string("unexpected character '") + c + "'");
+                    break;
+            }
+        }
+
+        // Close remaining indents
+        while (indent_stack.size() > 1) {
+            indent_stack.pop_back();
+            emit(token_type::dedent, "", line, 1);
+        }
+
+        // Ensure final newline
+        if (!tokens.empty() && tokens.back().type != token_type::newline) {
+            emit(token_type::newline, "", line, column);
+        }
+
+        emit(token_type::eof, "", line, column);
+    }
+};
+
+} // anonymous namespace
+
+lex_result lex(const std::string& source) {
+    lexer_state state{source};
+    state.lex_all();
+    return {std::move(state.tokens), std::move(state.errors), state.errors.empty()};
+}
+
+} // namespace mv

--- a/src/mv/lang/mv_lexer.h
+++ b/src/mv/lang/mv_lexer.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace mv {
+
+enum class token_type {
+    // Literals
+    number, string_lit, true_lit, false_lit, none_lit,
+
+    // Identifiers & keywords
+    ident,
+    kw_def, kw_return, kw_if, kw_elif, kw_else,
+    kw_for, kw_in, kw_and, kw_or, kw_not,
+
+    // Operators
+    plus, minus, star, slash, percent, power,    // + - * / % **
+    eq, ne, lt, gt, le, ge,                       // == != < > <= >=
+    assign,                                        // =
+    plus_assign, minus_assign, star_assign,        // += -= *=
+    slash_assign, percent_assign,                  // /= %=
+
+    // Delimiters
+    lparen, rparen,         // ( )
+    lbracket, rbracket,     // [ ]
+    comma, colon, dot,      // , : .
+
+    // Structure
+    newline, indent, dedent,
+
+    // Special
+    eof, error,
+};
+
+struct token {
+    token_type type = token_type::eof;
+    std::string text;
+    int line = 0;
+    int column = 0;
+};
+
+struct lex_result {
+    std::vector<token> tokens;
+    std::vector<std::string> errors;
+    bool success = true;
+};
+
+lex_result lex(const std::string& source);
+
+} // namespace mv

--- a/src/mv/lang/mv_parser.cpp
+++ b/src/mv/lang/mv_parser.cpp
@@ -1,0 +1,540 @@
+#include "mv_parser.h"
+#include "mv_lexer.h"
+
+#include <sstream>
+
+namespace mv {
+
+namespace {
+
+struct parser_state {
+    std::vector<token> tokens;
+    int pos = 0;
+    std::vector<std::string> errors;
+    bool had_error = false;
+
+    const token& current() const { return tokens[pos]; }
+    const token& peek() const { return tokens[pos]; }
+
+    token_type peek_type() const { return tokens[pos].type; }
+
+    bool at_end() const { return peek_type() == token_type::eof; }
+
+    const token& advance() {
+        const token& t = tokens[pos];
+        if (!at_end()) pos++;
+        return t;
+    }
+
+    bool check(token_type type) const { return peek_type() == type; }
+
+    bool match(token_type type) {
+        if (check(type)) { advance(); return true; }
+        return false;
+    }
+
+    const token& expect(token_type type, const std::string& msg) {
+        if (check(type)) return advance();
+        error(msg);
+        // Return current token anyway to avoid crashing
+        return tokens[pos];
+    }
+
+    void error(const std::string& msg) {
+        const token& t = current();
+        std::ostringstream oss;
+        oss << "line " << t.line << ":" << t.column << ": " << msg;
+        if (t.type != token_type::eof) {
+            oss << " (got '" << t.text << "')";
+        }
+        errors.push_back(oss.str());
+        had_error = true;
+    }
+
+    source_location loc() const {
+        return {current().line, current().column};
+    }
+
+    void skip_newlines() {
+        while (check(token_type::newline)) advance();
+    }
+
+    void synchronize() {
+        while (!at_end()) {
+            if (check(token_type::newline)) { advance(); return; }
+            if (check(token_type::kw_def) || check(token_type::kw_if) ||
+                check(token_type::kw_for) || check(token_type::kw_return)) return;
+            advance();
+        }
+    }
+
+    // ---- Expression parsing (precedence climbing) ----
+
+    expr_ptr parse_expr() { return parse_or(); }
+
+    expr_ptr parse_or() {
+        auto left = parse_and();
+        while (check(token_type::kw_or)) {
+            auto l = loc();
+            advance();
+            auto right = parse_and();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = binary_expr{binary_op::logical_or, std::move(left), std::move(right)};
+            left = std::move(e);
+        }
+        return left;
+    }
+
+    expr_ptr parse_and() {
+        auto left = parse_not();
+        while (check(token_type::kw_and)) {
+            auto l = loc();
+            advance();
+            auto right = parse_not();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = binary_expr{binary_op::logical_and, std::move(left), std::move(right)};
+            left = std::move(e);
+        }
+        return left;
+    }
+
+    expr_ptr parse_not() {
+        if (check(token_type::kw_not)) {
+            auto l = loc();
+            advance();
+            auto operand = parse_not();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = unary_expr{unary_op::logical_not, std::move(operand)};
+            return e;
+        }
+        return parse_comparison();
+    }
+
+    expr_ptr parse_comparison() {
+        auto left = parse_addition();
+        while (check(token_type::eq) || check(token_type::ne) ||
+               check(token_type::lt) || check(token_type::gt) ||
+               check(token_type::le) || check(token_type::ge)) {
+            auto l = loc();
+            auto op_tok = advance();
+            binary_op op;
+            switch (op_tok.type) {
+                case token_type::eq: op = binary_op::eq; break;
+                case token_type::ne: op = binary_op::ne; break;
+                case token_type::lt: op = binary_op::lt; break;
+                case token_type::gt: op = binary_op::gt; break;
+                case token_type::le: op = binary_op::le; break;
+                case token_type::ge: op = binary_op::ge; break;
+                default: op = binary_op::eq; break;
+            }
+            auto right = parse_addition();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = binary_expr{op, std::move(left), std::move(right)};
+            left = std::move(e);
+        }
+        return left;
+    }
+
+    expr_ptr parse_addition() {
+        auto left = parse_multiplication();
+        while (check(token_type::plus) || check(token_type::minus)) {
+            auto l = loc();
+            auto op_tok = advance();
+            binary_op op = (op_tok.type == token_type::plus) ? binary_op::add : binary_op::sub;
+            auto right = parse_multiplication();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = binary_expr{op, std::move(left), std::move(right)};
+            left = std::move(e);
+        }
+        return left;
+    }
+
+    expr_ptr parse_multiplication() {
+        auto left = parse_unary();
+        while (check(token_type::star) || check(token_type::slash) || check(token_type::percent)) {
+            auto l = loc();
+            auto op_tok = advance();
+            binary_op op;
+            switch (op_tok.type) {
+                case token_type::star: op = binary_op::mul; break;
+                case token_type::slash: op = binary_op::div; break;
+                default: op = binary_op::mod; break;
+            }
+            auto right = parse_unary();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = binary_expr{op, std::move(left), std::move(right)};
+            left = std::move(e);
+        }
+        return left;
+    }
+
+    expr_ptr parse_unary() {
+        if (check(token_type::minus)) {
+            auto l = loc();
+            advance();
+            auto operand = parse_power();
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = unary_expr{unary_op::negate, std::move(operand)};
+            return e;
+        }
+        return parse_power();
+    }
+
+    expr_ptr parse_power() {
+        auto left = parse_postfix();
+        if (check(token_type::power)) {
+            auto l = loc();
+            advance();
+            auto right = parse_unary(); // right-associative
+            auto e = std::make_unique<expr>();
+            e->loc = l;
+            e->kind = binary_expr{binary_op::power, std::move(left), std::move(right)};
+            return e;
+        }
+        return left;
+    }
+
+    expr_ptr parse_postfix() {
+        auto left = parse_primary();
+        while (true) {
+            if (check(token_type::lparen)) {
+                left = parse_call(std::move(left));
+            } else if (check(token_type::dot)) {
+                auto l = loc();
+                advance();
+                const token& attr_tok = expect(token_type::ident, "expected attribute name");
+                auto e = std::make_unique<expr>();
+                e->loc = l;
+                e->kind = attr_expr{std::move(left), attr_tok.text};
+                left = std::move(e);
+            } else if (check(token_type::lbracket)) {
+                auto l = loc();
+                advance();
+                auto index = parse_expr();
+                expect(token_type::rbracket, "expected ']'");
+                auto e = std::make_unique<expr>();
+                e->loc = l;
+                e->kind = index_expr{std::move(left), std::move(index)};
+                left = std::move(e);
+            } else {
+                break;
+            }
+        }
+        return left;
+    }
+
+    expr_ptr parse_call(expr_ptr callee) {
+        auto l = callee->loc;
+        advance(); // consume '('
+
+        std::vector<expr_ptr> positional;
+        std::vector<keyword_arg> kwargs;
+        bool seen_kwarg = false;
+
+        while (!check(token_type::rparen) && !at_end()) {
+            // Check for keyword argument: ident = expr
+            if (check(token_type::ident) && pos + 1 < static_cast<int>(tokens.size()) &&
+                tokens[pos + 1].type == token_type::assign) {
+                std::string name = advance().text;
+                advance(); // consume '='
+                auto value = parse_expr();
+                kwargs.push_back({std::move(name), std::move(value)});
+                seen_kwarg = true;
+            } else {
+                if (seen_kwarg) {
+                    error("positional argument after keyword argument");
+                }
+                positional.push_back(parse_expr());
+            }
+
+            if (!check(token_type::rparen)) {
+                expect(token_type::comma, "expected ',' or ')'");
+            }
+        }
+        expect(token_type::rparen, "expected ')'");
+
+        auto e = std::make_unique<expr>();
+        e->loc = l;
+        if (kwargs.empty()) {
+            e->kind = call_expr{std::move(callee), std::move(positional)};
+        } else {
+            e->kind = call_with_kwargs_expr{std::move(callee), std::move(positional), std::move(kwargs)};
+        }
+        return e;
+    }
+
+    expr_ptr parse_primary() {
+        auto l = loc();
+
+        if (check(token_type::number)) {
+            double val = std::stod(advance().text);
+            return make_expr<number_literal>(l, val);
+        }
+        if (check(token_type::string_lit)) {
+            return make_expr<string_literal>(l, advance().text);
+        }
+        if (check(token_type::true_lit)) {
+            advance();
+            return make_expr<bool_literal>(l, true);
+        }
+        if (check(token_type::false_lit)) {
+            advance();
+            return make_expr<bool_literal>(l, false);
+        }
+        if (check(token_type::none_lit)) {
+            advance();
+            return make_expr<none_literal>(l);
+        }
+        if (check(token_type::ident)) {
+            return make_expr<identifier>(l, advance().text);
+        }
+        if (check(token_type::lparen)) {
+            advance();
+            auto inner = parse_expr();
+            expect(token_type::rparen, "expected ')'");
+            return inner;
+        }
+        if (check(token_type::lbracket)) {
+            advance();
+            std::vector<expr_ptr> elements;
+            while (!check(token_type::rbracket) && !at_end()) {
+                elements.push_back(parse_expr());
+                if (!check(token_type::rbracket)) {
+                    expect(token_type::comma, "expected ',' or ']'");
+                }
+            }
+            expect(token_type::rbracket, "expected ']'");
+            return make_expr<list_expr>(l, std::move(elements));
+        }
+
+        error("expected expression");
+        advance(); // skip bad token
+        return make_expr<none_literal>(l);
+    }
+
+    // ---- Statement parsing ----
+
+    std::vector<stmt_ptr> parse_block() {
+        expect(token_type::colon, "expected ':'");
+        expect(token_type::newline, "expected newline after ':'");
+        expect(token_type::indent, "expected indented block");
+
+        std::vector<stmt_ptr> body;
+        while (!check(token_type::dedent) && !at_end()) {
+            skip_newlines();
+            if (check(token_type::dedent) || at_end()) break;
+            auto s = parse_stmt();
+            if (s) body.push_back(std::move(s));
+        }
+
+        if (check(token_type::dedent)) advance();
+        return body;
+    }
+
+    stmt_ptr parse_func_def() {
+        auto l = loc();
+        advance(); // consume 'def'
+        const token& name_tok = expect(token_type::ident, "expected function name");
+        std::string name = name_tok.text;
+
+        expect(token_type::lparen, "expected '('");
+        std::vector<std::string> params;
+        while (!check(token_type::rparen) && !at_end()) {
+            const token& param_tok = expect(token_type::ident, "expected parameter name");
+            params.push_back(param_tok.text);
+            if (!check(token_type::rparen)) {
+                expect(token_type::comma, "expected ',' or ')'");
+            }
+        }
+        expect(token_type::rparen, "expected ')'");
+
+        auto body = parse_block();
+
+        auto s = std::make_unique<stmt>();
+        s->loc = l;
+        s->kind = func_def{std::move(name), std::move(params), std::move(body)};
+        return s;
+    }
+
+    stmt_ptr parse_if_stmt() {
+        auto l = loc();
+        advance(); // consume 'if'
+        auto condition = parse_expr();
+        auto body = parse_block();
+        skip_newlines();
+
+        if_branch main{std::move(condition), std::move(body)};
+        std::vector<if_branch> elifs;
+        std::vector<stmt_ptr> else_body;
+
+        while (check(token_type::kw_elif)) {
+            advance();
+            auto elif_cond = parse_expr();
+            auto elif_body = parse_block();
+            skip_newlines();
+            elifs.push_back({std::move(elif_cond), std::move(elif_body)});
+        }
+
+        if (check(token_type::kw_else)) {
+            advance();
+            else_body = parse_block();
+            skip_newlines();
+        }
+
+        auto s = std::make_unique<stmt>();
+        s->loc = l;
+        s->kind = if_stmt{std::move(main), std::move(elifs), std::move(else_body)};
+        return s;
+    }
+
+    stmt_ptr parse_for_stmt() {
+        auto l = loc();
+        advance(); // consume 'for'
+        const token& var_tok = expect(token_type::ident, "expected loop variable");
+        std::string var_name = var_tok.text;
+        expect(token_type::kw_in, "expected 'in'");
+        auto iterable = parse_expr();
+        auto body = parse_block();
+
+        auto s = std::make_unique<stmt>();
+        s->loc = l;
+        s->kind = for_stmt{std::move(var_name), std::move(iterable), std::move(body)};
+        return s;
+    }
+
+    stmt_ptr parse_return_stmt() {
+        auto l = loc();
+        advance(); // consume 'return'
+
+        std::optional<expr_ptr> value;
+        if (!check(token_type::newline) && !check(token_type::eof) && !check(token_type::dedent)) {
+            value = parse_expr();
+        }
+
+        auto s = std::make_unique<stmt>();
+        s->loc = l;
+        s->kind = return_stmt{std::move(value)};
+        if (check(token_type::newline)) advance();
+        return s;
+    }
+
+    binary_op augmented_op(token_type type) {
+        switch (type) {
+            case token_type::plus_assign: return binary_op::add;
+            case token_type::minus_assign: return binary_op::sub;
+            case token_type::star_assign: return binary_op::mul;
+            case token_type::slash_assign: return binary_op::div;
+            case token_type::percent_assign: return binary_op::mod;
+            default: return binary_op::add;
+        }
+    }
+
+    bool is_augmented_assign(token_type type) {
+        return type == token_type::plus_assign || type == token_type::minus_assign ||
+               type == token_type::star_assign || type == token_type::slash_assign ||
+               type == token_type::percent_assign;
+    }
+
+    stmt_ptr parse_expr_or_assign_stmt() {
+        auto l = loc();
+        auto lhs = parse_expr();
+
+        // Simple assignment: name = expr
+        if (check(token_type::assign)) {
+            advance();
+            auto value = parse_expr();
+
+            if (auto* id = std::get_if<identifier>(&lhs->kind)) {
+                auto s = std::make_unique<stmt>();
+                s->loc = l;
+                s->kind = assign_stmt{id->name, std::move(value)};
+                if (check(token_type::newline)) advance();
+                return s;
+            }
+            if (auto* attr = std::get_if<attr_expr>(&lhs->kind)) {
+                auto s = std::make_unique<stmt>();
+                s->loc = l;
+                s->kind = attr_assign_stmt{std::move(attr->object), attr->attr, std::move(value)};
+                if (check(token_type::newline)) advance();
+                return s;
+            }
+            if (auto* idx = std::get_if<index_expr>(&lhs->kind)) {
+                auto s = std::make_unique<stmt>();
+                s->loc = l;
+                s->kind = index_assign_stmt{std::move(idx->object), std::move(idx->index), std::move(value)};
+                if (check(token_type::newline)) advance();
+                return s;
+            }
+            error("invalid assignment target");
+        }
+
+        // Augmented assignment: name += expr
+        if (is_augmented_assign(peek_type())) {
+            auto op = augmented_op(advance().type);
+            auto value = parse_expr();
+
+            if (auto* id = std::get_if<identifier>(&lhs->kind)) {
+                auto s = std::make_unique<stmt>();
+                s->loc = l;
+                s->kind = augmented_assign_stmt{id->name, op, std::move(value)};
+                if (check(token_type::newline)) advance();
+                return s;
+            }
+            error("augmented assignment requires a simple variable");
+        }
+
+        // Expression statement
+        auto s = std::make_unique<stmt>();
+        s->loc = l;
+        s->kind = expr_stmt{std::move(lhs)};
+        if (check(token_type::newline)) advance();
+        return s;
+    }
+
+    stmt_ptr parse_stmt() {
+        if (had_error && errors.size() > 20) return nullptr;
+
+        switch (peek_type()) {
+            case token_type::kw_def: return parse_func_def();
+            case token_type::kw_if: return parse_if_stmt();
+            case token_type::kw_for: return parse_for_stmt();
+            case token_type::kw_return: return parse_return_stmt();
+            default: return parse_expr_or_assign_stmt();
+        }
+    }
+
+    program parse_program() {
+        program prog;
+        skip_newlines();
+        while (!at_end()) {
+            if (had_error && errors.size() > 20) break;
+            auto s = parse_stmt();
+            if (s) prog.statements.push_back(std::move(s));
+            skip_newlines();
+        }
+        return prog;
+    }
+};
+
+} // anonymous namespace
+
+parse_result parse(const std::string& source) {
+    lex_result lr = lex(source);
+    if (!lr.success) {
+        return {{}, std::move(lr.errors), false};
+    }
+
+    parser_state state;
+    state.tokens = std::move(lr.tokens);
+    auto prog = state.parse_program();
+    return {std::move(prog), std::move(state.errors), !state.had_error};
+}
+
+} // namespace mv

--- a/src/mv/lang/mv_parser.cpp
+++ b/src/mv/lang/mv_parser.cpp
@@ -239,6 +239,7 @@ struct parser_state {
         bool seen_kwarg = false;
 
         while (!check(token_type::rparen) && !at_end()) {
+            int prev_pos = pos;
             // Check for keyword argument: ident = expr
             if (check(token_type::ident) && pos + 1 < static_cast<int>(tokens.size()) &&
                 tokens[pos + 1].type == token_type::assign) {
@@ -255,10 +256,16 @@ struct parser_state {
             }
 
             if (!check(token_type::rparen)) {
-                expect(token_type::comma, "expected ',' or ')'");
+                if (!check(token_type::comma)) {
+                    error("expected ',' or ')'");
+                    break;
+                }
+                advance(); // consume ','
             }
+            // Safety: prevent infinite loop
+            if (pos == prev_pos) break;
         }
-        expect(token_type::rparen, "expected ')'");
+        if (check(token_type::rparen)) advance();
 
         auto e = std::make_unique<expr>();
         e->loc = l;
@@ -305,12 +312,18 @@ struct parser_state {
             advance();
             std::vector<expr_ptr> elements;
             while (!check(token_type::rbracket) && !at_end()) {
+                int prev_pos = pos;
                 elements.push_back(parse_expr());
                 if (!check(token_type::rbracket)) {
-                    expect(token_type::comma, "expected ',' or ']'");
+                    if (!check(token_type::comma)) {
+                        error("expected ',' or ']'");
+                        break;
+                    }
+                    advance(); // consume ','
                 }
+                if (pos == prev_pos) break;
             }
-            expect(token_type::rbracket, "expected ']'");
+            if (check(token_type::rbracket)) advance();
             return make_expr<list_expr>(l, std::move(elements));
         }
 
@@ -322,16 +335,35 @@ struct parser_state {
     // ---- Statement parsing ----
 
     std::vector<stmt_ptr> parse_block() {
-        expect(token_type::colon, "expected ':'");
-        expect(token_type::newline, "expected newline after ':'");
-        expect(token_type::indent, "expected indented block");
+        if (!check(token_type::colon)) {
+            error("expected ':'");
+            synchronize();
+            return {};
+        }
+        advance(); // consume ':'
+        if (!check(token_type::newline)) {
+            error("expected newline after ':'");
+            synchronize();
+            return {};
+        }
+        advance(); // consume newline
+        if (!check(token_type::indent)) {
+            error("expected indented block");
+            return {};
+        }
+        advance(); // consume indent
 
         std::vector<stmt_ptr> body;
         while (!check(token_type::dedent) && !at_end()) {
             skip_newlines();
             if (check(token_type::dedent) || at_end()) break;
+            int prev_pos = pos;
             auto s = parse_stmt();
             if (s) body.push_back(std::move(s));
+            // Safety: if no progress was made, advance to prevent infinite loop
+            if (pos == prev_pos) {
+                advance();
+            }
         }
 
         if (check(token_type::dedent)) advance();
@@ -341,19 +373,43 @@ struct parser_state {
     stmt_ptr parse_func_def() {
         auto l = loc();
         advance(); // consume 'def'
-        const token& name_tok = expect(token_type::ident, "expected function name");
-        std::string name = name_tok.text;
+        if (!check(token_type::ident)) {
+            error("expected function name");
+            synchronize();
+            auto s = std::make_unique<stmt>();
+            s->loc = l;
+            s->kind = func_def{"", {}, {}};
+            return s;
+        }
+        std::string name = advance().text;
 
-        expect(token_type::lparen, "expected '('");
+        if (!check(token_type::lparen)) {
+            error("expected '('");
+            synchronize();
+            auto s = std::make_unique<stmt>();
+            s->loc = l;
+            s->kind = func_def{std::move(name), {}, {}};
+            return s;
+        }
+        advance(); // consume '('
+
         std::vector<std::string> params;
         while (!check(token_type::rparen) && !at_end()) {
-            const token& param_tok = expect(token_type::ident, "expected parameter name");
-            params.push_back(param_tok.text);
+            if (!check(token_type::ident)) {
+                error("expected parameter name");
+                synchronize();
+                break;
+            }
+            params.push_back(advance().text);
             if (!check(token_type::rparen)) {
-                expect(token_type::comma, "expected ',' or ')'");
+                if (!check(token_type::comma)) {
+                    error("expected ',' or ')'");
+                    break;
+                }
+                advance(); // consume ','
             }
         }
-        expect(token_type::rparen, "expected ')'");
+        if (check(token_type::rparen)) advance();
 
         auto body = parse_block();
 
@@ -397,9 +453,24 @@ struct parser_state {
     stmt_ptr parse_for_stmt() {
         auto l = loc();
         advance(); // consume 'for'
-        const token& var_tok = expect(token_type::ident, "expected loop variable");
-        std::string var_name = var_tok.text;
-        expect(token_type::kw_in, "expected 'in'");
+        if (!check(token_type::ident)) {
+            error("expected loop variable");
+            synchronize();
+            auto s = std::make_unique<stmt>();
+            s->loc = l;
+            s->kind = for_stmt{"", make_expr<none_literal>(l), {}};
+            return s;
+        }
+        std::string var_name = advance().text;
+        if (!check(token_type::kw_in)) {
+            error("expected 'in'");
+            synchronize();
+            auto s = std::make_unique<stmt>();
+            s->loc = l;
+            s->kind = for_stmt{std::move(var_name), make_expr<none_literal>(l), {}};
+            return s;
+        }
+        advance(); // consume 'in'
         auto iterable = parse_expr();
         auto body = parse_block();
 
@@ -515,9 +586,14 @@ struct parser_state {
         skip_newlines();
         while (!at_end()) {
             if (had_error && errors.size() > 20) break;
+            int prev_pos = pos;
             auto s = parse_stmt();
             if (s) prog.statements.push_back(std::move(s));
             skip_newlines();
+            // Safety: if no progress was made, advance to prevent infinite loop
+            if (pos == prev_pos) {
+                advance();
+            }
         }
         return prog;
     }

--- a/src/mv/lang/mv_parser.h
+++ b/src/mv/lang/mv_parser.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "mv_ast.h"
+
+#include <string>
+#include <vector>
+
+namespace mv {
+
+struct parse_result {
+    program prog;
+    std::vector<std::string> errors;
+    bool success = true;
+};
+
+parse_result parse(const std::string& source);
+
+} // namespace mv

--- a/src/mv/lang/mv_sandbox.cpp
+++ b/src/mv/lang/mv_sandbox.cpp
@@ -1,0 +1,100 @@
+#include "mv_sandbox.h"
+
+namespace mv {
+
+void sandbox::set_limits(const sandbox_limits& limits) {
+    limits_ = limits;
+}
+
+void sandbox::set_global(const std::string& name, mv_value value) {
+    globals_.push_back({name, std::move(value)});
+}
+
+void sandbox::register_native(const std::string& name, native_function fn) {
+    natives_.push_back({name, std::move(fn)});
+}
+
+void sandbox::register_native_kwargs(const std::string& name, native_kwargs_function fn) {
+    natives_kwargs_.push_back({name, std::move(fn)});
+}
+
+bool sandbox::compile(const std::string& source) {
+    errors_.clear();
+    compiled_ = false;
+
+    // Parse
+    auto pr = parse(source);
+    if (!pr.success) {
+        for (auto& msg : pr.errors) {
+            errors_.push_back({"parse", msg, 0, 0});
+        }
+        return false;
+    }
+
+    // Compile
+    auto cr = mv::compile(pr.prog);
+    if (!cr.success) {
+        for (auto& msg : cr.errors) {
+            errors_.push_back({"compile", msg, 0, 0});
+        }
+        return false;
+    }
+
+    compiled_prog_ = std::move(cr.program);
+    compiled_ = true;
+    return true;
+}
+
+script_result sandbox::call(const std::string& func_name, const std::vector<mv_value>& args) {
+    if (!compiled_) {
+        return {std::monostate{}, {{"runtime", "no compiled script", 0, 0}}, false};
+    }
+
+    vm v(compiled_prog_);
+    v.set_limits(limits_);
+
+    for (auto& [name, val] : globals_) {
+        v.set_global(name, val);
+    }
+    for (auto& [name, fn] : natives_) {
+        v.register_native(name, fn);
+    }
+    for (auto& [name, fn] : natives_kwargs_) {
+        v.register_native_kwargs(name, fn);
+    }
+
+    auto result = v.call_function(func_name, args);
+    if (!result.success) {
+        return {std::monostate{}, {{"runtime", result.error->message, result.error->line, 0}}, false};
+    }
+
+    return {std::move(result.value), {}, true};
+}
+
+script_result sandbox::run_draw(const std::string& source, mv_value ctx) {
+    if (!compile(source)) {
+        return {std::monostate{}, errors_, false};
+    }
+
+    vm v(compiled_prog_);
+    v.set_limits(limits_);
+
+    for (auto& [name, val] : globals_) {
+        v.set_global(name, val);
+    }
+    for (auto& [name, fn] : natives_) {
+        v.register_native(name, fn);
+    }
+    for (auto& [name, fn] : natives_kwargs_) {
+        v.register_native_kwargs(name, fn);
+    }
+
+    auto result = v.call_function("draw", {std::move(ctx)});
+    if (!result.success) {
+        return {std::monostate{}, {{"runtime", result.error->message, result.error->line, 0}}, false};
+    }
+
+    return {std::move(result.value), {}, true};
+}
+
+} // namespace mv

--- a/src/mv/lang/mv_sandbox.cpp
+++ b/src/mv/lang/mv_sandbox.cpp
@@ -1,8 +1,203 @@
 #include "mv_sandbox.h"
 
+#include <unordered_set>
+
 #include "raylib.h"
 
 namespace mv {
+
+namespace {
+
+struct validation_error {
+    std::string message;
+    int line = 0;
+    int column = 0;
+};
+
+using name_set = std::unordered_set<std::string>;
+
+void collect_function_names(const std::vector<stmt_ptr>& statements, name_set& names);
+
+void collect_function_names_from_stmt(const stmt& statement, name_set& names) {
+    std::visit([&](const auto& node) {
+        using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, func_def>) {
+            names.insert(node.name);
+            collect_function_names(node.body, names);
+        } else if constexpr (std::is_same_v<T, if_stmt>) {
+            collect_function_names(node.main.body, names);
+            for (const auto& branch : node.elifs) {
+                collect_function_names(branch.body, names);
+            }
+            collect_function_names(node.else_body, names);
+        } else if constexpr (std::is_same_v<T, for_stmt>) {
+            collect_function_names(node.body, names);
+        }
+    }, statement.kind);
+}
+
+void collect_function_names(const std::vector<stmt_ptr>& statements, name_set& names) {
+    for (const auto& statement : statements) {
+        collect_function_names_from_stmt(*statement, names);
+    }
+}
+
+void validate_expr(const expr& expression,
+                   const name_set& callable_names,
+                   const name_set& visible_names,
+                   std::vector<validation_error>& errors);
+
+void validate_expr_ptr(const expr_ptr& expression,
+                       const name_set& callable_names,
+                       const name_set& visible_names,
+                       std::vector<validation_error>& errors) {
+    if (expression) {
+        validate_expr(*expression, callable_names, visible_names, errors);
+    }
+}
+
+void validate_stmt(const stmt& statement,
+                   const name_set& callable_names,
+                   name_set& visible_names,
+                   std::vector<validation_error>& errors);
+
+void validate_block(const std::vector<stmt_ptr>& statements,
+                    const name_set& callable_names,
+                    name_set visible_names,
+                    std::vector<validation_error>& errors) {
+    for (const auto& statement : statements) {
+        validate_stmt(*statement, callable_names, visible_names, errors);
+    }
+}
+
+void validate_expr(const expr& expression,
+                   const name_set& callable_names,
+                   const name_set& visible_names,
+                   std::vector<validation_error>& errors) {
+    std::visit([&](const auto& node) {
+        using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, binary_expr>) {
+            validate_expr_ptr(node.left, callable_names, visible_names, errors);
+            validate_expr_ptr(node.right, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, unary_expr>) {
+            validate_expr_ptr(node.operand, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, call_expr>) {
+            if (auto* ident = std::get_if<identifier>(&node.callee->kind)) {
+                if (!callable_names.contains(ident->name) && !visible_names.contains(ident->name)) {
+                    errors.push_back({"undefined function '" + ident->name + "'",
+                                      expression.loc.line, expression.loc.column});
+                }
+            } else {
+                validate_expr_ptr(node.callee, callable_names, visible_names, errors);
+            }
+            for (const auto& arg : node.args) {
+                validate_expr_ptr(arg, callable_names, visible_names, errors);
+            }
+        } else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
+            if (auto* ident = std::get_if<identifier>(&node.callee->kind)) {
+                if (!callable_names.contains(ident->name) && !visible_names.contains(ident->name)) {
+                    errors.push_back({"undefined function '" + ident->name + "'",
+                                      expression.loc.line, expression.loc.column});
+                }
+            } else {
+                validate_expr_ptr(node.callee, callable_names, visible_names, errors);
+            }
+            for (const auto& arg : node.positional_args) {
+                validate_expr_ptr(arg, callable_names, visible_names, errors);
+            }
+            for (const auto& kw : node.keyword_args) {
+                validate_expr_ptr(kw.value, callable_names, visible_names, errors);
+            }
+        } else if constexpr (std::is_same_v<T, attr_expr>) {
+            validate_expr_ptr(node.object, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, index_expr>) {
+            validate_expr_ptr(node.object, callable_names, visible_names, errors);
+            validate_expr_ptr(node.index, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, list_expr>) {
+            for (const auto& item : node.elements) {
+                validate_expr_ptr(item, callable_names, visible_names, errors);
+            }
+        }
+    }, expression.kind);
+}
+
+void validate_stmt(const stmt& statement,
+                   const name_set& callable_names,
+                   name_set& visible_names,
+                   std::vector<validation_error>& errors) {
+    std::visit([&](const auto& node) {
+        using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, expr_stmt>) {
+            validate_expr_ptr(node.expression, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, assign_stmt>) {
+            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+            visible_names.insert(node.name);
+        } else if constexpr (std::is_same_v<T, attr_assign_stmt>) {
+            validate_expr_ptr(node.object, callable_names, visible_names, errors);
+            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, index_assign_stmt>) {
+            validate_expr_ptr(node.object, callable_names, visible_names, errors);
+            validate_expr_ptr(node.index, callable_names, visible_names, errors);
+            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, return_stmt>) {
+            if (node.value.has_value()) {
+                validate_expr_ptr(*node.value, callable_names, visible_names, errors);
+            }
+        } else if constexpr (std::is_same_v<T, if_stmt>) {
+            validate_expr_ptr(node.main.condition, callable_names, visible_names, errors);
+            validate_block(node.main.body, callable_names, visible_names, errors);
+            for (const auto& branch : node.elifs) {
+                validate_expr_ptr(branch.condition, callable_names, visible_names, errors);
+                validate_block(branch.body, callable_names, visible_names, errors);
+            }
+            validate_block(node.else_body, callable_names, visible_names, errors);
+        } else if constexpr (std::is_same_v<T, for_stmt>) {
+            validate_expr_ptr(node.iterable, callable_names, visible_names, errors);
+            name_set loop_visible = visible_names;
+            loop_visible.insert(node.var_name);
+            validate_block(node.body, callable_names, loop_visible, errors);
+            visible_names.insert(node.var_name);
+        } else if constexpr (std::is_same_v<T, func_def>) {
+            name_set function_visible = visible_names;
+            for (const auto& param : node.params) {
+                function_visible.insert(param);
+            }
+            validate_block(node.body, callable_names, function_visible, errors);
+        } else if constexpr (std::is_same_v<T, augmented_assign_stmt>) {
+            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+            visible_names.insert(node.name);
+        }
+    }, statement.kind);
+}
+
+std::vector<validation_error> validate_callable_names(const program& prog,
+                                                      const std::vector<std::pair<std::string, mv_value>>& globals,
+                                                      const std::vector<std::pair<std::string, native_function>>& natives,
+                                                      const std::vector<std::pair<std::string, native_kwargs_function>>& natives_kwargs) {
+    name_set callable_names;
+    name_set visible_names;
+
+    for (const auto& [name, _] : globals) {
+        visible_names.insert(name);
+        callable_names.insert(name);
+    }
+    for (const auto& [name, _] : natives) {
+        callable_names.insert(name);
+    }
+    for (const auto& [name, _] : natives_kwargs) {
+        callable_names.insert(name);
+    }
+
+    collect_function_names(prog.statements, callable_names);
+
+    std::vector<validation_error> errors;
+    for (const auto& statement : prog.statements) {
+        validate_stmt(*statement, callable_names, visible_names, errors);
+    }
+    return errors;
+}
+
+} // namespace
 
 void sandbox::set_limits(const sandbox_limits& limits) {
     limits_ = limits;
@@ -29,6 +224,14 @@ bool sandbox::compile(const std::string& source) {
     if (!pr.success) {
         for (auto& msg : pr.errors) {
             errors_.push_back({"parse", msg, 0, 0});
+        }
+        return false;
+    }
+
+    const auto validation_errors = validate_callable_names(pr.prog, globals_, natives_, natives_kwargs_);
+    if (!validation_errors.empty()) {
+        for (const auto& err : validation_errors) {
+            errors_.push_back({"compile", err.message, err.line, err.column});
         }
         return false;
     }

--- a/src/mv/lang/mv_sandbox.cpp
+++ b/src/mv/lang/mv_sandbox.cpp
@@ -1,5 +1,7 @@
 #include "mv_sandbox.h"
 
+#include "raylib.h"
+
 namespace mv {
 
 void sandbox::set_limits(const sandbox_limits& limits) {
@@ -46,8 +48,34 @@ bool sandbox::compile(const std::string& source) {
 }
 
 script_result sandbox::call(const std::string& func_name, const std::vector<mv_value>& args) {
+    static int call_count = 0;
+    if (call_count < 3) {
+        TraceLog(LOG_INFO, "MV SANDBOX: call('%s') compiled=%d funcs=%d consts=%d",
+                 func_name.c_str(), compiled_ ? 1 : 0,
+                 static_cast<int>(compiled_prog_.functions.size()),
+                 static_cast<int>(compiled_prog_.constants.size()));
+        auto fit = compiled_prog_.function_map.find(func_name);
+        if (fit != compiled_prog_.function_map.end()) {
+            const auto& func = compiled_prog_.functions[fit->second];
+            TraceLog(LOG_INFO, "MV SANDBOX: func '%s' locals=%d params=%d instrs=%d",
+                     func.name.c_str(), func.local_count, func.param_count,
+                     static_cast<int>(func.code.size()));
+            int limit = static_cast<int>(func.code.size());
+            if (limit > 60) limit = 60;
+            for (int i = 0; i < limit; i++) {
+                const auto& ins = func.code[i];
+                int op_int = static_cast<int>(ins.op);
+                TraceLog(LOG_INFO, "MV SANDBOX:   [%03d] L%d op=%d arg=%u", i, ins.source_line, op_int, ins.arg);
+            }
+        } else {
+            TraceLog(LOG_WARNING, "MV SANDBOX: func '%s' NOT FOUND in map", func_name.c_str());
+        }
+        call_count++;
+    }
+
     if (!compiled_) {
-        return {std::monostate{}, {{"runtime", "no compiled script", 0, 0}}, false};
+        errors_ = {{"runtime", "no compiled script", 0, 0}};
+        return {std::monostate{}, errors_, false};
     }
 
     vm v(compiled_prog_);
@@ -65,9 +93,11 @@ script_result sandbox::call(const std::string& func_name, const std::vector<mv_v
 
     auto result = v.call_function(func_name, args);
     if (!result.success) {
-        return {std::monostate{}, {{"runtime", result.error->message, result.error->line, 0}}, false};
+        errors_ = {{"runtime", result.error->message, result.error->line, 0}};
+        return {std::monostate{}, errors_, false};
     }
 
+    errors_.clear();
     return {std::move(result.value), {}, true};
 }
 

--- a/src/mv/lang/mv_sandbox.cpp
+++ b/src/mv/lang/mv_sandbox.cpp
@@ -1,5 +1,8 @@
 #include "mv_sandbox.h"
 
+#include <cctype>
+#include <optional>
+#include <sstream>
 #include <unordered_set>
 
 #include "raylib.h"
@@ -15,6 +18,60 @@ struct validation_error {
 };
 
 using name_set = std::unordered_set<std::string>;
+
+bool is_known_name(const std::string& name,
+                   const name_set& callable_names,
+                   const name_set& visible_names) {
+    return callable_names.contains(name) || visible_names.contains(name);
+}
+
+std::optional<script_error> parse_error_message(const std::string& phase, const std::string& message) {
+    auto skip_spaces = [&](size_t& i) {
+        while (i < message.size() && std::isspace(static_cast<unsigned char>(message[i]))) {
+            ++i;
+        }
+    };
+
+    if (message.rfind("line ", 0) == 0) {
+        size_t i = 5;
+        int line = 0;
+        while (i < message.size() && std::isdigit(static_cast<unsigned char>(message[i]))) {
+            line = line * 10 + (message[i] - '0');
+            ++i;
+        }
+
+        int column = 0;
+        if (i < message.size() && message[i] == ':') {
+            ++i;
+            while (i < message.size() && std::isdigit(static_cast<unsigned char>(message[i]))) {
+                column = column * 10 + (message[i] - '0');
+                ++i;
+            }
+        }
+
+        if (i < message.size() && message[i] == ':') {
+            ++i;
+        }
+        skip_spaces(i);
+        return script_error{phase, message.substr(i), line, column};
+    }
+
+    if (message.rfind("compile error line ", 0) == 0) {
+        size_t i = 19;
+        int line = 0;
+        while (i < message.size() && std::isdigit(static_cast<unsigned char>(message[i]))) {
+            line = line * 10 + (message[i] - '0');
+            ++i;
+        }
+        if (i < message.size() && message[i] == ':') {
+            ++i;
+        }
+        skip_spaces(i);
+        return script_error{phase, message.substr(i), line, 0};
+    }
+
+    return std::nullopt;
+}
 
 void collect_function_names(const std::vector<stmt_ptr>& statements, name_set& names);
 
@@ -76,6 +133,12 @@ void validate_expr(const expr& expression,
                    std::vector<validation_error>& errors) {
     std::visit([&](const auto& node) {
         using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, identifier>) {
+            if (!is_known_name(node.name, callable_names, visible_names)) {
+                errors.push_back({"undefined variable '" + node.name + "'",
+                                  expression.loc.line, expression.loc.column});
+            }
+        } else
         if constexpr (std::is_same_v<T, binary_expr>) {
             validate_expr_ptr(node.left, callable_names, visible_names, errors);
             validate_expr_ptr(node.right, callable_names, visible_names, errors);
@@ -83,7 +146,7 @@ void validate_expr(const expr& expression,
             validate_expr_ptr(node.operand, callable_names, visible_names, errors);
         } else if constexpr (std::is_same_v<T, call_expr>) {
             if (auto* ident = std::get_if<identifier>(&node.callee->kind)) {
-                if (!callable_names.contains(ident->name) && !visible_names.contains(ident->name)) {
+                if (!is_known_name(ident->name, callable_names, visible_names)) {
                     errors.push_back({"undefined function '" + ident->name + "'",
                                       expression.loc.line, expression.loc.column});
                 }
@@ -95,7 +158,7 @@ void validate_expr(const expr& expression,
             }
         } else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
             if (auto* ident = std::get_if<identifier>(&node.callee->kind)) {
-                if (!callable_names.contains(ident->name) && !visible_names.contains(ident->name)) {
+                if (!is_known_name(ident->name, callable_names, visible_names)) {
                     errors.push_back({"undefined function '" + ident->name + "'",
                                       expression.loc.line, expression.loc.column});
                 }
@@ -201,29 +264,46 @@ std::vector<validation_error> validate_callable_names(const program& prog,
 
 void sandbox::set_limits(const sandbox_limits& limits) {
     limits_ = limits;
+    if (runtime_vm_) {
+        runtime_vm_->set_limits(limits_);
+    }
 }
 
 void sandbox::set_global(const std::string& name, mv_value value) {
     globals_.push_back({name, std::move(value)});
+    if (runtime_vm_) {
+        runtime_vm_->set_global(globals_.back().first, globals_.back().second);
+    }
 }
 
 void sandbox::register_native(const std::string& name, native_function fn) {
     natives_.push_back({name, std::move(fn)});
+    if (runtime_vm_) {
+        runtime_vm_->register_native(natives_.back().first, natives_.back().second);
+    }
 }
 
 void sandbox::register_native_kwargs(const std::string& name, native_kwargs_function fn) {
     natives_kwargs_.push_back({name, std::move(fn)});
+    if (runtime_vm_) {
+        runtime_vm_->register_native_kwargs(natives_kwargs_.back().first, natives_kwargs_.back().second);
+    }
 }
 
 bool sandbox::compile(const std::string& source) {
     errors_.clear();
     compiled_ = false;
+    runtime_vm_.reset();
 
     // Parse
     auto pr = parse(source);
     if (!pr.success) {
         for (auto& msg : pr.errors) {
-            errors_.push_back({"parse", msg, 0, 0});
+            if (auto parsed = parse_error_message("parse", msg)) {
+                errors_.push_back(*parsed);
+            } else {
+                errors_.push_back({"parse", msg, 0, 0});
+            }
         }
         return false;
     }
@@ -240,61 +320,38 @@ bool sandbox::compile(const std::string& source) {
     auto cr = mv::compile(pr.prog);
     if (!cr.success) {
         for (auto& msg : cr.errors) {
-            errors_.push_back({"compile", msg, 0, 0});
+            if (auto parsed = parse_error_message("compile", msg)) {
+                errors_.push_back(*parsed);
+            } else {
+                errors_.push_back({"compile", msg, 0, 0});
+            }
         }
         return false;
     }
 
     compiled_prog_ = std::move(cr.program);
+    runtime_vm_ = std::make_unique<vm>(compiled_prog_);
+    runtime_vm_->set_limits(limits_);
+    for (auto& [name, val] : globals_) {
+        runtime_vm_->set_global(name, val);
+    }
+    for (auto& [name, fn] : natives_) {
+        runtime_vm_->register_native(name, fn);
+    }
+    for (auto& [name, fn] : natives_kwargs_) {
+        runtime_vm_->register_native_kwargs(name, fn);
+    }
     compiled_ = true;
     return true;
 }
 
 script_result sandbox::call(const std::string& func_name, const std::vector<mv_value>& args) {
-    static int call_count = 0;
-    if (call_count < 3) {
-        TraceLog(LOG_INFO, "MV SANDBOX: call('%s') compiled=%d funcs=%d consts=%d",
-                 func_name.c_str(), compiled_ ? 1 : 0,
-                 static_cast<int>(compiled_prog_.functions.size()),
-                 static_cast<int>(compiled_prog_.constants.size()));
-        auto fit = compiled_prog_.function_map.find(func_name);
-        if (fit != compiled_prog_.function_map.end()) {
-            const auto& func = compiled_prog_.functions[fit->second];
-            TraceLog(LOG_INFO, "MV SANDBOX: func '%s' locals=%d params=%d instrs=%d",
-                     func.name.c_str(), func.local_count, func.param_count,
-                     static_cast<int>(func.code.size()));
-            int limit = static_cast<int>(func.code.size());
-            if (limit > 60) limit = 60;
-            for (int i = 0; i < limit; i++) {
-                const auto& ins = func.code[i];
-                int op_int = static_cast<int>(ins.op);
-                TraceLog(LOG_INFO, "MV SANDBOX:   [%03d] L%d op=%d arg=%u", i, ins.source_line, op_int, ins.arg);
-            }
-        } else {
-            TraceLog(LOG_WARNING, "MV SANDBOX: func '%s' NOT FOUND in map", func_name.c_str());
-        }
-        call_count++;
-    }
-
-    if (!compiled_) {
+    if (!compiled_ || !runtime_vm_) {
         errors_ = {{"runtime", "no compiled script", 0, 0}};
         return {std::monostate{}, errors_, false};
     }
 
-    vm v(compiled_prog_);
-    v.set_limits(limits_);
-
-    for (auto& [name, val] : globals_) {
-        v.set_global(name, val);
-    }
-    for (auto& [name, fn] : natives_) {
-        v.register_native(name, fn);
-    }
-    for (auto& [name, fn] : natives_kwargs_) {
-        v.register_native_kwargs(name, fn);
-    }
-
-    auto result = v.call_function(func_name, args);
+    auto result = runtime_vm_->call_function(func_name, args);
     if (!result.success) {
         errors_ = {{"runtime", result.error->message, result.error->line, 0}};
         return {std::monostate{}, errors_, false};
@@ -308,26 +365,7 @@ script_result sandbox::run_draw(const std::string& source, mv_value ctx) {
     if (!compile(source)) {
         return {std::monostate{}, errors_, false};
     }
-
-    vm v(compiled_prog_);
-    v.set_limits(limits_);
-
-    for (auto& [name, val] : globals_) {
-        v.set_global(name, val);
-    }
-    for (auto& [name, fn] : natives_) {
-        v.register_native(name, fn);
-    }
-    for (auto& [name, fn] : natives_kwargs_) {
-        v.register_native_kwargs(name, fn);
-    }
-
-    auto result = v.call_function("draw", {std::move(ctx)});
-    if (!result.success) {
-        return {std::monostate{}, {{"runtime", result.error->message, result.error->line, 0}}, false};
-    }
-
-    return {std::move(result.value), {}, true};
+    return call("draw", {std::move(ctx)});
 }
 
 } // namespace mv

--- a/src/mv/lang/mv_sandbox.h
+++ b/src/mv/lang/mv_sandbox.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "mv_parser.h"
+#include "mv_compiler.h"
+#include "mv_vm.h"
+
+#include <string>
+#include <vector>
+
+namespace mv {
+
+struct script_error {
+    std::string phase;   // "lex", "parse", "compile", "runtime"
+    std::string message;
+    int line = 0;
+    int column = 0;
+};
+
+struct script_result {
+    mv_value value;
+    std::vector<script_error> errors;
+    bool success = true;
+};
+
+class sandbox {
+public:
+    void set_limits(const sandbox_limits& limits);
+    void set_global(const std::string& name, mv_value value);
+    void register_native(const std::string& name, native_function fn);
+    void register_native_kwargs(const std::string& name, native_kwargs_function fn);
+
+    // Compile source into a prepared script. Returns false on error.
+    bool compile(const std::string& source);
+
+    // Call a function on the already-compiled script.
+    script_result call(const std::string& func_name, const std::vector<mv_value>& args);
+
+    // Convenience: compile + call draw(ctx)
+    script_result run_draw(const std::string& source, mv_value ctx);
+
+    const std::vector<script_error>& last_errors() const { return errors_; }
+
+private:
+    sandbox_limits limits_;
+    std::vector<script_error> errors_;
+
+    // Compiled state
+    bool compiled_ = false;
+    compiled_program compiled_prog_;
+
+    // Pre-registered globals and natives
+    std::vector<std::pair<std::string, mv_value>> globals_;
+    std::vector<std::pair<std::string, native_function>> natives_;
+    std::vector<std::pair<std::string, native_kwargs_function>> natives_kwargs_;
+};
+
+} // namespace mv

--- a/src/mv/lang/mv_sandbox.h
+++ b/src/mv/lang/mv_sandbox.h
@@ -5,6 +5,7 @@
 #include "mv_vm.h"
 
 #include <string>
+#include <memory>
 #include <vector>
 
 namespace mv {
@@ -47,6 +48,7 @@ private:
     // Compiled state
     bool compiled_ = false;
     compiled_program compiled_prog_;
+    std::unique_ptr<vm> runtime_vm_;
 
     // Pre-registered globals and natives
     std::vector<std::pair<std::string, mv_value>> globals_;

--- a/src/mv/lang/mv_vm.cpp
+++ b/src/mv/lang/mv_vm.cpp
@@ -1,0 +1,618 @@
+#include "mv_vm.h"
+
+#include <cmath>
+#include <sstream>
+
+namespace mv {
+
+// ---- Helpers ----
+
+bool is_truthy(const mv_value& val) {
+    return std::visit([](const auto& v) -> bool {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, double>) return v != 0.0;
+        else if constexpr (std::is_same_v<T, bool>) return v;
+        else if constexpr (std::is_same_v<T, std::string>) return !v.empty();
+        else if constexpr (std::is_same_v<T, std::shared_ptr<mv_list>>) return v && !v->elements.empty();
+        else if constexpr (std::is_same_v<T, std::shared_ptr<mv_object>>) return v != nullptr;
+        else if constexpr (std::is_same_v<T, std::monostate>) return false;
+        else return false;
+    }, val);
+}
+
+std::string value_type_name(const mv_value& val) {
+    return std::visit([](const auto& v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, double>) return "number";
+        else if constexpr (std::is_same_v<T, bool>) return "bool";
+        else if constexpr (std::is_same_v<T, std::string>) return "string";
+        else if constexpr (std::is_same_v<T, std::shared_ptr<mv_list>>) return "list";
+        else if constexpr (std::is_same_v<T, std::shared_ptr<mv_object>>) return v ? v->type_name : "object";
+        else if constexpr (std::is_same_v<T, std::monostate>) return "None";
+        else return "unknown";
+    }, val);
+}
+
+std::string value_to_string(const mv_value& val) {
+    return std::visit([](const auto& v) -> std::string {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, double>) {
+            std::ostringstream oss;
+            oss << v;
+            return oss.str();
+        }
+        else if constexpr (std::is_same_v<T, bool>) return v ? "True" : "False";
+        else if constexpr (std::is_same_v<T, std::string>) return v;
+        else if constexpr (std::is_same_v<T, std::shared_ptr<mv_list>>) {
+            std::string s = "[";
+            if (v) {
+                for (size_t i = 0; i < v->elements.size(); i++) {
+                    if (i > 0) s += ", ";
+                    s += value_to_string(v->elements[i]);
+                }
+            }
+            return s + "]";
+        }
+        else if constexpr (std::is_same_v<T, std::shared_ptr<mv_object>>) {
+            return v ? "<" + v->type_name + ">" : "<null>";
+        }
+        else if constexpr (std::is_same_v<T, std::monostate>) return "None";
+        else return "?";
+    }, val);
+}
+
+// ---- VM implementation ----
+
+vm::vm(compiled_program prog) : program_(std::move(prog)) {
+    stack_.reserve(256);
+    frames_.reserve(32);
+}
+
+void vm::set_global(const std::string& name, mv_value value) {
+    globals_[name] = std::move(value);
+}
+
+void vm::register_native(const std::string& name, native_function fn) {
+    natives_[name] = std::move(fn);
+    globals_[name] = std::string("__native__:" + name);
+}
+
+void vm::register_native_kwargs(const std::string& name, native_kwargs_function fn) {
+    natives_kwargs_[name] = std::move(fn);
+    globals_[name] = std::string("__native_kwargs__:" + name);
+}
+
+void vm::set_limits(const sandbox_limits& limits) {
+    limits_ = limits;
+}
+
+void vm::push(mv_value val) {
+    stack_.push_back(std::move(val));
+}
+
+mv_value vm::pop() {
+    mv_value val = std::move(stack_.back());
+    stack_.pop_back();
+    return val;
+}
+
+mv_value& vm::peek_ref(int offset) {
+    return stack_[stack_.size() - 1 - offset];
+}
+
+const std::string& vm::get_string_constant(uint32_t idx) const {
+    return std::get<std::string>(program_.constants[idx]);
+}
+
+std::optional<vm_error> vm::check_number_result(double val, int line) {
+    if (std::isnan(val) || std::isinf(val)) {
+        return vm_error{"numeric result is NaN or infinity", line};
+    }
+    return std::nullopt;
+}
+
+vm_result vm::run_top_level() {
+    auto it = program_.function_map.find("__main__");
+    if (it == program_.function_map.end()) {
+        return {std::monostate{}, vm_error{"no main chunk found", 0}, false};
+    }
+
+    // Register all script function names as globals so call opcode can resolve them
+    for (auto& [fname, fidx] : program_.function_map) {
+        if (fname != "__main__") {
+            globals_[fname] = std::string("__func__:" + fname);
+        }
+    }
+
+    step_count_ = 0;
+    stack_.clear();
+    frames_.clear();
+
+    call_frame frame;
+    frame.chunk = &program_.functions[it->second];
+    frame.ip = 0;
+    frame.stack_base = 0;
+    frame.locals.resize(frame.chunk->local_count);
+
+    frames_.push_back(std::move(frame));
+    return execute();
+}
+
+vm_result vm::call_function(const std::string& name, const std::vector<mv_value>& args) {
+    // First run top level to define functions
+    auto top_result = run_top_level();
+    if (!top_result.success) return top_result;
+
+    auto it = program_.function_map.find(name);
+    if (it == program_.function_map.end()) {
+        return {std::monostate{}, vm_error{"function '" + name + "' not defined", 0}, false};
+    }
+
+    step_count_ = 0;
+    stack_.clear();
+    frames_.clear();
+
+    const function_chunk& func = program_.functions[it->second];
+    if (static_cast<int>(args.size()) != func.param_count) {
+        return {std::monostate{}, vm_error{
+            "function '" + name + "' expects " + std::to_string(func.param_count) +
+            " args, got " + std::to_string(args.size()), 0}, false};
+    }
+
+    call_frame frame;
+    frame.chunk = &func;
+    frame.ip = 0;
+    frame.stack_base = 0;
+    frame.locals.resize(func.local_count);
+
+    for (int i = 0; i < static_cast<int>(args.size()); i++) {
+        frame.locals[i] = args[i];
+    }
+
+    frames_.push_back(std::move(frame));
+    return execute();
+}
+
+vm_result vm::execute() {
+    while (!frames_.empty()) {
+        auto& frame = frames_.back();
+
+        if (frame.ip >= static_cast<int>(frame.chunk->code.size())) {
+            frames_.pop_back();
+            if (frames_.empty()) {
+                { mv_value v = stack_.empty() ? mv_value{std::monostate{}} : pop(); return {std::move(v), std::nullopt, true}; }
+            }
+            push(std::monostate{}); // implicit return None
+            continue;
+        }
+
+        auto err = run_instruction(frame);
+        if (err) {
+            return {std::monostate{}, std::move(*err), false};
+        }
+    }
+
+    { mv_value v = stack_.empty() ? mv_value{std::monostate{}} : pop(); return {std::move(v), std::nullopt, true}; }
+}
+
+std::optional<vm_error> vm::run_instruction(call_frame& frame) {
+    if (++step_count_ > limits_.max_steps) {
+        return vm_error{"execution step limit exceeded (" + std::to_string(limits_.max_steps) + ")", 0};
+    }
+
+    const instruction& instr = frame.chunk->code[frame.ip++];
+    int line = instr.source_line;
+
+    switch (instr.op) {
+    case opcode::load_const:
+        push(std::visit([](const auto& v) -> mv_value { return v; }, program_.constants[instr.arg]));
+        break;
+
+    case opcode::load_none: push(std::monostate{}); break;
+    case opcode::load_true: push(true); break;
+    case opcode::load_false: push(false); break;
+    case opcode::pop: pop(); break;
+
+    case opcode::load_local:
+        if (instr.arg < frame.locals.size()) {
+            push(frame.locals[instr.arg]);
+        } else {
+            return vm_error{"invalid local variable slot", line};
+        }
+        break;
+
+    case opcode::store_local:
+        if (instr.arg >= frame.locals.size()) {
+            frame.locals.resize(instr.arg + 1);
+        }
+        frame.locals[instr.arg] = pop();
+        break;
+
+    case opcode::load_global: {
+        const std::string& name = get_string_constant(instr.arg);
+        auto it = globals_.find(name);
+        if (it != globals_.end()) {
+            push(it->second);
+        } else {
+            return vm_error{"undefined variable '" + name + "'", line};
+        }
+        break;
+    }
+
+    case opcode::store_global: {
+        const std::string& name = get_string_constant(instr.arg);
+        globals_[name] = pop();
+        break;
+    }
+
+    case opcode::add: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) {
+                double result = *na + *nb;
+                if (auto err = check_number_result(result, line)) return err;
+                push(result);
+                break;
+            }
+        }
+        if (auto* sa = std::get_if<std::string>(&a)) {
+            if (auto* sb = std::get_if<std::string>(&b)) {
+                std::string result = *sa + *sb;
+                if (static_cast<int>(result.size()) > limits_.max_string_length) {
+                    return vm_error{"string length exceeds limit", line};
+                }
+                push(std::move(result));
+                break;
+            }
+        }
+        return vm_error{"cannot add " + value_type_name(a) + " and " + value_type_name(b), line};
+    }
+
+    case opcode::sub: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) {
+                double result = *na - *nb;
+                if (auto err = check_number_result(result, line)) return err;
+                push(result);
+                break;
+            }
+        }
+        return vm_error{"cannot subtract " + value_type_name(b) + " from " + value_type_name(a), line};
+    }
+
+    case opcode::mul: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) {
+                double result = *na * *nb;
+                if (auto err = check_number_result(result, line)) return err;
+                push(result);
+                break;
+            }
+        }
+        return vm_error{"cannot multiply " + value_type_name(a) + " and " + value_type_name(b), line};
+    }
+
+    case opcode::div_op: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) {
+                if (*nb == 0.0) return vm_error{"division by zero", line};
+                double result = *na / *nb;
+                if (auto err = check_number_result(result, line)) return err;
+                push(result);
+                break;
+            }
+        }
+        return vm_error{"cannot divide " + value_type_name(a) + " by " + value_type_name(b), line};
+    }
+
+    case opcode::mod: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) {
+                if (*nb == 0.0) return vm_error{"modulo by zero", line};
+                double result = std::fmod(*na, *nb);
+                if (auto err = check_number_result(result, line)) return err;
+                push(result);
+                break;
+            }
+        }
+        return vm_error{"cannot modulo " + value_type_name(a) + " by " + value_type_name(b), line};
+    }
+
+    case opcode::power: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) {
+                double result = std::pow(*na, *nb);
+                if (auto err = check_number_result(result, line)) return err;
+                push(result);
+                break;
+            }
+        }
+        return vm_error{"cannot raise " + value_type_name(a) + " to power " + value_type_name(b), line};
+    }
+
+    case opcode::negate: {
+        auto val = pop();
+        if (auto* n = std::get_if<double>(&val)) {
+            push(-*n);
+            break;
+        }
+        return vm_error{"cannot negate " + value_type_name(val), line};
+    }
+
+    case opcode::cmp_eq: { auto b = pop(), a = pop(); push(a == b); break; }
+    case opcode::cmp_ne: { auto b = pop(), a = pop(); push(a != b); break; }
+
+    case opcode::cmp_lt: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) { push(*na < *nb); break; }
+        }
+        return vm_error{"cannot compare " + value_type_name(a) + " and " + value_type_name(b), line};
+    }
+    case opcode::cmp_gt: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) { push(*na > *nb); break; }
+        }
+        return vm_error{"cannot compare " + value_type_name(a) + " and " + value_type_name(b), line};
+    }
+    case opcode::cmp_le: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) { push(*na <= *nb); break; }
+        }
+        return vm_error{"cannot compare " + value_type_name(a) + " and " + value_type_name(b), line};
+    }
+    case opcode::cmp_ge: {
+        auto b = pop(), a = pop();
+        if (auto* na = std::get_if<double>(&a)) {
+            if (auto* nb = std::get_if<double>(&b)) { push(*na >= *nb); break; }
+        }
+        return vm_error{"cannot compare " + value_type_name(a) + " and " + value_type_name(b), line};
+    }
+
+    case opcode::logical_not:
+        push(!is_truthy(pop()));
+        break;
+
+    case opcode::jump:
+        frame.ip = static_cast<int>(instr.arg);
+        break;
+
+    case opcode::jump_if_false:
+        if (!is_truthy(peek_ref())) {
+            frame.ip = static_cast<int>(instr.arg);
+        }
+        break;
+
+    case opcode::jump_if_true:
+        if (is_truthy(peek_ref())) {
+            frame.ip = static_cast<int>(instr.arg);
+        }
+        break;
+
+    case opcode::call: {
+        int arg_count = static_cast<int>(instr.arg);
+        mv_value callee = stack_[stack_.size() - 1 - arg_count];
+
+        // Check for native function
+        if (auto* s = std::get_if<std::string>(&callee)) {
+            if (s->substr(0, 10) == "__native__") {
+                std::string native_name = s->substr(11);
+                auto it = natives_.find(native_name);
+                if (it != natives_.end()) {
+                    std::vector<mv_value> args(arg_count);
+                    for (int i = arg_count - 1; i >= 0; i--) args[i] = pop();
+                    pop(); // callee
+                    push(it->second(args));
+                    break;
+                }
+            }
+            if (s->substr(0, 17) == "__native_kwargs__") {
+                std::string native_name = s->substr(18);
+                auto it = natives_kwargs_.find(native_name);
+                if (it != natives_kwargs_.end()) {
+                    std::vector<mv_value> args(arg_count);
+                    for (int i = arg_count - 1; i >= 0; i--) args[i] = pop();
+                    pop(); // callee
+                    std::vector<std::pair<std::string, mv_value>> empty_kwargs;
+                    push(it->second(args, empty_kwargs));
+                    break;
+                }
+            }
+        }
+
+        // Script function - resolve __func__:name marker to function_map
+        std::string func_name;
+        if (auto* s = std::get_if<std::string>(&callee)) {
+            if (s->size() > 8 && s->substr(0, 8) == "__func__") {
+                func_name = s->substr(9);
+            } else {
+                func_name = *s;
+            }
+        }
+
+        auto func_it = program_.function_map.end();
+        if (!func_name.empty()) {
+            func_it = program_.function_map.find(func_name);
+        }
+
+        if (func_it == program_.function_map.end()) {
+            return vm_error{"'" + value_to_string(callee) + "' is not callable", line};
+        }
+
+        if (static_cast<int>(frames_.size()) >= limits_.max_call_depth) {
+            return vm_error{"call depth limit exceeded (" + std::to_string(limits_.max_call_depth) + ")", line};
+        }
+
+        const function_chunk& func = program_.functions[func_it->second];
+        if (arg_count != func.param_count) {
+            return vm_error{
+                "function '" + func.name + "' expects " + std::to_string(func.param_count) +
+                " args, got " + std::to_string(arg_count), line};
+        }
+
+        call_frame new_frame;
+        new_frame.chunk = &func;
+        new_frame.ip = 0;
+        new_frame.stack_base = static_cast<int>(stack_.size()) - arg_count - 1;
+        new_frame.locals.resize(func.local_count);
+
+        for (int i = arg_count - 1; i >= 0; i--) {
+            new_frame.locals[i] = pop();
+        }
+        pop(); // callee
+
+        frames_.push_back(std::move(new_frame));
+        break;
+    }
+
+    case opcode::call_kwargs: {
+        int positional_count = static_cast<int>(instr.arg);
+        // Next instruction must be kwarg_count
+        if (frame.ip >= static_cast<int>(frame.chunk->code.size()) ||
+            frame.chunk->code[frame.ip].op != opcode::kwarg_count) {
+            return vm_error{"internal error: expected kwarg_count after call_kwargs", line};
+        }
+        int kw_count = static_cast<int>(frame.chunk->code[frame.ip++].arg);
+
+        // Pop kwargs (value, name pairs in reverse)
+        std::vector<std::pair<std::string, mv_value>> kwargs(kw_count);
+        for (int i = kw_count - 1; i >= 0; i--) {
+            mv_value val = pop();
+            mv_value name_val = pop();
+            kwargs[i] = {std::get<std::string>(name_val), std::move(val)};
+        }
+
+        // Pop positional args
+        std::vector<mv_value> pos_args(positional_count);
+        for (int i = positional_count - 1; i >= 0; i--) {
+            pos_args[i] = pop();
+        }
+
+        mv_value callee = pop();
+
+        // Check for native kwargs function
+        if (auto* s = std::get_if<std::string>(&callee)) {
+            if (s->substr(0, 17) == "__native_kwargs__") {
+                std::string native_name = s->substr(18);
+                auto it = natives_kwargs_.find(native_name);
+                if (it != natives_kwargs_.end()) {
+                    push(it->second(pos_args, kwargs));
+                    break;
+                }
+            }
+            // Also allow regular natives (kwargs discarded)
+            if (s->substr(0, 10) == "__native__") {
+                std::string native_name = s->substr(11);
+                auto it = natives_.find(native_name);
+                if (it != natives_.end()) {
+                    push(it->second(pos_args));
+                    break;
+                }
+            }
+        }
+
+        return vm_error{"kwargs call to non-native function not supported", line};
+    }
+
+    case opcode::kwarg_count:
+        return vm_error{"internal error: unexpected kwarg_count", line};
+
+    case opcode::load_kwarg_name: {
+        const std::string& name = get_string_constant(instr.arg);
+        push(name);
+        break;
+    }
+
+    case opcode::return_op: {
+        mv_value result = pop();
+        frames_.pop_back();
+        push(std::move(result));
+        break;
+    }
+
+    case opcode::load_attr: {
+        auto obj_val = pop();
+        const std::string& attr_name = get_string_constant(instr.arg);
+        if (auto* obj = std::get_if<std::shared_ptr<mv_object>>(&obj_val)) {
+            if (*obj) {
+                push((*obj)->get_attr(attr_name));
+                break;
+            }
+        }
+        return vm_error{"cannot access attribute '" + attr_name + "' on " + value_type_name(obj_val), line};
+    }
+
+    case opcode::store_attr: {
+        auto val = pop();
+        auto obj_val = pop();
+        const std::string& attr_name = get_string_constant(instr.arg);
+        if (auto* obj = std::get_if<std::shared_ptr<mv_object>>(&obj_val)) {
+            if (*obj) {
+                (*obj)->set_attr(attr_name, std::move(val));
+                break;
+            }
+        }
+        return vm_error{"cannot set attribute on " + value_type_name(obj_val), line};
+    }
+
+    case opcode::build_list: {
+        int count = static_cast<int>(instr.arg);
+        if (count > limits_.max_list_size) {
+            return vm_error{"list size exceeds limit", line};
+        }
+        auto list = std::make_shared<mv_list>();
+        list->elements.resize(count);
+        for (int i = count - 1; i >= 0; i--) {
+            list->elements[i] = pop();
+        }
+        push(std::move(list));
+        break;
+    }
+
+    case opcode::load_index: {
+        auto idx_val = pop();
+        auto obj_val = pop();
+        if (auto* list = std::get_if<std::shared_ptr<mv_list>>(&obj_val)) {
+            if (auto* idx = std::get_if<double>(&idx_val)) {
+                int i = static_cast<int>(*idx);
+                if (*list && i >= 0 && i < static_cast<int>((*list)->elements.size())) {
+                    push((*list)->elements[i]);
+                    break;
+                }
+                // Out of bounds -> None (used by for-loop pattern)
+                push(std::monostate{});
+                break;
+            }
+        }
+        return vm_error{"cannot index " + value_type_name(obj_val) + " with " + value_type_name(idx_val), line};
+    }
+
+    case opcode::store_index: {
+        auto val = pop();
+        auto idx_val = pop();
+        auto obj_val = pop();
+        if (auto* list = std::get_if<std::shared_ptr<mv_list>>(&obj_val)) {
+            if (auto* idx = std::get_if<double>(&idx_val)) {
+                int i = static_cast<int>(*idx);
+                if (*list && i >= 0 && i < static_cast<int>((*list)->elements.size())) {
+                    (*list)->elements[i] = std::move(val);
+                    break;
+                }
+                return vm_error{"list index out of range", line};
+            }
+        }
+        return vm_error{"cannot index-assign " + value_type_name(obj_val), line};
+    }
+    }
+
+    return std::nullopt;
+}
+
+} // namespace mv

--- a/src/mv/lang/mv_vm.cpp
+++ b/src/mv/lang/mv_vm.cpp
@@ -591,6 +591,22 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
         break;
     }
 
+    case opcode::append_list: {
+        auto value = pop();
+        auto list_val = pop();
+        if (auto* list = std::get_if<std::shared_ptr<mv_list>>(&list_val)) {
+            if (*list) {
+                if (static_cast<int>((*list)->elements.size()) >= limits_.max_list_size) {
+                    return vm_error{"list size exceeds limit", line};
+                }
+                (*list)->elements.push_back(std::move(value));
+                push(std::monostate{});
+                break;
+            }
+        }
+        return vm_error{"cannot append to " + value_type_name(list_val), line};
+    }
+
     case opcode::load_index: {
         auto idx_val = pop();
         auto obj_val = pop();

--- a/src/mv/lang/mv_vm.cpp
+++ b/src/mv/lang/mv_vm.cpp
@@ -265,6 +265,21 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
                 break;
             }
         }
+        if (auto* la = std::get_if<std::shared_ptr<mv_list>>(&a)) {
+            if (auto* lb = std::get_if<std::shared_ptr<mv_list>>(&b)) {
+                auto result = std::make_shared<mv_list>();
+                if (*la) result->elements = (*la)->elements;
+                if (*lb) {
+                    result->elements.insert(result->elements.end(),
+                                            (*lb)->elements.begin(), (*lb)->elements.end());
+                }
+                if (static_cast<int>(result->elements.size()) > limits_.max_list_size) {
+                    return vm_error{"list size exceeds limit", line};
+                }
+                push(mv_value{result});
+                break;
+            }
+        }
         return vm_error{"cannot add " + value_type_name(a) + " and " + value_type_name(b), line};
     }
 

--- a/src/mv/lang/mv_vm.cpp
+++ b/src/mv/lang/mv_vm.cpp
@@ -5,6 +5,96 @@
 
 namespace mv {
 
+namespace {
+
+std::optional<vec2> cached_point_from_value(const mv_value& value) {
+    if (auto* obj = std::get_if<std::shared_ptr<mv_object>>(&value)) {
+        if (*obj && (*obj)->cached_point.has_value()) {
+            return (*obj)->cached_point;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<scene_node> cached_scene_node_from_value(const mv_value& value) {
+    if (auto* obj = std::get_if<std::shared_ptr<mv_object>>(&value)) {
+        if (*obj && (*obj)->cached_scene_node.has_value()) {
+            return (*obj)->cached_scene_node;
+        }
+    }
+    return std::nullopt;
+}
+
+void try_build_list_render_caches(mv_list& list) {
+    if (list.elements.empty()) {
+        list.cached_points = std::vector<vec2>{};
+        list.cached_scene_nodes = std::vector<scene_node>{};
+        return;
+    }
+
+    bool all_points = true;
+    bool all_scene_nodes = true;
+    std::vector<vec2> points;
+    std::vector<scene_node> scene_nodes;
+    points.reserve(list.elements.size());
+    scene_nodes.reserve(list.elements.size());
+
+    for (const auto& element : list.elements) {
+        if (all_points) {
+            if (auto point = cached_point_from_value(element)) {
+                points.push_back(*point);
+            } else {
+                all_points = false;
+                points.clear();
+            }
+        }
+        if (all_scene_nodes) {
+            if (auto node = cached_scene_node_from_value(element)) {
+                scene_nodes.push_back(*node);
+            } else {
+                all_scene_nodes = false;
+                scene_nodes.clear();
+            }
+        }
+        if (!all_points && !all_scene_nodes) {
+            break;
+        }
+    }
+
+    list.cached_points = all_points ? std::optional<std::vector<vec2>>(std::move(points)) : std::nullopt;
+    list.cached_scene_nodes = all_scene_nodes
+        ? std::optional<std::vector<scene_node>>(std::move(scene_nodes))
+        : std::nullopt;
+}
+
+void update_list_caches_for_append(mv_list& list, const mv_value& appended) {
+    if (list.cached_points.has_value()) {
+        if (auto point = cached_point_from_value(appended)) {
+            list.cached_points->push_back(*point);
+        } else {
+            list.cached_points.reset();
+        }
+    } else if (list.elements.size() == 1) {
+        if (auto point = cached_point_from_value(appended)) {
+            list.cached_points = std::vector<vec2>{*point};
+        }
+    }
+
+    if (list.cached_scene_nodes.has_value()) {
+        if (auto node = cached_scene_node_from_value(appended)) {
+            list.cached_scene_nodes->push_back(*node);
+        } else {
+            list.cached_scene_nodes.reset();
+        }
+    } else if (list.elements.size() == 1) {
+        if (auto node = cached_scene_node_from_value(appended)) {
+            list.cached_scene_nodes = std::vector<scene_node>{*node};
+        }
+    }
+}
+
+} // namespace
+
 // ---- Helpers ----
 
 bool is_truthy(const mv_value& val) {
@@ -15,6 +105,8 @@ bool is_truthy(const mv_value& val) {
         else if constexpr (std::is_same_v<T, std::string>) return !v.empty();
         else if constexpr (std::is_same_v<T, std::shared_ptr<mv_list>>) return v && !v->elements.empty();
         else if constexpr (std::is_same_v<T, std::shared_ptr<mv_object>>) return v != nullptr;
+        else if constexpr (std::is_same_v<T, native_ref>) return v.index >= 0;
+        else if constexpr (std::is_same_v<T, function_ref>) return v.index >= 0;
         else if constexpr (std::is_same_v<T, std::monostate>) return false;
         else return false;
     }, val);
@@ -28,6 +120,8 @@ std::string value_type_name(const mv_value& val) {
         else if constexpr (std::is_same_v<T, std::string>) return "string";
         else if constexpr (std::is_same_v<T, std::shared_ptr<mv_list>>) return "list";
         else if constexpr (std::is_same_v<T, std::shared_ptr<mv_object>>) return v ? v->type_name : "object";
+        else if constexpr (std::is_same_v<T, native_ref>) return "native_function";
+        else if constexpr (std::is_same_v<T, function_ref>) return "function";
         else if constexpr (std::is_same_v<T, std::monostate>) return "None";
         else return "unknown";
     }, val);
@@ -56,6 +150,8 @@ std::string value_to_string(const mv_value& val) {
         else if constexpr (std::is_same_v<T, std::shared_ptr<mv_object>>) {
             return v ? "<" + v->type_name + ">" : "<null>";
         }
+        else if constexpr (std::is_same_v<T, native_ref>) return "<native>";
+        else if constexpr (std::is_same_v<T, function_ref>) return "<function>";
         else if constexpr (std::is_same_v<T, std::monostate>) return "None";
         else return "?";
     }, val);
@@ -73,13 +169,31 @@ void vm::set_global(const std::string& name, mv_value value) {
 }
 
 void vm::register_native(const std::string& name, native_function fn) {
-    natives_[name] = std::move(fn);
-    globals_[name] = std::string("__native__:" + name);
+    int index = 0;
+    auto it = native_index_by_name_.find(name);
+    if (it == native_index_by_name_.end()) {
+        index = static_cast<int>(native_table_.size());
+        native_index_by_name_[name] = index;
+        native_table_.push_back(std::move(fn));
+    } else {
+        index = it->second;
+        native_table_[static_cast<size_t>(index)] = std::move(fn);
+    }
+    globals_[name] = native_ref{index, false};
 }
 
 void vm::register_native_kwargs(const std::string& name, native_kwargs_function fn) {
-    natives_kwargs_[name] = std::move(fn);
-    globals_[name] = std::string("__native_kwargs__:" + name);
+    int index = 0;
+    auto it = native_kwargs_index_by_name_.find(name);
+    if (it == native_kwargs_index_by_name_.end()) {
+        index = static_cast<int>(native_kwargs_table_.size());
+        native_kwargs_index_by_name_[name] = index;
+        native_kwargs_table_.push_back(std::move(fn));
+    } else {
+        index = it->second;
+        native_kwargs_table_[static_cast<size_t>(index)] = std::move(fn);
+    }
+    globals_[name] = native_ref{index, true};
 }
 
 void vm::set_limits(const sandbox_limits& limits) {
@@ -120,7 +234,7 @@ vm_result vm::run_top_level() {
     // Register all script function names as globals so call opcode can resolve them
     for (auto& [fname, fidx] : program_.function_map) {
         if (fname != "__main__") {
-            globals_[fname] = std::string("__func__:" + fname);
+            globals_[fname] = function_ref{fidx};
         }
     }
 
@@ -415,49 +529,33 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
         int arg_count = static_cast<int>(instr.arg);
         mv_value callee = stack_[stack_.size() - 1 - arg_count];
 
-        // Check for native function
-        if (auto* s = std::get_if<std::string>(&callee)) {
-            if (s->substr(0, 10) == "__native__") {
-                std::string native_name = s->substr(11);
-                auto it = natives_.find(native_name);
-                if (it != natives_.end()) {
-                    std::vector<mv_value> args(arg_count);
-                    for (int i = arg_count - 1; i >= 0; i--) args[i] = pop();
-                    pop(); // callee
-                    push(it->second(args));
-                    break;
-                }
-            }
-            if (s->substr(0, 17) == "__native_kwargs__") {
-                std::string native_name = s->substr(18);
-                auto it = natives_kwargs_.find(native_name);
-                if (it != natives_kwargs_.end()) {
-                    std::vector<mv_value> args(arg_count);
-                    for (int i = arg_count - 1; i >= 0; i--) args[i] = pop();
-                    pop(); // callee
+        if (auto* native = std::get_if<native_ref>(&callee)) {
+            std::vector<mv_value> args(arg_count);
+            for (int i = arg_count - 1; i >= 0; i--) args[i] = pop();
+            pop(); // callee
+            if (native->kwargs) {
+                if (native->index >= 0 && native->index < static_cast<int>(native_kwargs_table_.size())) {
                     std::vector<std::pair<std::string, mv_value>> empty_kwargs;
-                    push(it->second(args, empty_kwargs));
+                    push(native_kwargs_table_[static_cast<size_t>(native->index)](args, empty_kwargs));
                     break;
                 }
+            } else if (native->index >= 0 && native->index < static_cast<int>(native_table_.size())) {
+                push(native_table_[static_cast<size_t>(native->index)](args));
+                break;
             }
         }
 
-        // Script function - resolve __func__:name marker to function_map
-        std::string func_name;
-        if (auto* s = std::get_if<std::string>(&callee)) {
-            if (s->size() > 8 && s->substr(0, 8) == "__func__") {
-                func_name = s->substr(9);
-            } else {
-                func_name = *s;
+        int func_index = -1;
+        if (auto* fn = std::get_if<function_ref>(&callee)) {
+            func_index = fn->index;
+        } else if (auto* s = std::get_if<std::string>(&callee)) {
+            auto func_it = program_.function_map.find(*s);
+            if (func_it != program_.function_map.end()) {
+                func_index = func_it->second;
             }
         }
 
-        auto func_it = program_.function_map.end();
-        if (!func_name.empty()) {
-            func_it = program_.function_map.find(func_name);
-        }
-
-        if (func_it == program_.function_map.end()) {
+        if (func_index < 0 || func_index >= static_cast<int>(program_.functions.size())) {
             return vm_error{"'" + value_to_string(callee) + "' is not callable", line};
         }
 
@@ -465,7 +563,7 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
             return vm_error{"call depth limit exceeded (" + std::to_string(limits_.max_call_depth) + ")", line};
         }
 
-        const function_chunk& func = program_.functions[func_it->second];
+        const function_chunk& func = program_.functions[static_cast<size_t>(func_index)];
         if (arg_count != func.param_count) {
             return vm_error{
                 "function '" + func.name + "' expects " + std::to_string(func.param_count) +
@@ -513,23 +611,26 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
         mv_value callee = pop();
 
         // Check for native kwargs function
-        if (auto* s = std::get_if<std::string>(&callee)) {
-            if (s->substr(0, 17) == "__native_kwargs__") {
-                std::string native_name = s->substr(18);
-                auto it = natives_kwargs_.find(native_name);
-                if (it != natives_kwargs_.end()) {
-                    push(it->second(pos_args, kwargs));
+        if (auto* native = std::get_if<native_ref>(&callee)) {
+            if (native->kwargs) {
+                if (native->index >= 0 && native->index < static_cast<int>(native_kwargs_table_.size())) {
+                    push(native_kwargs_table_[static_cast<size_t>(native->index)](pos_args, kwargs));
                     break;
                 }
+            } else if (native->index >= 0 && native->index < static_cast<int>(native_table_.size())) {
+                push(native_table_[static_cast<size_t>(native->index)](pos_args));
+                break;
             }
-            // Also allow regular natives (kwargs discarded)
-            if (s->substr(0, 10) == "__native__") {
-                std::string native_name = s->substr(11);
-                auto it = natives_.find(native_name);
-                if (it != natives_.end()) {
-                    push(it->second(pos_args));
-                    break;
-                }
+        } else if (auto* s = std::get_if<std::string>(&callee)) {
+            auto native_kwargs_it = native_kwargs_index_by_name_.find(*s);
+            if (native_kwargs_it != native_kwargs_index_by_name_.end()) {
+                push(native_kwargs_table_[static_cast<size_t>(native_kwargs_it->second)](pos_args, kwargs));
+                break;
+            }
+            auto native_it = native_index_by_name_.find(*s);
+            if (native_it != native_index_by_name_.end()) {
+                push(native_table_[static_cast<size_t>(native_it->second)](pos_args));
+                break;
             }
         }
 
@@ -587,6 +688,7 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
         for (int i = count - 1; i >= 0; i--) {
             list->elements[i] = pop();
         }
+        try_build_list_render_caches(*list);
         push(std::move(list));
         break;
     }
@@ -600,6 +702,7 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
                     return vm_error{"list size exceeds limit", line};
                 }
                 (*list)->elements.push_back(std::move(value));
+                update_list_caches_for_append(**list, (*list)->elements.back());
                 push(std::monostate{});
                 break;
             }
@@ -634,6 +737,7 @@ std::optional<vm_error> vm::run_instruction(call_frame& frame) {
                 int i = static_cast<int>(*idx);
                 if (*list && i >= 0 && i < static_cast<int>((*list)->elements.size())) {
                     (*list)->elements[i] = std::move(val);
+                    (*list)->clear_cached_render_data();
                     break;
                 }
                 return vm_error{"list index out of range", line};

--- a/src/mv/lang/mv_vm.h
+++ b/src/mv/lang/mv_vm.h
@@ -1,0 +1,115 @@
+#pragma once
+
+#include "mv_bytecode.h"
+
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace mv {
+
+// Forward declarations to break recursive type
+struct mv_list;
+struct mv_object;
+
+using mv_value = std::variant<
+    double,                         // number
+    bool,                           // bool
+    std::string,                    // string
+    std::shared_ptr<mv_list>,       // list
+    std::shared_ptr<mv_object>,     // object (for ctx, Scene, Node, etc.)
+    std::monostate                  // None
+>;
+
+struct mv_list {
+    std::vector<mv_value> elements;
+};
+
+struct mv_object {
+    std::string type_name;
+    std::unordered_map<std::string, mv_value> attrs;
+
+    mv_value get_attr(const std::string& name) const {
+        auto it = attrs.find(name);
+        if (it != attrs.end()) return it->second;
+        return std::monostate{};
+    }
+
+    void set_attr(const std::string& name, mv_value val) {
+        attrs[name] = std::move(val);
+    }
+};
+
+using native_function = std::function<mv_value(const std::vector<mv_value>&)>;
+
+using native_kwargs_function = std::function<mv_value(
+    const std::vector<mv_value>&,
+    const std::vector<std::pair<std::string, mv_value>>&
+)>;
+
+struct vm_error {
+    std::string message;
+    int line = 0;
+};
+
+struct sandbox_limits {
+    int max_steps = 1000000;
+    int max_call_depth = 32;
+    int max_string_length = 1024;
+    int max_list_size = 1024;
+};
+
+struct vm_result {
+    mv_value value;
+    std::optional<vm_error> error;
+    bool success = true;
+};
+
+class vm {
+public:
+    explicit vm(compiled_program prog);
+
+    void set_global(const std::string& name, mv_value value);
+    void register_native(const std::string& name, native_function fn);
+    void register_native_kwargs(const std::string& name, native_kwargs_function fn);
+    void set_limits(const sandbox_limits& limits);
+
+    vm_result run_top_level();
+    vm_result call_function(const std::string& name, const std::vector<mv_value>& args);
+
+private:
+    struct call_frame {
+        const function_chunk* chunk = nullptr;
+        int ip = 0;
+        int stack_base = 0;
+        std::vector<mv_value> locals;
+    };
+
+    compiled_program program_;
+    std::vector<mv_value> stack_;
+    std::vector<call_frame> frames_;
+    std::unordered_map<std::string, mv_value> globals_;
+    std::unordered_map<std::string, native_function> natives_;
+    std::unordered_map<std::string, native_kwargs_function> natives_kwargs_;
+    sandbox_limits limits_;
+    int step_count_ = 0;
+
+    vm_result execute();
+    std::optional<vm_error> run_instruction(call_frame& frame);
+    void push(mv_value val);
+    mv_value pop();
+    mv_value& peek_ref(int offset = 0);
+    const std::string& get_string_constant(uint32_t idx) const;
+    std::optional<vm_error> check_number_result(double val, int line);
+};
+
+// Helpers
+bool is_truthy(const mv_value& val);
+std::string value_type_name(const mv_value& val);
+std::string value_to_string(const mv_value& val);
+
+} // namespace mv

--- a/src/mv/lang/mv_vm.h
+++ b/src/mv/lang/mv_vm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "mv_bytecode.h"
+#include "../api/mv_scene.h"
 
 #include <functional>
 #include <memory>
@@ -16,22 +17,44 @@ namespace mv {
 struct mv_list;
 struct mv_object;
 
+struct native_ref {
+    int index = -1;
+    bool kwargs = false;
+    bool operator==(const native_ref&) const = default;
+};
+
+struct function_ref {
+    int index = -1;
+    bool operator==(const function_ref&) const = default;
+};
+
 using mv_value = std::variant<
     double,                         // number
     bool,                           // bool
     std::string,                    // string
     std::shared_ptr<mv_list>,       // list
     std::shared_ptr<mv_object>,     // object (for ctx, Scene, Node, etc.)
+    native_ref,                     // native callable
+    function_ref,                   // script callable
     std::monostate                  // None
 >;
 
 struct mv_list {
     std::vector<mv_value> elements;
+    std::optional<std::vector<vec2>> cached_points;
+    std::optional<std::vector<scene_node>> cached_scene_nodes;
+
+    void clear_cached_render_data() {
+        cached_points.reset();
+        cached_scene_nodes.reset();
+    }
 };
 
 struct mv_object {
     std::string type_name;
     std::unordered_map<std::string, mv_value> attrs;
+    std::optional<scene_node> cached_scene_node;
+    std::optional<vec2> cached_point;
 
     mv_value get_attr(const std::string& name) const {
         auto it = attrs.find(name);
@@ -39,8 +62,31 @@ struct mv_object {
         return std::monostate{};
     }
 
+    const mv_value* find_attr(const std::string& name) const {
+        auto it = attrs.find(name);
+        return it != attrs.end() ? &it->second : nullptr;
+    }
+
+    void reserve_attrs(std::size_t capacity) {
+        attrs.reserve(capacity);
+    }
+
+    void clear_cached_render_data() {
+        cached_scene_node.reset();
+        cached_point.reset();
+    }
+
     void set_attr(const std::string& name, mv_value val) {
         attrs[name] = std::move(val);
+        clear_cached_render_data();
+    }
+
+    void set_cached_scene_node(scene_node node) {
+        cached_scene_node = std::move(node);
+    }
+
+    void set_cached_point(vec2 point) {
+        cached_point = point;
     }
 };
 
@@ -93,8 +139,10 @@ private:
     std::vector<mv_value> stack_;
     std::vector<call_frame> frames_;
     std::unordered_map<std::string, mv_value> globals_;
-    std::unordered_map<std::string, native_function> natives_;
-    std::unordered_map<std::string, native_kwargs_function> natives_kwargs_;
+    std::vector<native_function> native_table_;
+    std::vector<native_kwargs_function> native_kwargs_table_;
+    std::unordered_map<std::string, int> native_index_by_name_;
+    std::unordered_map<std::string, int> native_kwargs_index_by_name_;
     sandbox_limits limits_;
     int step_count_ = 0;
 

--- a/src/mv/mv_runtime.cpp
+++ b/src/mv/mv_runtime.cpp
@@ -1,0 +1,64 @@
+#include "mv_runtime.h"
+
+#include "api/mv_builtins.h"
+#include "api/mv_context.h"
+#include "render/mv_renderer.h"
+
+#include <fstream>
+#include <sstream>
+
+namespace mv {
+
+bool mv_runtime::load_file(const std::string& path) {
+    std::ifstream file(path);
+    if (!file.is_open()) return false;
+
+    std::ostringstream ss;
+    ss << file.rdbuf();
+    return load_source(ss.str());
+}
+
+bool mv_runtime::load_source(const std::string& source) {
+    loaded_ = false;
+    sandbox_ = sandbox{};
+
+    register_builtins_to_sandbox(sandbox_);
+
+    if (!sandbox_.compile(source)) return false;
+
+    loaded_ = true;
+    return true;
+}
+
+std::optional<scene> mv_runtime::tick(const context_input& input) {
+    if (!loaded_) return std::nullopt;
+
+    auto ctx = build_context(input);
+    auto result = sandbox_.call("draw", {mv_value{ctx}});
+
+    if (!result.success) return std::nullopt;
+
+    auto sc = extract_scene(result.value);
+    if (!sc.has_value()) return std::nullopt;
+
+    // Inject spectrum data into SpectrumBar nodes
+    for (auto& node : sc->nodes) {
+        if (auto* sb = std::get_if<spectrum_bar_node>(&node)) {
+            sb->spectrum.clear();
+            sb->spectrum.reserve(input.spectrum.size());
+            for (float v : input.spectrum) {
+                sb->spectrum.push_back(v);
+            }
+        }
+    }
+
+    validate_scene(*sc, validation_limits_);
+    return sc;
+}
+
+void mv_runtime::reset() {
+    sandbox_ = sandbox{};
+    loaded_ = false;
+}
+
+} // namespace mv

--- a/src/mv/mv_runtime.cpp
+++ b/src/mv/mv_runtime.cpp
@@ -35,7 +35,7 @@ bool mv_runtime::load_source(const std::string& source) {
 std::optional<scene> mv_runtime::tick(const context_input& input) {
     if (!loaded_) return std::nullopt;
 
-    auto ctx = build_context(input);
+    auto ctx = context_builder_.build(input);
     auto result = sandbox_.call("draw", {mv_value{ctx}});
 
     if (!result.success) {

--- a/src/mv/mv_runtime.cpp
+++ b/src/mv/mv_runtime.cpp
@@ -64,7 +64,7 @@ std::optional<scene> mv_runtime::tick(const context_input& input) {
         return std::nullopt;
     }
 
-    // Inject spectrum data into SpectrumBar nodes
+    // Inject audio spectrum into legacy SpectrumBar nodes for compatibility.
     for (auto& node : sc->nodes) {
         if (auto* sb = std::get_if<spectrum_bar_node>(&node)) {
             sb->spectrum.clear();

--- a/src/mv/mv_runtime.cpp
+++ b/src/mv/mv_runtime.cpp
@@ -7,6 +7,8 @@
 #include <fstream>
 #include <sstream>
 
+#include "raylib.h"
+
 namespace mv {
 
 bool mv_runtime::load_file(const std::string& path) {
@@ -36,10 +38,31 @@ std::optional<scene> mv_runtime::tick(const context_input& input) {
     auto ctx = build_context(input);
     auto result = sandbox_.call("draw", {mv_value{ctx}});
 
-    if (!result.success) return std::nullopt;
+    if (!result.success) {
+        static int log_count_a = 0;
+        if (log_count_a < 5) {
+            TraceLog(LOG_WARNING, "MV tick: call('draw') failed");
+            for (const auto& e : result.errors) {
+                TraceLog(LOG_WARNING, "MV tick:   L%d [%s] %s", e.line, e.phase.c_str(), e.message.c_str());
+            }
+            log_count_a++;
+        }
+        return std::nullopt;
+    }
 
     auto sc = extract_scene(result.value);
-    if (!sc.has_value()) return std::nullopt;
+    if (!sc.has_value()) {
+        static int log_count_b = 0;
+        if (log_count_b < 5) {
+            TraceLog(LOG_WARNING, "MV tick: extract_scene failed (return value is not a Scene)");
+            TraceLog(LOG_WARNING, "MV tick:   value type index = %d", static_cast<int>(result.value.index()));
+            if (auto obj = std::get_if<std::shared_ptr<mv_object>>(&result.value)) {
+                TraceLog(LOG_WARNING, "MV tick:   object type_name = '%s'", (*obj)->type_name.c_str());
+            }
+            log_count_b++;
+        }
+        return std::nullopt;
+    }
 
     // Inject spectrum data into SpectrumBar nodes
     for (auto& node : sc->nodes) {

--- a/src/mv/mv_runtime.h
+++ b/src/mv/mv_runtime.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "api/mv_context.h"
+#include "api/mv_scene.h"
+#include "lang/mv_sandbox.h"
+#include "render/mv_validator.h"
+
+#include <optional>
+#include <string>
+
+namespace mv {
+
+// Per-song MV script runtime.
+// Lifecycle: load script → compile once → tick every frame with context_input.
+class mv_runtime {
+public:
+    // Load and compile script from file. Returns false on error.
+    bool load_file(const std::string& path);
+
+    // Load and compile script from string.
+    bool load_source(const std::string& source);
+
+    // Returns true if a script is compiled and ready.
+    bool is_loaded() const { return loaded_; }
+
+    // Execute draw(ctx) and return the validated scene.
+    // Returns nullopt on error or if no script is loaded.
+    std::optional<scene> tick(const context_input& input);
+
+    // Get last error messages (compile or runtime).
+    const std::vector<script_error>& last_errors() const { return sandbox_.last_errors(); }
+
+    // Reset state (unload script).
+    void reset();
+
+private:
+    sandbox sandbox_;
+    bool loaded_ = false;
+    validation_limits validation_limits_;
+};
+
+} // namespace mv

--- a/src/mv/mv_runtime.h
+++ b/src/mv/mv_runtime.h
@@ -35,6 +35,7 @@ public:
 
 private:
     sandbox sandbox_;
+    context_builder context_builder_;
     bool loaded_ = false;
     validation_limits validation_limits_;
 };

--- a/src/mv/mv_script_editor_style.cpp
+++ b/src/mv/mv_script_editor_style.cpp
@@ -1,6 +1,9 @@
 #include "mv_script_editor_style.h"
 
+#include <algorithm>
 #include <cctype>
+#include <unordered_set>
+#include <utility>
 
 #include "scenes/theme.h"
 
@@ -14,6 +17,217 @@ bool is_ident_start(char c) {
 
 bool is_ident_char(char c) {
     return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
+
+bool is_completion_char(char c) {
+    return is_ident_char(c) || c == '.';
+}
+
+std::string trim_comment(const std::string& line) {
+    const size_t comment = line.find('#');
+    return comment == std::string::npos ? line : line.substr(0, comment);
+}
+
+int leading_indent_width(const std::string& line) {
+    int width = 0;
+    for (char c : line) {
+        if (c == ' ') {
+            ++width;
+        } else if (c == '\t') {
+            width += 4;
+        } else {
+            break;
+        }
+    }
+    return width;
+}
+
+std::string ltrim_copy(const std::string& text) {
+    size_t i = 0;
+    while (i < text.size() && std::isspace(static_cast<unsigned char>(text[i]))) {
+        ++i;
+    }
+    return text.substr(i);
+}
+
+bool starts_with(const std::string& text, const std::string& prefix) {
+    return text.rfind(prefix, 0) == 0;
+}
+
+std::string parse_leading_identifier(const std::string& text, size_t start = 0, size_t* end_out = nullptr) {
+    if (start >= text.size() || !is_ident_start(text[start])) {
+        return {};
+    }
+    size_t i = start + 1;
+    while (i < text.size() && is_ident_char(text[i])) {
+        ++i;
+    }
+    if (end_out != nullptr) {
+        *end_out = i;
+    }
+    return text.substr(start, i - start);
+}
+
+std::pair<std::string, bool> parse_assignment_target(const std::string& trimmed) {
+    size_t ident_end = 0;
+    const std::string name = parse_leading_identifier(trimmed, 0, &ident_end);
+    if (name.empty()) {
+        return {"", false};
+    }
+
+    size_t i = ident_end;
+    while (i < trimmed.size() && std::isspace(static_cast<unsigned char>(trimmed[i]))) {
+        ++i;
+    }
+    if (i >= trimmed.size()) {
+        return {"", false};
+    }
+
+    std::string op;
+    if (trimmed.compare(i, 2, "+=") == 0 || trimmed.compare(i, 2, "-=") == 0 ||
+        trimmed.compare(i, 2, "*=") == 0 || trimmed.compare(i, 2, "/=") == 0 ||
+        trimmed.compare(i, 2, "%=") == 0) {
+        op = trimmed.substr(i, 2);
+        i += 2;
+    } else if (trimmed[i] == '=' && (i + 1 >= trimmed.size() || trimmed[i + 1] != '=')) {
+        op = "=";
+        ++i;
+    } else {
+        return {"", false};
+    }
+
+    while (i < trimmed.size() && std::isspace(static_cast<unsigned char>(trimmed[i]))) {
+        ++i;
+    }
+    const bool is_list_assignment = (op == "=") && trimmed.compare(i, 2, "[]") == 0;
+    return {name, is_list_assignment};
+}
+
+std::vector<std::string> parse_def_params(const std::string& trimmed) {
+    std::vector<std::string> params;
+    if (!starts_with(trimmed, "def ")) {
+        return params;
+    }
+
+    const size_t lparen = trimmed.find('(');
+    const size_t rparen = trimmed.find(')', lparen == std::string::npos ? 0 : lparen + 1);
+    if (lparen == std::string::npos || rparen == std::string::npos || rparen <= lparen + 1) {
+        return params;
+    }
+
+    size_t i = lparen + 1;
+    while (i < rparen) {
+        while (i < rparen && (std::isspace(static_cast<unsigned char>(trimmed[i])) || trimmed[i] == ',')) {
+            ++i;
+        }
+        size_t end = 0;
+        const std::string ident = parse_leading_identifier(trimmed, i, &end);
+        if (!ident.empty()) {
+            params.push_back(ident);
+            i = end;
+        } else {
+            ++i;
+        }
+    }
+    return params;
+}
+
+std::string parse_def_name(const std::string& trimmed) {
+    if (!starts_with(trimmed, "def ")) {
+        return {};
+    }
+    return parse_leading_identifier(trimmed, 4);
+}
+
+std::string parse_for_var(const std::string& trimmed) {
+    if (!starts_with(trimmed, "for ")) {
+        return {};
+    }
+    return parse_leading_identifier(trimmed, 4);
+}
+
+struct completion_scope {
+    int min_indent = 0;
+    std::unordered_set<std::string> names;
+    std::unordered_set<std::string> list_names;
+};
+
+struct discovered_symbols {
+    std::vector<std::string> visible_names;
+    std::unordered_set<std::string> list_names;
+};
+
+discovered_symbols collect_visible_symbols(const std::vector<std::string>& lines, int cursor_line, int cursor_col) {
+    std::vector<completion_scope> scopes;
+    scopes.push_back({});
+
+    for (int line_index = 0; line_index <= cursor_line && line_index < static_cast<int>(lines.size()); ++line_index) {
+        std::string line = lines[static_cast<size_t>(line_index)];
+        if (line_index == cursor_line) {
+            line = line.substr(0, static_cast<size_t>(std::clamp(cursor_col, 0, static_cast<int>(line.size()))));
+        }
+        line = trim_comment(line);
+        const int indent = leading_indent_width(line);
+
+        while (scopes.size() > 1 && indent < scopes.back().min_indent) {
+            scopes.pop_back();
+        }
+
+        std::string trimmed = ltrim_copy(line);
+        if (trimmed.empty()) {
+            continue;
+        }
+
+        std::vector<std::string> next_scope_names;
+        std::vector<std::string> next_scope_list_names;
+
+        const std::string def_name = parse_def_name(trimmed);
+        if (!def_name.empty()) {
+            scopes.back().names.insert(def_name);
+            next_scope_names = parse_def_params(trimmed);
+        }
+
+        const std::string for_var = parse_for_var(trimmed);
+        if (!for_var.empty()) {
+            scopes.back().names.insert(for_var);
+            next_scope_names.push_back(for_var);
+        }
+
+        const auto [assigned_name, is_list_assignment] = parse_assignment_target(trimmed);
+        if (!assigned_name.empty()) {
+            scopes.back().names.insert(assigned_name);
+            if (is_list_assignment) {
+                scopes.back().list_names.insert(assigned_name);
+            }
+        }
+
+        if (!trimmed.empty() && trimmed.back() == ':') {
+            completion_scope child_scope;
+            child_scope.min_indent = indent + 1;
+            for (const auto& name : next_scope_names) {
+                child_scope.names.insert(name);
+            }
+            for (const auto& name : next_scope_list_names) {
+                child_scope.list_names.insert(name);
+            }
+            scopes.push_back(std::move(child_scope));
+        }
+    }
+
+    std::unordered_set<std::string> seen_names;
+    discovered_symbols symbols;
+    for (const auto& scope : scopes) {
+        for (const auto& name : scope.names) {
+            if (seen_names.insert(name).second) {
+                symbols.visible_names.push_back(name);
+            }
+        }
+        for (const auto& name : scope.list_names) {
+            symbols.list_names.insert(name);
+        }
+    }
+    std::sort(symbols.visible_names.begin(), symbols.visible_names.end());
+    return symbols;
 }
 
 bool is_in_list(const std::string& value, std::initializer_list<const char*> names) {
@@ -32,6 +246,18 @@ Color string_color() { return g_theme->slow; }
 Color comment_color() { return g_theme->text_hint; }
 Color number_color() { return g_theme->fast; }
 Color punctuation_color() { return g_theme->text_dim; }
+
+void append_matches(std::vector<ui::text_editor_completion_item>& items,
+                    const std::vector<ui::text_editor_completion_item>& source,
+                    const std::string& prefix,
+                    std::unordered_set<std::string>& seen_labels) {
+    for (const auto& item : source) {
+        if ((prefix.empty() || item.label.rfind(prefix, 0) == 0) &&
+            seen_labels.insert(item.label).second) {
+            items.push_back(item);
+        }
+    }
+}
 
 Color identifier_color(const std::string& ident) {
     if (is_in_list(ident, {"def", "return", "if", "elif", "else", "for", "in", "and", "or", "not",
@@ -129,6 +355,158 @@ std::vector<ui::text_editor_span> highlight_mv_script_line(const std::string& li
         ++i;
     }
     return spans;
+}
+
+ui::text_editor_completion_result complete_mv_script_line(const std::vector<std::string>& lines,
+                                                          int cursor_line, int cursor_col) {
+    ui::text_editor_completion_result result;
+    if (cursor_line < 0 || cursor_line >= static_cast<int>(lines.size())) {
+        return result;
+    }
+
+    const std::string& line = lines[static_cast<size_t>(cursor_line)];
+    const int clamped_col = std::clamp(cursor_col, 0, static_cast<int>(line.size()));
+
+    int start = clamped_col;
+    while (start > 0 && is_completion_char(line[start - 1])) {
+        --start;
+    }
+    int end = clamped_col;
+    while (end < static_cast<int>(line.size()) && is_completion_char(line[end])) {
+        ++end;
+    }
+
+    const std::string token = line.substr(static_cast<size_t>(start), static_cast<size_t>(end - start));
+    if (token.empty()) {
+        return result;
+    }
+
+    static const std::vector<ui::text_editor_completion_item> kRootItems = {
+        {"def", "def"},
+        {"return", "return"},
+        {"if", "if"},
+        {"elif", "elif"},
+        {"else", "else"},
+        {"for", "for"},
+        {"in", "in"},
+        {"and", "and"},
+        {"or", "or"},
+        {"not", "not"},
+        {"Scene", "Scene("},
+        {"Point", "Point("},
+        {"Background", "Background("},
+        {"Rect", "Rect("},
+        {"Circle", "Circle("},
+        {"Line", "Line("},
+        {"Text", "Text("},
+        {"Polyline", "Polyline("},
+        {"sin", "sin("},
+        {"cos", "cos("},
+        {"abs", "abs("},
+        {"floor", "floor("},
+        {"ceil", "ceil("},
+        {"sqrt", "sqrt("},
+        {"min", "min("},
+        {"max", "max("},
+        {"clamp", "clamp("},
+        {"lerp", "lerp("},
+        {"smoothstep", "smoothstep("},
+        {"rgb", "rgb("},
+        {"len", "len("},
+        {"range", "range("},
+        {"str", "str("},
+        {"int", "int("},
+        {"float", "float("},
+        {"pi", "pi()"},
+        {"ctx", "ctx"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kCtxItems = {
+        {"ctx.time", "ctx.time"},
+        {"ctx.audio", "ctx.audio"},
+        {"ctx.chart", "ctx.chart"},
+        {"ctx.screen", "ctx.screen"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kTimeItems = {
+        {"ctx.time.ms", "ctx.time.ms"},
+        {"ctx.time.sec", "ctx.time.sec"},
+        {"ctx.time.length_ms", "ctx.time.length_ms"},
+        {"ctx.time.bpm", "ctx.time.bpm"},
+        {"ctx.time.beat", "ctx.time.beat"},
+        {"ctx.time.beat_phase", "ctx.time.beat_phase"},
+        {"ctx.time.progress", "ctx.time.progress"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kAudioItems = {
+        {"ctx.audio.spectrum", "ctx.audio.spectrum"},
+        {"ctx.audio.spectrum_size", "ctx.audio.spectrum_size"},
+        {"ctx.audio.waveform", "ctx.audio.waveform"},
+        {"ctx.audio.waveform_size", "ctx.audio.waveform_size"},
+        {"ctx.audio.waveform_index", "ctx.audio.waveform_index"},
+        {"ctx.audio.oscilloscope", "ctx.audio.oscilloscope"},
+        {"ctx.audio.oscilloscope_size", "ctx.audio.oscilloscope_size"},
+        {"ctx.audio.level", "ctx.audio.level"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kChartItems = {
+        {"ctx.chart.total_notes", "ctx.chart.total_notes"},
+        {"ctx.chart.combo", "ctx.chart.combo"},
+        {"ctx.chart.accuracy", "ctx.chart.accuracy"},
+        {"ctx.chart.key_count", "ctx.chart.key_count"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kScreenItems = {
+        {"ctx.screen.w", "ctx.screen.w"},
+        {"ctx.screen.h", "ctx.screen.h"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kListItems = {
+        {"append", "append("},
+    };
+
+    const discovered_symbols symbols = collect_visible_symbols(lines, cursor_line, cursor_col);
+    std::vector<ui::text_editor_completion_item> matches;
+    std::unordered_set<std::string> seen_labels;
+    if (token.rfind("ctx.time.", 0) == 0) {
+        append_matches(matches, kTimeItems, token, seen_labels);
+    } else if (token.rfind("ctx.audio.", 0) == 0) {
+        append_matches(matches, kAudioItems, token, seen_labels);
+    } else if (token.rfind("ctx.chart.", 0) == 0) {
+        append_matches(matches, kChartItems, token, seen_labels);
+    } else if (token.rfind("ctx.screen.", 0) == 0) {
+        append_matches(matches, kScreenItems, token, seen_labels);
+    } else if (token.rfind("ctx.", 0) == 0 || token == "ctx") {
+        append_matches(matches, kCtxItems, token, seen_labels);
+    } else if (const size_t dot = token.rfind('.'); dot != std::string::npos) {
+        const std::string base = token.substr(0, dot);
+        const std::string member_prefix = token.substr(dot + 1);
+        if (symbols.list_names.contains(base)) {
+            std::vector<ui::text_editor_completion_item> list_matches;
+            append_matches(list_matches, kListItems, member_prefix, seen_labels);
+            for (const auto& item : list_matches) {
+                matches.push_back({base + "." + item.label, base + "." + item.insert_text});
+            }
+        }
+    } else {
+        for (const auto& name : symbols.visible_names) {
+            if (token.empty() || name.rfind(token, 0) == 0) {
+                if (seen_labels.insert(name).second) {
+                    matches.push_back({name, name});
+                }
+            }
+        }
+        append_matches(matches, kRootItems, token, seen_labels);
+    }
+
+    if (matches.empty()) {
+        return result;
+    }
+
+    result.replace_start = start;
+    result.replace_end = end;
+    result.items = std::move(matches);
+    return result;
 }
 
 } // namespace mv

--- a/src/mv/mv_script_editor_style.cpp
+++ b/src/mv/mv_script_editor_style.cpp
@@ -1,0 +1,134 @@
+#include "mv_script_editor_style.h"
+
+#include <cctype>
+
+#include "scenes/theme.h"
+
+namespace mv {
+
+namespace {
+
+bool is_ident_start(char c) {
+    return std::isalpha(static_cast<unsigned char>(c)) || c == '_';
+}
+
+bool is_ident_char(char c) {
+    return std::isalnum(static_cast<unsigned char>(c)) || c == '_';
+}
+
+bool is_in_list(const std::string& value, std::initializer_list<const char*> names) {
+    for (const char* name : names) {
+        if (value == name) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Color keyword_color() { return g_theme->accent; }
+Color builtin_color() { return g_theme->success; }
+Color node_color() { return g_theme->fast; }
+Color string_color() { return g_theme->slow; }
+Color comment_color() { return g_theme->text_hint; }
+Color number_color() { return g_theme->fast; }
+Color punctuation_color() { return g_theme->text_dim; }
+
+Color identifier_color(const std::string& ident) {
+    if (is_in_list(ident, {"def", "return", "if", "elif", "else", "for", "in", "and", "or", "not",
+                           "True", "False", "None"})) {
+        return keyword_color();
+    }
+    if (is_in_list(ident, {"Scene", "Point", "Background", "Rect", "Circle", "Line", "Text",
+                           "Polyline"})) {
+        return node_color();
+    }
+    if (is_in_list(ident, {"SpectrumBar", "BeatGrid", "PulseRing"})) {
+        return g_theme->text_hint;
+    }
+    if (is_in_list(ident, {"sin", "cos", "abs", "floor", "ceil", "sqrt", "min", "max",
+                           "clamp", "lerp", "smoothstep", "rgb", "len", "range",
+                           "str", "int", "float", "pi"})) {
+        return builtin_color();
+    }
+    if (ident == "ctx") {
+        return g_theme->text_secondary;
+    }
+    return g_theme->text;
+}
+
+} // namespace
+
+const ui::text_editor_style& mv_script_editor_style() {
+    static const ui::text_editor_style style{
+        .font_size = 20,
+        .line_spacing = 4.0f,
+        .letter_spacing = 2.0f,
+    };
+    return style;
+}
+
+std::vector<ui::text_editor_span> highlight_mv_script_line(const std::string& line) {
+    std::vector<ui::text_editor_span> spans;
+    size_t i = 0;
+    while (i < line.size()) {
+        const char c = line[i];
+
+        if (c == '#') {
+            spans.push_back({line.substr(i), comment_color()});
+            break;
+        }
+
+        if (c == '"' || c == '\'') {
+            const char quote = c;
+            size_t j = i + 1;
+            while (j < line.size()) {
+                if (line[j] == '\\') {
+                    j += 2;
+                    continue;
+                }
+                if (line[j] == quote) {
+                    ++j;
+                    break;
+                }
+                ++j;
+            }
+            spans.push_back({line.substr(i, j - i), string_color()});
+            i = j;
+            continue;
+        }
+
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            size_t j = i + 1;
+            while (j < line.size() && std::isdigit(static_cast<unsigned char>(line[j]))) {
+                ++j;
+            }
+            if (j < line.size() && line[j] == '.') {
+                ++j;
+                while (j < line.size() && std::isdigit(static_cast<unsigned char>(line[j]))) {
+                    ++j;
+                }
+            }
+            spans.push_back({line.substr(i, j - i), number_color()});
+            i = j;
+            continue;
+        }
+
+        if (is_ident_start(c)) {
+            size_t j = i + 1;
+            while (j < line.size() && is_ident_char(line[j])) {
+                ++j;
+            }
+            const std::string ident = line.substr(i, j - i);
+            spans.push_back({ident, identifier_color(ident)});
+            i = j;
+            continue;
+        }
+
+        const Color color = std::isspace(static_cast<unsigned char>(c)) ? g_theme->text : punctuation_color();
+        spans.push_back({line.substr(i, 1), color});
+        ++i;
+    }
+    return spans;
+}
+
+} // namespace mv

--- a/src/mv/mv_script_editor_style.h
+++ b/src/mv/mv_script_editor_style.h
@@ -9,5 +9,7 @@ namespace mv {
 
 const ui::text_editor_style& mv_script_editor_style();
 std::vector<ui::text_editor_span> highlight_mv_script_line(const std::string& line);
+ui::text_editor_completion_result complete_mv_script_line(const std::vector<std::string>& lines,
+                                                          int cursor_line, int cursor_col);
 
 } // namespace mv

--- a/src/mv/mv_script_editor_style.h
+++ b/src/mv/mv_script_editor_style.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "ui/ui_text_editor.h"
+
+namespace mv {
+
+const ui::text_editor_style& mv_script_editor_style();
+std::vector<ui::text_editor_span> highlight_mv_script_line(const std::string& line);
+
+} // namespace mv

--- a/src/mv/mv_script_panel.cpp
+++ b/src/mv/mv_script_panel.cpp
@@ -1,17 +1,6 @@
 #include "mv_script_panel.h"
 
 #include "mv/mv_script_editor_style.h"
-#include "theme.h"
-#include "ui_draw.h"
-#include "ui_layout.h"
-
-namespace {
-
-constexpr float kButtonRowHeight = 30.0f;
-constexpr float kErrorAreaHeight = 80.0f;
-constexpr float kSpacing = 8.0f;
-
-} // anonymous namespace
 
 mv_script_panel_result mv_script_panel::draw(
     const mv_script_panel_model& model,
@@ -20,57 +9,11 @@ mv_script_panel_result mv_script_panel::draw(
     mv_script_panel_result result;
     const Rectangle& c = model.content_rect;
 
-    // Layout: editor | spacing | buttons | spacing | errors
-    float editor_h = c.height - kButtonRowHeight - kErrorAreaHeight - kSpacing * 2;
-    Rectangle editor_rect = {c.x, c.y, c.width, editor_h};
-    Rectangle button_row = {c.x, c.y + editor_h + kSpacing, c.width, kButtonRowHeight};
-    Rectangle error_rect = {c.x, button_row.y + kButtonRowHeight + kSpacing, c.width, kErrorAreaHeight};
-
     // Text editor
-    ui::draw_text_editor(editor_rect, state.editor, 500,
-                         mv::mv_script_editor_style(), mv::highlight_mv_script_line);
-
-    // Buttons
-    float btn_w = (button_row.width - 4.0f) * 0.5f;
-    Rectangle compile_btn = {button_row.x, button_row.y, btn_w, kButtonRowHeight};
-    Rectangle save_btn = {button_row.x + btn_w + 4.0f, button_row.y, btn_w, kButtonRowHeight};
-
-    auto compile_state = ui::draw_button(compile_btn, "Compile", 14);
-    auto save_state = ui::draw_button(save_btn, "Save", 14);
-
-    if (compile_state.clicked) result.compile_clicked = true;
-    if (save_state.clicked) result.save_clicked = true;
-
-    // Error display area
-    DrawRectangleRec(error_rect, with_alpha(g_theme->section, 200));
-    DrawRectangleLinesEx(error_rect, 1.0f, g_theme->border_light);
-
-    if (state.show_compile_result) {
-        Rectangle error_content = ui::inset(error_rect, ui::edge_insets::uniform(6.0f));
-        if (state.compile_success) {
-            DrawText("OK", static_cast<int>(error_content.x), static_cast<int>(error_content.y),
-                     14, Color{100, 200, 100, 255});
-        } else {
-            float y = error_content.y;
-            int max_errors = std::min(static_cast<int>(state.errors.size()), 5);
-            for (int i = 0; i < max_errors; i++) {
-                const auto& err = state.errors[i];
-                const char* text = TextFormat("L%d: %s", err.line, err.message.c_str());
-                DrawText(text, static_cast<int>(error_content.x), static_cast<int>(y),
-                         12, Color{255, 120, 100, 255});
-                y += 14.0f;
-            }
-            if (static_cast<int>(state.errors.size()) > max_errors) {
-                const char* more = TextFormat("... +%d more", static_cast<int>(state.errors.size()) - max_errors);
-                DrawText(more, static_cast<int>(error_content.x), static_cast<int>(y),
-                         12, g_theme->text_dim);
-            }
-        }
-    } else {
-        Rectangle error_content = ui::inset(error_rect, ui::edge_insets::uniform(6.0f));
-        DrawText("Press Compile to check", static_cast<int>(error_content.x),
-                 static_cast<int>(error_content.y), 12, g_theme->text_hint);
-    }
+    auto editor_result = ui::draw_text_editor(c, state.editor, 500,
+                         mv::mv_script_editor_style(), mv::highlight_mv_script_line,
+                         mv::complete_mv_script_line);
+    result.text_changed = editor_result.changed;
 
     return result;
 }

--- a/src/mv/mv_script_panel.cpp
+++ b/src/mv/mv_script_panel.cpp
@@ -1,5 +1,6 @@
-#include "editor_mv_script_panel.h"
+#include "mv_script_panel.h"
 
+#include "mv/mv_script_editor_style.h"
 #include "theme.h"
 #include "ui_draw.h"
 #include "ui_layout.h"
@@ -12,11 +13,11 @@ constexpr float kSpacing = 8.0f;
 
 } // anonymous namespace
 
-editor_mv_script_panel_result editor_mv_script_panel::draw(
-    const editor_mv_script_panel_model& model,
-    editor_mv_script_panel_state& state) {
+mv_script_panel_result mv_script_panel::draw(
+    const mv_script_panel_model& model,
+    mv_script_panel_state& state) {
 
-    editor_mv_script_panel_result result;
+    mv_script_panel_result result;
     const Rectangle& c = model.content_rect;
 
     // Layout: editor | spacing | buttons | spacing | errors
@@ -26,7 +27,8 @@ editor_mv_script_panel_result editor_mv_script_panel::draw(
     Rectangle error_rect = {c.x, button_row.y + kButtonRowHeight + kSpacing, c.width, kErrorAreaHeight};
 
     // Text editor
-    ui::draw_text_editor(editor_rect, state.editor, 20, 500);
+    ui::draw_text_editor(editor_rect, state.editor, 500,
+                         mv::mv_script_editor_style(), mv::highlight_mv_script_line);
 
     // Buttons
     float btn_w = (button_row.width - 4.0f) * 0.5f;

--- a/src/mv/mv_script_panel.h
+++ b/src/mv/mv_script_panel.h
@@ -7,26 +7,26 @@
 #include "raylib.h"
 #include "ui_text_editor.h"
 
-struct editor_mv_script_panel_state {
+struct mv_script_panel_state {
     ui::text_editor_state editor;
     std::vector<mv::script_error> errors;
     bool compile_success = false;
     bool show_compile_result = false;
 };
 
-struct editor_mv_script_panel_model {
+struct mv_script_panel_model {
     Rectangle content_rect = {};
     Vector2 mouse = {};
 };
 
-struct editor_mv_script_panel_result {
+struct mv_script_panel_result {
     bool compile_clicked = false;
     bool save_clicked = false;
 };
 
-class editor_mv_script_panel {
+class mv_script_panel {
 public:
-    static editor_mv_script_panel_result draw(
-        const editor_mv_script_panel_model& model,
-        editor_mv_script_panel_state& state);
+    static mv_script_panel_result draw(
+        const mv_script_panel_model& model,
+        mv_script_panel_state& state);
 };

--- a/src/mv/mv_script_panel.h
+++ b/src/mv/mv_script_panel.h
@@ -10,8 +10,6 @@
 struct mv_script_panel_state {
     ui::text_editor_state editor;
     std::vector<mv::script_error> errors;
-    bool compile_success = false;
-    bool show_compile_result = false;
 };
 
 struct mv_script_panel_model {
@@ -20,8 +18,7 @@ struct mv_script_panel_model {
 };
 
 struct mv_script_panel_result {
-    bool compile_clicked = false;
-    bool save_clicked = false;
+    bool text_changed = false;
 };
 
 class mv_script_panel {

--- a/src/mv/render/mv_renderer.cpp
+++ b/src/mv/render/mv_renderer.cpp
@@ -1,0 +1,121 @@
+#include "mv_renderer.h"
+
+#include "raylib.h"
+#include "raymath.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace mv {
+
+namespace {
+
+Color to_raylib(const color& c, float opacity = 1.0f) {
+    uint8_t a = static_cast<uint8_t>(std::clamp(c.a * opacity, 0.0f, 255.0f));
+    return {c.r, c.g, c.b, a};
+}
+
+void draw_node(const rect_node& n) {
+    Color col = to_raylib(n.fill, n.opacity);
+    if (n.rotation != 0.0f) {
+        Rectangle rec = {n.x + n.w * 0.5f, n.y + n.h * 0.5f, n.w, n.h};
+        Vector2 origin = {n.w * 0.5f, n.h * 0.5f};
+        DrawRectanglePro(rec, origin, n.rotation, col);
+    } else {
+        DrawRectangle(static_cast<int>(n.x), static_cast<int>(n.y),
+                      static_cast<int>(n.w), static_cast<int>(n.h), col);
+    }
+}
+
+void draw_node(const line_node& n) {
+    Color col = to_raylib(n.stroke, n.opacity);
+    DrawLineEx({n.x1, n.y1}, {n.x2, n.y2}, n.thickness, col);
+}
+
+void draw_node(const text_node& n) {
+    Color col = to_raylib(n.fill, n.opacity);
+    DrawText(n.text.c_str(), static_cast<int>(n.x), static_cast<int>(n.y),
+             n.font_size, col);
+}
+
+void draw_node(const circle_node& n) {
+    Color col = to_raylib(n.fill, n.opacity);
+    DrawCircle(static_cast<int>(n.cx), static_cast<int>(n.cy),
+               n.radius, col);
+}
+
+void draw_node(const polyline_node& n) {
+    if (n.points.size() < 2) return;
+    Color col = to_raylib(n.stroke, n.opacity);
+    for (size_t i = 0; i + 1 < n.points.size(); i++) {
+        DrawLineEx({n.points[i].x, n.points[i].y},
+                   {n.points[i + 1].x, n.points[i + 1].y},
+                   n.thickness, col);
+    }
+}
+
+void draw_node(const spectrum_bar_node& n) {
+    if (n.bar_count <= 0) return;
+    Color col = to_raylib(n.fill, n.opacity);
+    float bar_w = n.w / static_cast<float>(n.bar_count);
+    float gap = bar_w * 0.1f;
+    for (int i = 0; i < n.bar_count; i++) {
+        float amp = 0.0f;
+        if (i < static_cast<int>(n.spectrum.size())) {
+            amp = std::clamp(n.spectrum[i], 0.0f, 1.0f);
+        }
+        float bar_h = n.h * amp;
+        float bx = n.x + i * bar_w + gap * 0.5f;
+        float by = n.y + n.h - bar_h;
+        DrawRectangle(static_cast<int>(bx), static_cast<int>(by),
+                      static_cast<int>(bar_w - gap), static_cast<int>(bar_h), col);
+    }
+}
+
+void draw_node(const beat_grid_node& n) {
+    Color col = to_raylib(n.stroke, n.opacity);
+    // Horizontal lines that pulse with beat
+    float phase_offset = n.beat_phase * 40.0f; // scroll speed
+    float spacing = 40.0f;
+    for (float y = n.y - spacing + std::fmod(phase_offset, spacing);
+         y < n.y + n.h; y += spacing) {
+        if (y >= n.y) {
+            DrawLineEx({n.x, y}, {n.x + n.w, y}, n.thickness, col);
+        }
+    }
+    // Vertical lines (static)
+    for (float x = n.x; x <= n.x + n.w; x += spacing) {
+        DrawLineEx({x, n.y}, {x, n.y + n.h}, n.thickness, col);
+    }
+}
+
+void draw_node(const pulse_ring_node& n) {
+    Color col = to_raylib(n.stroke, n.opacity);
+    // Ring expands and fades with beat_phase
+    float scale = 1.0f + n.beat_phase * 0.5f;
+    float alpha_mul = 1.0f - n.beat_phase;
+    col.a = static_cast<uint8_t>(std::clamp(col.a * alpha_mul, 0.0f, 255.0f));
+    DrawCircleLines(static_cast<int>(n.cx), static_cast<int>(n.cy),
+                    n.radius * scale, col);
+}
+
+void draw_node(const background_node& n) {
+    Color col = to_raylib(n.fill, n.opacity);
+    DrawRectangle(0, 0, 1280, 720, col);
+}
+
+} // anonymous namespace
+
+void render_scene(const scene& sc) {
+    // Clear with scene clear color if alpha > 0
+    if (sc.clear_color.a > 0) {
+        DrawRectangle(0, 0, 1280, 720,
+                      to_raylib(sc.clear_color));
+    }
+
+    for (const auto& node : sc.nodes) {
+        std::visit([](const auto& n) { draw_node(n); }, node);
+    }
+}
+
+} // namespace mv

--- a/src/mv/render/mv_renderer.h
+++ b/src/mv/render/mv_renderer.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "../api/mv_scene.h"
+
+namespace mv {
+
+// Render a scene using raylib 2D draw calls.
+// Assumes virtual_screen coordinate system (1280x720) is already active.
+void render_scene(const scene& sc);
+
+} // namespace mv

--- a/src/mv/render/mv_validator.cpp
+++ b/src/mv/render/mv_validator.cpp
@@ -1,0 +1,109 @@
+#include "mv_validator.h"
+
+#include <cmath>
+#include <sstream>
+
+namespace mv {
+
+namespace {
+
+bool is_finite(float v) { return std::isfinite(v); }
+
+// Clamp and sanitize a single float, return true if it was changed
+bool sanitize_float(float& v, float lo, float hi) {
+    if (!is_finite(v)) { v = 0; return true; }
+    if (v < lo) { v = lo; return true; }
+    if (v > hi) { v = hi; return true; }
+    return false;
+}
+
+} // anonymous namespace
+
+validation_result validate_scene(scene& sc, const validation_limits& limits) {
+    validation_result result;
+
+    // Node count limit
+    if (static_cast<int>(sc.nodes.size()) > limits.max_nodes) {
+        std::ostringstream oss;
+        oss << "node count " << sc.nodes.size() << " exceeds limit "
+            << limits.max_nodes << ", truncated";
+        result.warnings.push_back(oss.str());
+        sc.nodes.resize(limits.max_nodes);
+    }
+
+    // Sanitize node values (NaN/inf → 0, clamp to reasonable range)
+    constexpr float kCoordMax = 4096.0f;
+    constexpr float kSizeMax = 4096.0f;
+
+    for (auto& node : sc.nodes) {
+        std::visit([&](auto& n) {
+            using T = std::decay_t<decltype(n)>;
+            if constexpr (std::is_same_v<T, rect_node>) {
+                sanitize_float(n.x, -kCoordMax, kCoordMax);
+                sanitize_float(n.y, -kCoordMax, kCoordMax);
+                sanitize_float(n.w, 0, kSizeMax);
+                sanitize_float(n.h, 0, kSizeMax);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, line_node>) {
+                sanitize_float(n.x1, -kCoordMax, kCoordMax);
+                sanitize_float(n.y1, -kCoordMax, kCoordMax);
+                sanitize_float(n.x2, -kCoordMax, kCoordMax);
+                sanitize_float(n.y2, -kCoordMax, kCoordMax);
+                sanitize_float(n.thickness, 0, 100);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, text_node>) {
+                sanitize_float(n.x, -kCoordMax, kCoordMax);
+                sanitize_float(n.y, -kCoordMax, kCoordMax);
+                sanitize_float(n.opacity, 0, 1);
+                if (n.font_size < 1) n.font_size = 1;
+                if (n.font_size > 200) n.font_size = 200;
+                if (n.text.size() > 256) n.text.resize(256);
+            }
+            else if constexpr (std::is_same_v<T, circle_node>) {
+                sanitize_float(n.cx, -kCoordMax, kCoordMax);
+                sanitize_float(n.cy, -kCoordMax, kCoordMax);
+                sanitize_float(n.radius, 0, kSizeMax);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, polyline_node>) {
+                for (auto& p : n.points) {
+                    sanitize_float(p.x, -kCoordMax, kCoordMax);
+                    sanitize_float(p.y, -kCoordMax, kCoordMax);
+                }
+                sanitize_float(n.thickness, 0, 100);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, spectrum_bar_node>) {
+                sanitize_float(n.x, -kCoordMax, kCoordMax);
+                sanitize_float(n.y, -kCoordMax, kCoordMax);
+                sanitize_float(n.w, 0, kSizeMax);
+                sanitize_float(n.h, 0, kSizeMax);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, beat_grid_node>) {
+                sanitize_float(n.x, -kCoordMax, kCoordMax);
+                sanitize_float(n.y, -kCoordMax, kCoordMax);
+                sanitize_float(n.w, 0, kSizeMax);
+                sanitize_float(n.h, 0, kSizeMax);
+                sanitize_float(n.beat_phase, 0, 1);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, pulse_ring_node>) {
+                sanitize_float(n.cx, -kCoordMax, kCoordMax);
+                sanitize_float(n.cy, -kCoordMax, kCoordMax);
+                sanitize_float(n.radius, 0, kSizeMax);
+                sanitize_float(n.beat_phase, 0, 1);
+                sanitize_float(n.opacity, 0, 1);
+            }
+            else if constexpr (std::is_same_v<T, background_node>) {
+                sanitize_float(n.opacity, 0, 1);
+            }
+        }, node);
+    }
+
+    return result;
+}
+
+} // namespace mv

--- a/src/mv/render/mv_validator.h
+++ b/src/mv/render/mv_validator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "../api/mv_scene.h"
+
+#include <string>
+#include <vector>
+
+namespace mv {
+
+struct validation_limits {
+    int max_nodes = 512;
+};
+
+struct validation_result {
+    bool ok = true;
+    std::vector<std::string> warnings;
+};
+
+// Validate a scene before rendering. Truncates excess nodes and reports warnings.
+validation_result validate_scene(scene& sc, const validation_limits& limits = {});
+
+} // namespace mv

--- a/src/scenes/editor/controller/editor_runtime_controller.cpp
+++ b/src/scenes/editor/controller/editor_runtime_controller.cpp
@@ -22,6 +22,7 @@ editor_shortcut_result editor_runtime_controller::handle_shortcuts(const editor_
 
     if (!metadata_input_active &&
         !timing_input_active &&
+        !context.mv_script_editor_active &&
         !context.timing_panel.bar_pick_mode &&
         !context.timeline_drag.active &&
         context.space_pressed) {
@@ -32,7 +33,7 @@ editor_shortcut_result editor_runtime_controller::handle_shortcuts(const editor_
             context.hitsound_path);
     }
 
-    if (context.ctrl_down && context.z_pressed) {
+    if (context.ctrl_down && context.z_pressed && !context.mv_script_editor_active) {
         if (context.shift_down) {
             context.state.redo();
         } else {
@@ -42,7 +43,7 @@ editor_shortcut_result editor_runtime_controller::handle_shortcuts(const editor_
         editor_transport_service::sync(context.transport, &context.state, context.hitsound_path, true);
     }
 
-    if (context.ctrl_down && context.y_pressed) {
+    if (context.ctrl_down && context.y_pressed && !context.mv_script_editor_active) {
         context.state.redo();
         editor_scene_sync::sync_after_history_change(context.sync_context);
         editor_transport_service::sync(context.transport, &context.state, context.hitsound_path, true);
@@ -50,6 +51,7 @@ editor_shortcut_result editor_runtime_controller::handle_shortcuts(const editor_
 
     if (!metadata_input_active &&
         !timing_input_active &&
+        !context.mv_script_editor_active &&
         context.delete_pressed &&
         context.selected_note_index.has_value()) {
         const size_t selected_index = *context.selected_note_index;

--- a/src/scenes/editor/controller/editor_runtime_controller.h
+++ b/src/scenes/editor/controller/editor_runtime_controller.h
@@ -16,6 +16,7 @@ struct editor_shortcut_context {
     std::optional<int>& space_playback_start_tick;
     const std::string& hitsound_path;
     bool blocking_modal = false;
+    bool mv_script_editor_active = false;
     bool space_pressed = false;
     bool ctrl_down = false;
     bool shift_down = false;

--- a/src/scenes/editor/editor_mv_script_panel.cpp
+++ b/src/scenes/editor/editor_mv_script_panel.cpp
@@ -26,7 +26,7 @@ editor_mv_script_panel_result editor_mv_script_panel::draw(
     Rectangle error_rect = {c.x, button_row.y + kButtonRowHeight + kSpacing, c.width, kErrorAreaHeight};
 
     // Text editor
-    ui::draw_text_editor(editor_rect, state.editor, 14, 500);
+    ui::draw_text_editor(editor_rect, state.editor, 20, 500);
 
     // Buttons
     float btn_w = (button_row.width - 4.0f) * 0.5f;

--- a/src/scenes/editor/editor_mv_script_panel.cpp
+++ b/src/scenes/editor/editor_mv_script_panel.cpp
@@ -1,0 +1,74 @@
+#include "editor_mv_script_panel.h"
+
+#include "theme.h"
+#include "ui_draw.h"
+#include "ui_layout.h"
+
+namespace {
+
+constexpr float kButtonRowHeight = 30.0f;
+constexpr float kErrorAreaHeight = 80.0f;
+constexpr float kSpacing = 8.0f;
+
+} // anonymous namespace
+
+editor_mv_script_panel_result editor_mv_script_panel::draw(
+    const editor_mv_script_panel_model& model,
+    editor_mv_script_panel_state& state) {
+
+    editor_mv_script_panel_result result;
+    const Rectangle& c = model.content_rect;
+
+    // Layout: editor | spacing | buttons | spacing | errors
+    float editor_h = c.height - kButtonRowHeight - kErrorAreaHeight - kSpacing * 2;
+    Rectangle editor_rect = {c.x, c.y, c.width, editor_h};
+    Rectangle button_row = {c.x, c.y + editor_h + kSpacing, c.width, kButtonRowHeight};
+    Rectangle error_rect = {c.x, button_row.y + kButtonRowHeight + kSpacing, c.width, kErrorAreaHeight};
+
+    // Text editor
+    ui::draw_text_editor(editor_rect, state.editor, 14, 500);
+
+    // Buttons
+    float btn_w = (button_row.width - 4.0f) * 0.5f;
+    Rectangle compile_btn = {button_row.x, button_row.y, btn_w, kButtonRowHeight};
+    Rectangle save_btn = {button_row.x + btn_w + 4.0f, button_row.y, btn_w, kButtonRowHeight};
+
+    auto compile_state = ui::draw_button(compile_btn, "Compile", 14);
+    auto save_state = ui::draw_button(save_btn, "Save", 14);
+
+    if (compile_state.clicked) result.compile_clicked = true;
+    if (save_state.clicked) result.save_clicked = true;
+
+    // Error display area
+    DrawRectangleRec(error_rect, with_alpha(g_theme->section, 200));
+    DrawRectangleLinesEx(error_rect, 1.0f, g_theme->border_light);
+
+    if (state.show_compile_result) {
+        Rectangle error_content = ui::inset(error_rect, ui::edge_insets::uniform(6.0f));
+        if (state.compile_success) {
+            DrawText("OK", static_cast<int>(error_content.x), static_cast<int>(error_content.y),
+                     14, Color{100, 200, 100, 255});
+        } else {
+            float y = error_content.y;
+            int max_errors = std::min(static_cast<int>(state.errors.size()), 5);
+            for (int i = 0; i < max_errors; i++) {
+                const auto& err = state.errors[i];
+                const char* text = TextFormat("L%d: %s", err.line, err.message.c_str());
+                DrawText(text, static_cast<int>(error_content.x), static_cast<int>(y),
+                         12, Color{255, 120, 100, 255});
+                y += 14.0f;
+            }
+            if (static_cast<int>(state.errors.size()) > max_errors) {
+                const char* more = TextFormat("... +%d more", static_cast<int>(state.errors.size()) - max_errors);
+                DrawText(more, static_cast<int>(error_content.x), static_cast<int>(y),
+                         12, g_theme->text_dim);
+            }
+        }
+    } else {
+        Rectangle error_content = ui::inset(error_rect, ui::edge_insets::uniform(6.0f));
+        DrawText("Press Compile to check", static_cast<int>(error_content.x),
+                 static_cast<int>(error_content.y), 12, g_theme->text_hint);
+    }
+
+    return result;
+}

--- a/src/scenes/editor/editor_mv_script_panel.h
+++ b/src/scenes/editor/editor_mv_script_panel.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "mv/lang/mv_sandbox.h"
+#include "raylib.h"
+#include "ui_text_editor.h"
+
+struct editor_mv_script_panel_state {
+    ui::text_editor_state editor;
+    std::vector<mv::script_error> errors;
+    bool compile_success = false;
+    bool show_compile_result = false;
+};
+
+struct editor_mv_script_panel_model {
+    Rectangle content_rect = {};
+    Vector2 mouse = {};
+};
+
+struct editor_mv_script_panel_result {
+    bool compile_clicked = false;
+    bool save_clicked = false;
+};
+
+class editor_mv_script_panel {
+public:
+    static editor_mv_script_panel_result draw(
+        const editor_mv_script_panel_model& model,
+        editor_mv_script_panel_state& state);
+};

--- a/src/scenes/editor/editor_scene_types.h
+++ b/src/scenes/editor/editor_scene_types.h
@@ -32,6 +32,11 @@ struct editor_timeline_note_drag_state {
     int current_tick = 0;
 };
 
+enum class editor_right_panel_tab {
+    timing,
+    mv_script,
+};
+
 enum class editor_pending_action {
     none,
     exit_to_song_select,

--- a/src/scenes/editor/editor_scene_types.h
+++ b/src/scenes/editor/editor_scene_types.h
@@ -34,7 +34,6 @@ struct editor_timeline_note_drag_state {
 
 enum class editor_right_panel_tab {
     timing,
-    mv_script,
 };
 
 enum class editor_pending_action {

--- a/src/scenes/editor/view/editor_right_panel_view.cpp
+++ b/src/scenes/editor/view/editor_right_panel_view.cpp
@@ -10,78 +10,42 @@
 namespace {
 namespace layout = editor::layout;
 
-constexpr float kTabBarHeight = 28.0f;
-constexpr float kTabGap = 4.0f;
-constexpr float kTabContentGap = 8.0f;
-
 const char* timing_event_type_label(timing_event_type type) {
     return type == timing_event_type::bpm ? "BPM" : "Meter";
 }
 }
 
 editor_right_panel_view_result editor_right_panel_view::draw(const editor_right_panel_view_model& model,
-                                                             editor_timing_panel_state& timing_state,
-                                                             editor_mv_script_panel_state& mv_script_state) {
+                                                             editor_timing_panel_state& timing_state) {
     editor_right_panel_view_result result;
     const Rectangle content = ui::inset(layout::kRightPanelRect, ui::edge_insets::uniform(16.0f));
 
-    // Tab bar
-    Rectangle tab_bar = {content.x, content.y, content.width, kTabBarHeight};
-    float tab_w = (tab_bar.width - kTabGap) * 0.5f;
-    Rectangle timing_tab = {tab_bar.x, tab_bar.y, tab_w, kTabBarHeight};
-    Rectangle mv_tab = {tab_bar.x + tab_w + kTabGap, tab_bar.y, tab_w, kTabBarHeight};
-
-    bool timing_active = (model.active_tab == editor_right_panel_tab::timing);
-    auto timing_btn = ui::draw_button_colored(timing_tab, "Timing", 14,
-        timing_active ? g_theme->row_selected : g_theme->row,
-        timing_active ? g_theme->row_selected_hover : g_theme->row_hover,
-        g_theme->text);
-    auto mv_btn = ui::draw_button_colored(mv_tab, "MV Script", 14,
-        !timing_active ? g_theme->row_selected : g_theme->row,
-        !timing_active ? g_theme->row_selected_hover : g_theme->row_hover,
-        g_theme->text);
-
-    if (timing_btn.clicked) result.timing_tab_clicked = true;
-    if (mv_btn.clicked) result.mv_script_tab_clicked = true;
-
-    // Content area below tabs
-    Rectangle tab_content = {
-        content.x, content.y + kTabBarHeight + kTabContentGap,
-        content.width, content.height - kTabBarHeight - kTabContentGap
-    };
-
-    if (model.active_tab == editor_right_panel_tab::timing) {
-        // Timing panel (existing logic)
-        std::vector<editor_timing_panel_item> items;
-        items.reserve(model.timing_events->size());
-        for (size_t index = 0; index < model.timing_events->size(); ++index) {
-            const timing_event& event = (*model.timing_events)[index];
-            items.push_back({
-                index,
-                std::string(timing_event_type_label(event.type)) + " " + model.meter_map->bar_beat_label(event.tick),
-                event.type == timing_event_type::bpm
-                    ? TextFormat("%.1f", event.bpm)
-                    : TextFormat("%d/%d", event.numerator, event.denominator),
-                model.selected_event_index.has_value() && *model.selected_event_index == index
-            });
-        }
-
-        std::optional<timing_event> selected_event;
-        if (model.selected_event_index.has_value() && *model.selected_event_index < model.timing_events->size()) {
-            selected_event = (*model.timing_events)[*model.selected_event_index];
-        }
-
-        result.panel_result = editor_timing_panel::draw(
-            {tab_content, model.mouse, std::move(items), selected_event, model.delete_enabled},
-            timing_state);
-        const Rectangle editor_box = {tab_content.x, tab_content.y + 372.0f, tab_content.width, 164.0f};
-        result.clicked_outside_editor = IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
-                                        !CheckCollisionPointRec(model.mouse, editor_box);
-    } else {
-        // MV Script panel
-        result.mv_script_result = editor_mv_script_panel::draw(
-            {tab_content, model.mouse}, mv_script_state);
+    // Timing panel
+    std::vector<editor_timing_panel_item> items;
+    items.reserve(model.timing_events->size());
+    for (size_t index = 0; index < model.timing_events->size(); ++index) {
+        const timing_event& event = (*model.timing_events)[index];
+        items.push_back({
+            index,
+            std::string(timing_event_type_label(event.type)) + " " + model.meter_map->bar_beat_label(event.tick),
+            event.type == timing_event_type::bpm
+                ? TextFormat("%.1f", event.bpm)
+                : TextFormat("%d/%d", event.numerator, event.denominator),
+            model.selected_event_index.has_value() && *model.selected_event_index == index
+        });
     }
+
+    std::optional<timing_event> selected_event;
+    if (model.selected_event_index.has_value() && *model.selected_event_index < model.timing_events->size()) {
+        selected_event = (*model.timing_events)[*model.selected_event_index];
+    }
+
+    result.panel_result = editor_timing_panel::draw(
+        {content, model.mouse, std::move(items), selected_event, model.delete_enabled},
+        timing_state);
+    const Rectangle editor_box = {content.x, content.y + 372.0f, content.width, 164.0f};
+    result.clicked_outside_editor = IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+                                    !CheckCollisionPointRec(model.mouse, editor_box);
 
     return result;
 }

--- a/src/scenes/editor/view/editor_right_panel_view.cpp
+++ b/src/scenes/editor/view/editor_right_panel_view.cpp
@@ -3,10 +3,16 @@
 #include <string>
 
 #include "editor/view/editor_layout.h"
+#include "theme.h"
+#include "ui_draw.h"
 #include "ui_layout.h"
 
 namespace {
 namespace layout = editor::layout;
+
+constexpr float kTabBarHeight = 28.0f;
+constexpr float kTabGap = 4.0f;
+constexpr float kTabContentGap = 8.0f;
 
 const char* timing_event_type_label(timing_event_type type) {
     return type == timing_event_type::bpm ? "BPM" : "Meter";
@@ -14,31 +20,68 @@ const char* timing_event_type_label(timing_event_type type) {
 }
 
 editor_right_panel_view_result editor_right_panel_view::draw(const editor_right_panel_view_model& model,
-                                                             editor_timing_panel_state& state) {
+                                                             editor_timing_panel_state& timing_state,
+                                                             editor_mv_script_panel_state& mv_script_state) {
     editor_right_panel_view_result result;
     const Rectangle content = ui::inset(layout::kRightPanelRect, ui::edge_insets::uniform(16.0f));
 
-    std::vector<editor_timing_panel_item> items;
-    items.reserve(model.timing_events->size());
-    for (size_t index = 0; index < model.timing_events->size(); ++index) {
-        const timing_event& event = (*model.timing_events)[index];
-        items.push_back({
-            index,
-            std::string(timing_event_type_label(event.type)) + " " + model.meter_map->bar_beat_label(event.tick),
-            event.type == timing_event_type::bpm ? TextFormat("%.1f", event.bpm) : TextFormat("%d/%d", event.numerator, event.denominator),
-            model.selected_event_index.has_value() && *model.selected_event_index == index
-        });
+    // Tab bar
+    Rectangle tab_bar = {content.x, content.y, content.width, kTabBarHeight};
+    float tab_w = (tab_bar.width - kTabGap) * 0.5f;
+    Rectangle timing_tab = {tab_bar.x, tab_bar.y, tab_w, kTabBarHeight};
+    Rectangle mv_tab = {tab_bar.x + tab_w + kTabGap, tab_bar.y, tab_w, kTabBarHeight};
+
+    bool timing_active = (model.active_tab == editor_right_panel_tab::timing);
+    auto timing_btn = ui::draw_button_colored(timing_tab, "Timing", 14,
+        timing_active ? g_theme->row_selected : g_theme->row,
+        timing_active ? g_theme->row_selected_hover : g_theme->row_hover,
+        g_theme->text);
+    auto mv_btn = ui::draw_button_colored(mv_tab, "MV Script", 14,
+        !timing_active ? g_theme->row_selected : g_theme->row,
+        !timing_active ? g_theme->row_selected_hover : g_theme->row_hover,
+        g_theme->text);
+
+    if (timing_btn.clicked) result.timing_tab_clicked = true;
+    if (mv_btn.clicked) result.mv_script_tab_clicked = true;
+
+    // Content area below tabs
+    Rectangle tab_content = {
+        content.x, content.y + kTabBarHeight + kTabContentGap,
+        content.width, content.height - kTabBarHeight - kTabContentGap
+    };
+
+    if (model.active_tab == editor_right_panel_tab::timing) {
+        // Timing panel (existing logic)
+        std::vector<editor_timing_panel_item> items;
+        items.reserve(model.timing_events->size());
+        for (size_t index = 0; index < model.timing_events->size(); ++index) {
+            const timing_event& event = (*model.timing_events)[index];
+            items.push_back({
+                index,
+                std::string(timing_event_type_label(event.type)) + " " + model.meter_map->bar_beat_label(event.tick),
+                event.type == timing_event_type::bpm
+                    ? TextFormat("%.1f", event.bpm)
+                    : TextFormat("%d/%d", event.numerator, event.denominator),
+                model.selected_event_index.has_value() && *model.selected_event_index == index
+            });
+        }
+
+        std::optional<timing_event> selected_event;
+        if (model.selected_event_index.has_value() && *model.selected_event_index < model.timing_events->size()) {
+            selected_event = (*model.timing_events)[*model.selected_event_index];
+        }
+
+        result.panel_result = editor_timing_panel::draw(
+            {tab_content, model.mouse, std::move(items), selected_event, model.delete_enabled},
+            timing_state);
+        const Rectangle editor_box = {tab_content.x, tab_content.y + 372.0f, tab_content.width, 164.0f};
+        result.clicked_outside_editor = IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+                                        !CheckCollisionPointRec(model.mouse, editor_box);
+    } else {
+        // MV Script panel
+        result.mv_script_result = editor_mv_script_panel::draw(
+            {tab_content, model.mouse}, mv_script_state);
     }
 
-    std::optional<timing_event> selected_event;
-    if (model.selected_event_index.has_value() && *model.selected_event_index < model.timing_events->size()) {
-        selected_event = (*model.timing_events)[*model.selected_event_index];
-    }
-
-    result.panel_result = editor_timing_panel::draw(
-        {content, model.mouse, std::move(items), selected_event, model.delete_enabled},
-        state);
-    const Rectangle editor_box = {content.x, content.y + 372.0f, content.width, 164.0f};
-    result.clicked_outside_editor = IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && !CheckCollisionPointRec(model.mouse, editor_box);
     return result;
 }

--- a/src/scenes/editor/view/editor_right_panel_view.h
+++ b/src/scenes/editor/view/editor_right_panel_view.h
@@ -4,12 +4,10 @@
 #include <vector>
 
 #include "editor/editor_meter_map.h"
-#include "editor/editor_mv_script_panel.h"
 #include "editor/editor_scene_types.h"
 #include "editor/editor_timing_panel.h"
 
 struct editor_right_panel_view_model {
-    editor_right_panel_tab active_tab = editor_right_panel_tab::timing;
     const std::vector<timing_event>* timing_events = nullptr;
     const editor_meter_map* meter_map = nullptr;
     std::optional<size_t> selected_event_index;
@@ -20,14 +18,10 @@ struct editor_right_panel_view_model {
 struct editor_right_panel_view_result {
     editor_timing_panel_result panel_result;
     bool clicked_outside_editor = false;
-    bool timing_tab_clicked = false;
-    bool mv_script_tab_clicked = false;
-    editor_mv_script_panel_result mv_script_result;
 };
 
 class editor_right_panel_view final {
 public:
     static editor_right_panel_view_result draw(const editor_right_panel_view_model& model,
-                                               editor_timing_panel_state& timing_state,
-                                               editor_mv_script_panel_state& mv_script_state);
+                                               editor_timing_panel_state& timing_state);
 };

--- a/src/scenes/editor/view/editor_right_panel_view.h
+++ b/src/scenes/editor/view/editor_right_panel_view.h
@@ -4,9 +4,12 @@
 #include <vector>
 
 #include "editor/editor_meter_map.h"
+#include "editor/editor_mv_script_panel.h"
+#include "editor/editor_scene_types.h"
 #include "editor/editor_timing_panel.h"
 
 struct editor_right_panel_view_model {
+    editor_right_panel_tab active_tab = editor_right_panel_tab::timing;
     const std::vector<timing_event>* timing_events = nullptr;
     const editor_meter_map* meter_map = nullptr;
     std::optional<size_t> selected_event_index;
@@ -17,10 +20,14 @@ struct editor_right_panel_view_model {
 struct editor_right_panel_view_result {
     editor_timing_panel_result panel_result;
     bool clicked_outside_editor = false;
+    bool timing_tab_clicked = false;
+    bool mv_script_tab_clicked = false;
+    editor_mv_script_panel_result mv_script_result;
 };
 
 class editor_right_panel_view final {
 public:
     static editor_right_panel_view_result draw(const editor_right_panel_view_model& model,
-                                               editor_timing_panel_state& state);
+                                               editor_timing_panel_state& timing_state,
+                                               editor_mv_script_panel_state& mv_script_state);
 };

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -1,8 +1,12 @@
 #include "editor_scene.h"
 
+#include <filesystem>
+#include <fstream>
 #include <memory>
 
 #include "audio_manager.h"
+#include "core/app_paths.h"
+#include "mv/api/mv_builtins.h"
 #include "editor/controller/editor_runtime_controller.h"
 #include "editor/view/editor_cursor_hud_view.h"
 #include "editor/editor_flow_controller.h"
@@ -100,6 +104,17 @@ void editor_scene::on_enter() {
     selected_note_index_ = load_result.selected_note_index;
     timeline_drag_ = {};
     resume_state_.reset();
+
+    // Load MV script if exists
+    auto script_file = app_paths::script_path(song_.meta.song_id);
+    if (std::filesystem::exists(script_file)) {
+        std::ifstream ifs(script_file);
+        std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+        ui::text_editor_set_text(mv_script_panel_.editor, content);
+    } else {
+        ui::text_editor_set_text(mv_script_panel_.editor,
+            "def draw(ctx):\n  return Scene([])\n");
+    }
 }
 
 void editor_scene::on_exit() {
@@ -129,7 +144,7 @@ void editor_scene::update(float dt) {
         IsKeyPressed(KEY_F5),
         IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT),
         has_active_metadata_input(),
-        timing_panel_.active_input_field != editor_timing_input_field::none,
+        timing_panel_.active_input_field != editor_timing_input_field::none || mv_script_panel_.editor.active,
         timing_panel_.bar_pick_mode,
         timeline_drag_.active,
         save_dialog_submit,
@@ -157,6 +172,7 @@ void editor_scene::update(float dt) {
         space_playback_start_tick_,
         hitsound_path_,
         has_blocking_modal(),
+        mv_script_panel_.editor.active,
         IsKeyPressed(KEY_SPACE),
         IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL),
         IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT),
@@ -264,12 +280,33 @@ void editor_scene::draw() {
 
     editor_scene_sync::sync_timing_event_selection(make_sync_context());
     const editor_right_panel_view_result right_panel = editor_right_panel_view::draw({
+        right_panel_tab_,
         &state_->data().timing_events,
         &meter_map_,
         timing_panel_.selected_event_index,
         can_delete_selected_timing_event(),
         virtual_screen::get_virtual_mouse(),
-    }, timing_panel_);
+    }, timing_panel_, mv_script_panel_);
+
+    // Tab switching
+    if (right_panel.timing_tab_clicked) right_panel_tab_ = editor_right_panel_tab::timing;
+    if (right_panel.mv_script_tab_clicked) right_panel_tab_ = editor_right_panel_tab::mv_script;
+
+    // MV Script panel actions
+    if (right_panel.mv_script_result.compile_clicked) {
+        mv::sandbox sandbox;
+        mv::register_builtins_to_sandbox(sandbox);
+        std::string source = ui::text_editor_get_text(mv_script_panel_.editor);
+        mv_script_panel_.compile_success = sandbox.compile(source);
+        mv_script_panel_.errors = sandbox.last_errors();
+        mv_script_panel_.show_compile_result = true;
+    }
+    if (right_panel.mv_script_result.save_clicked) {
+        auto path = app_paths::script_path(song_.meta.song_id);
+        std::filesystem::create_directories(path.parent_path());
+        std::ofstream ofs(path);
+        ofs << ui::text_editor_get_text(mv_script_panel_.editor);
+    }
     const editor_timing_panel_update_result update_result = editor_panel_controller::update_timing_panel(
         metadata_panel_,
         timing_panel_,

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -1,12 +1,8 @@
 #include "editor_scene.h"
 
-#include <filesystem>
-#include <fstream>
 #include <memory>
 
 #include "audio_manager.h"
-#include "core/app_paths.h"
-#include "mv/api/mv_builtins.h"
 #include "editor/controller/editor_runtime_controller.h"
 #include "editor/view/editor_cursor_hud_view.h"
 #include "editor/editor_flow_controller.h"
@@ -104,17 +100,6 @@ void editor_scene::on_enter() {
     selected_note_index_ = load_result.selected_note_index;
     timeline_drag_ = {};
     resume_state_.reset();
-
-    // Load MV script if exists
-    auto script_file = app_paths::script_path(song_.meta.song_id);
-    if (std::filesystem::exists(script_file)) {
-        std::ifstream ifs(script_file);
-        std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
-        ui::text_editor_set_text(mv_script_panel_.editor, content);
-    } else {
-        ui::text_editor_set_text(mv_script_panel_.editor,
-            "def draw(ctx):\n  return Scene([])\n");
-    }
 }
 
 void editor_scene::on_exit() {
@@ -144,7 +129,7 @@ void editor_scene::update(float dt) {
         IsKeyPressed(KEY_F5),
         IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT),
         has_active_metadata_input(),
-        timing_panel_.active_input_field != editor_timing_input_field::none || mv_script_panel_.editor.active,
+        timing_panel_.active_input_field != editor_timing_input_field::none,
         timing_panel_.bar_pick_mode,
         timeline_drag_.active,
         save_dialog_submit,
@@ -172,7 +157,7 @@ void editor_scene::update(float dt) {
         space_playback_start_tick_,
         hitsound_path_,
         has_blocking_modal(),
-        mv_script_panel_.editor.active,
+        false,
         IsKeyPressed(KEY_SPACE),
         IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL),
         IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT),
@@ -280,33 +265,12 @@ void editor_scene::draw() {
 
     editor_scene_sync::sync_timing_event_selection(make_sync_context());
     const editor_right_panel_view_result right_panel = editor_right_panel_view::draw({
-        right_panel_tab_,
         &state_->data().timing_events,
         &meter_map_,
         timing_panel_.selected_event_index,
         can_delete_selected_timing_event(),
         virtual_screen::get_virtual_mouse(),
-    }, timing_panel_, mv_script_panel_);
-
-    // Tab switching
-    if (right_panel.timing_tab_clicked) right_panel_tab_ = editor_right_panel_tab::timing;
-    if (right_panel.mv_script_tab_clicked) right_panel_tab_ = editor_right_panel_tab::mv_script;
-
-    // MV Script panel actions
-    if (right_panel.mv_script_result.compile_clicked) {
-        mv::sandbox sandbox;
-        mv::register_builtins_to_sandbox(sandbox);
-        std::string source = ui::text_editor_get_text(mv_script_panel_.editor);
-        mv_script_panel_.compile_success = sandbox.compile(source);
-        mv_script_panel_.errors = sandbox.last_errors();
-        mv_script_panel_.show_compile_result = true;
-    }
-    if (right_panel.mv_script_result.save_clicked) {
-        auto path = app_paths::script_path(song_.meta.song_id);
-        std::filesystem::create_directories(path.parent_path());
-        std::ofstream ofs(path);
-        ofs << ui::text_editor_get_text(mv_script_panel_.editor);
-    }
+    }, timing_panel_);
     const editor_timing_panel_update_result update_result = editor_panel_controller::update_timing_panel(
         metadata_panel_,
         timing_panel_,

--- a/src/scenes/editor_scene.h
+++ b/src/scenes/editor_scene.h
@@ -12,6 +12,7 @@
 #include "editor/editor_timing_panel.h"
 #include "editor/editor_panel_controller.h"
 #include "editor/editor_scene_sync.h"
+#include "editor/editor_mv_script_panel.h"
 #include "editor/editor_scene_types.h"
 #include "editor/viewport/editor_timeline_viewport.h"
 #include "raylib.h"
@@ -78,4 +79,6 @@ private:
     metadata_panel_state metadata_panel_;
     save_dialog_state save_dialog_;
     unsaved_changes_dialog_state unsaved_changes_dialog_;
+    editor_right_panel_tab right_panel_tab_ = editor_right_panel_tab::timing;
+    editor_mv_script_panel_state mv_script_panel_;
 };

--- a/src/scenes/editor_scene.h
+++ b/src/scenes/editor_scene.h
@@ -12,7 +12,6 @@
 #include "editor/editor_timing_panel.h"
 #include "editor/editor_panel_controller.h"
 #include "editor/editor_scene_sync.h"
-#include "editor/editor_mv_script_panel.h"
 #include "editor/editor_scene_types.h"
 #include "editor/viewport/editor_timeline_viewport.h"
 #include "raylib.h"
@@ -80,5 +79,4 @@ private:
     save_dialog_state save_dialog_;
     unsaved_changes_dialog_state unsaved_changes_dialog_;
     editor_right_panel_tab right_panel_tab_ = editor_right_panel_tab::timing;
-    editor_mv_script_panel_state mv_script_panel_;
 };

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -99,7 +99,7 @@ void mv_editor_scene::draw() {
         static_cast<float>(kScreenHeight) - kHeaderHeight - kPadding * 2.0f
     };
 
-    auto result = editor_mv_script_panel::draw({content, virtual_screen::get_virtual_mouse()}, panel_state_);
+    auto result = mv_script_panel::draw({content, virtual_screen::get_virtual_mouse()}, panel_state_);
 
     if (result.compile_clicked) {
         compile_script();

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -1,0 +1,133 @@
+#include "mv_editor_scene.h"
+
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+#include "core/app_paths.h"
+#include "mv/api/mv_builtins.h"
+#include "mv/lang/mv_sandbox.h"
+#include "scene_common.h"
+#include "scene_manager.h"
+#include "song_select_scene.h"
+#include "theme.h"
+#include "ui_draw.h"
+#include "ui_layout.h"
+#include "ui_text_editor.h"
+#include "virtual_screen.h"
+
+namespace {
+
+constexpr float kHeaderHeight = 48.0f;
+constexpr float kPadding = 16.0f;
+constexpr float kBackButtonWidth = 100.0f;
+constexpr float kBackButtonHeight = 30.0f;
+
+} // namespace
+
+mv_editor_scene::mv_editor_scene(scene_manager& manager, song_data song)
+    : scene(manager), song_(std::move(song)) {
+}
+
+void mv_editor_scene::on_enter() {
+    auto script_file = app_paths::script_path(song_.meta.song_id);
+    if (std::filesystem::exists(script_file)) {
+        std::ifstream ifs(script_file);
+        std::string content((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
+        ui::text_editor_set_text(panel_state_.editor, content);
+    } else {
+        ui::text_editor_set_text(panel_state_.editor,
+            "def draw(ctx):\n  return Scene([])\n");
+    }
+    panel_state_.show_compile_result = false;
+    dirty_ = false;
+}
+
+void mv_editor_scene::on_exit() {
+}
+
+void mv_editor_scene::update(float dt) {
+    ui::begin_hit_regions();
+
+    if (IsKeyPressed(KEY_ESCAPE)) {
+        manager_.change_scene(std::make_unique<song_select_scene>(manager_, song_.meta.song_id));
+        return;
+    }
+
+    if (!panel_state_.editor.active) {
+        if (IsKeyDown(KEY_LEFT_CONTROL) && IsKeyPressed(KEY_S)) {
+            save_script();
+            return;
+        }
+    }
+}
+
+void mv_editor_scene::draw() {
+    virtual_screen::begin();
+    ClearBackground(g_theme->bg);
+    DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
+    ui::begin_draw_queue();
+
+    // Header
+    Rectangle header = {0, 0, static_cast<float>(kScreenWidth), kHeaderHeight};
+    DrawRectangleRec(header, g_theme->section);
+    DrawRectangleLinesEx(header, 1.0f, g_theme->border_light);
+
+    const char* title = TextFormat("MV Script - %s", song_.meta.title.c_str());
+    DrawText(title, static_cast<int>(kPadding), 14, 20, g_theme->text);
+
+    // Back button
+    Rectangle back_btn = {
+        static_cast<float>(kScreenWidth) - kBackButtonWidth - kPadding,
+        (kHeaderHeight - kBackButtonHeight) * 0.5f,
+        kBackButtonWidth, kBackButtonHeight
+    };
+    auto back_result = ui::draw_button(back_btn, "Back", 14);
+    if (back_result.clicked) {
+        manager_.change_scene(std::make_unique<song_select_scene>(manager_, song_.meta.song_id));
+        ui::flush_draw_queue();
+        virtual_screen::end();
+        ClearBackground(BLACK);
+        virtual_screen::draw_to_screen();
+        return;
+    }
+
+    // MV script panel content area
+    Rectangle content = {
+        kPadding, kHeaderHeight + kPadding,
+        static_cast<float>(kScreenWidth) - kPadding * 2.0f,
+        static_cast<float>(kScreenHeight) - kHeaderHeight - kPadding * 2.0f
+    };
+
+    auto result = editor_mv_script_panel::draw({content, virtual_screen::get_virtual_mouse()}, panel_state_);
+
+    if (result.compile_clicked) {
+        compile_script();
+    }
+    if (result.save_clicked) {
+        save_script();
+    }
+
+    ui::flush_draw_queue();
+    virtual_screen::end();
+
+    ClearBackground(BLACK);
+    virtual_screen::draw_to_screen();
+}
+
+void mv_editor_scene::compile_script() {
+    mv::sandbox sandbox;
+    mv::register_builtins_to_sandbox(sandbox);
+    std::string source = ui::text_editor_get_text(panel_state_.editor);
+    panel_state_.compile_success = sandbox.compile(source);
+    panel_state_.errors = sandbox.last_errors();
+    panel_state_.show_compile_result = true;
+}
+
+void mv_editor_scene::save_script() {
+    auto path = app_paths::script_path(song_.meta.song_id);
+    std::filesystem::create_directories(path.parent_path());
+    std::ofstream ofs(path);
+    ofs << ui::text_editor_get_text(panel_state_.editor);
+    dirty_ = false;
+}

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -39,11 +39,14 @@ void mv_editor_scene::on_enter() {
         ui::text_editor_set_text(panel_state_.editor,
             "def draw(ctx):\n  return Scene([])\n");
     }
-    panel_state_.show_compile_result = false;
     dirty_ = false;
+    compile_script();
 }
 
 void mv_editor_scene::on_exit() {
+    if (dirty_) {
+        save_script();
+    }
 }
 
 void mv_editor_scene::update(float dt) {
@@ -101,11 +104,15 @@ void mv_editor_scene::draw() {
 
     auto result = mv_script_panel::draw({content, virtual_screen::get_virtual_mouse()}, panel_state_);
 
-    if (result.compile_clicked) {
-        compile_script();
+    if (result.text_changed) {
+        dirty_ = true;
+        last_change_time_ = GetTime();
+        pending_compile_ = true;
     }
-    if (result.save_clicked) {
-        save_script();
+    // Debounced auto-compile: 0.3s after last change
+    if (pending_compile_ && (GetTime() - last_change_time_) >= 0.3) {
+        compile_script();
+        pending_compile_ = false;
     }
 
     ui::flush_draw_queue();
@@ -116,12 +123,29 @@ void mv_editor_scene::draw() {
 }
 
 void mv_editor_scene::compile_script() {
-    mv::sandbox sandbox;
-    mv::register_builtins_to_sandbox(sandbox);
-    std::string source = ui::text_editor_get_text(panel_state_.editor);
-    panel_state_.compile_success = sandbox.compile(source);
-    panel_state_.errors = sandbox.last_errors();
-    panel_state_.show_compile_result = true;
+    try {
+        mv::sandbox sandbox;
+        mv::register_builtins_to_sandbox(sandbox);
+        std::string source = ui::text_editor_get_text(panel_state_.editor);
+        sandbox.compile(source);
+        panel_state_.errors = sandbox.last_errors();
+
+        // Populate inline error markers for squiggly underlines
+        panel_state_.editor.error_markers.clear();
+        for (const auto& err : panel_state_.errors) {
+            if (err.line > 0) {
+                panel_state_.editor.error_markers.push_back({
+                    err.line, std::max(err.column - 1, 0), std::max(err.column, 0), err.message
+                });
+            }
+        }
+    } catch (const std::exception& e) {
+        panel_state_.errors = {{"internal", e.what(), 0, 0}};
+        panel_state_.editor.error_markers.clear();
+    } catch (...) {
+        panel_state_.errors = {{"internal", "unexpected error during compile", 0, 0}};
+        panel_state_.editor.error_markers.clear();
+    }
 }
 
 void mv_editor_scene::save_script() {

--- a/src/scenes/mv_editor_scene.h
+++ b/src/scenes/mv_editor_scene.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <string>
+
+#include "data_models.h"
+#include "editor/editor_mv_script_panel.h"
+#include "scene.h"
+
+// MV(.rmv)スクリプトの編集画面。曲選択画面から遷移する。
+class mv_editor_scene final : public scene {
+public:
+    mv_editor_scene(scene_manager& manager, song_data song);
+
+    void on_enter() override;
+    void on_exit() override;
+    void update(float dt) override;
+    void draw() override;
+
+private:
+    void compile_script();
+    void save_script();
+
+    song_data song_;
+    editor_mv_script_panel_state panel_state_;
+    bool dirty_ = false;
+};

--- a/src/scenes/mv_editor_scene.h
+++ b/src/scenes/mv_editor_scene.h
@@ -23,4 +23,6 @@ private:
     song_data song_;
     mv_script_panel_state panel_state_;
     bool dirty_ = false;
+    double last_change_time_ = 0.0;
+    bool pending_compile_ = false;
 };

--- a/src/scenes/mv_editor_scene.h
+++ b/src/scenes/mv_editor_scene.h
@@ -3,7 +3,7 @@
 #include <string>
 
 #include "data_models.h"
-#include "editor/editor_mv_script_panel.h"
+#include "mv/mv_script_panel.h"
 #include "scene.h"
 
 // MV(.rmv)スクリプトの編集画面。曲選択画面から遷移する。
@@ -21,6 +21,6 @@ private:
     void save_script();
 
     song_data song_;
-    editor_mv_script_panel_state panel_state_;
+    mv_script_panel_state panel_state_;
     bool dirty_ = false;
 };

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -53,14 +53,11 @@ constexpr Rectangle kJudgeFeedbackRect = ui::place(kScreenRect, 320.0f, 42.0f,
                                                    {0.0f, 34.0f});
 constexpr Rectangle kFailureTextRect = ui::place(kScreenRect, 360.0f, 44.0f,
                                                  ui::anchor::center, ui::anchor::center);
-constexpr float kTapNoteBaseHeight = 0.2f;
 constexpr float kTapNoteBaseLength = 0.78f;
-constexpr float kTapNoteWireHeight = 0.22f;
-constexpr float kTapNoteWireLength = 0.82f;
-constexpr float kHoldNoteBaseHeight = 0.12f;
-constexpr float kHoldNoteWireHeight = 0.14f;
 constexpr float kJudgeLineY = 0.40f;
 constexpr float kJudgeLineGlowY = 0.46f;
+constexpr float kTapNoteY = 0.00f;
+constexpr float kHoldNoteY = 0.00f;
 
 float lane_center_x(int lane, int key_count) {
     const float total_width = key_count * g_settings.lane_width + (key_count - 1) * kLaneGap;
@@ -69,9 +66,8 @@ float lane_center_x(int lane, int key_count) {
     return left + visual_lane * (g_settings.lane_width + kLaneGap);
 }
 
-Color darkened_lane_color(Color color) {
-    return {static_cast<unsigned char>(color.r * 0.7f), static_cast<unsigned char>(color.g * 0.7f),
-            static_cast<unsigned char>(color.b * 0.72f), color.a};
+void draw_note_plane(float center_x, float y, float center_z, float width, float length, Color fill) {
+    DrawPlane({center_x, y, center_z}, {width, length}, fill);
 }
 
 Color judge_color(judge_result result) {
@@ -203,7 +199,7 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
     for (int lane = 0; lane < state.key_count; ++lane) {
         const float center_x = lane_center_x(lane, state.key_count);
         const bool lane_held = state.input_handler.is_lane_held(lane);
-        const Color lane_fill = lane_held ? darkened_lane_color(g_theme->lane) : g_theme->lane;
+        const Color lane_fill = lane_held ? g_theme->lane_pressed : g_theme->lane;
         DrawCube({center_x, -0.08f, (lane_start_z + lane_end_z) * 0.5f}, g_settings.lane_width, 0.05f,
                  lane_end_z - lane_start_z, lane_fill);
         DrawCubeWires({center_x, -0.08f, (lane_start_z + lane_end_z) * 0.5f}, g_settings.lane_width, 0.05f,
@@ -215,7 +211,6 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
     if (draw_queue.has_active_notes()) {
         const std::vector<note_state>& note_states = state.judge_system.note_states();
         const Color note_color = g_theme->note_color;
-        const Color note_outline = g_theme->note_outline;
 
         for (int lane = 0; lane < state.key_count; ++lane) {
             for (const size_t idx : draw_queue.active_indices_for_lane(lane)) {
@@ -229,24 +224,15 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
                     const float visual_head_z = note_state.is_holding() ? judgement_z : head_z;
                     const float segment_start = std::max(std::min(visual_head_z, tail_z), lane_start_z);
                     const float segment_end = std::min(std::max(head_z, tail_z), lane_end_z);
-                    const float hold_height = kHoldNoteBaseHeight * g_settings.note_height;
-                    const float hold_wire_height = kHoldNoteWireHeight * g_settings.note_height;
                     if (segment_end > segment_start) {
-                        DrawCube({center_x, 0.30f, (segment_start + segment_end) * 0.5f}, g_settings.lane_width * 0.92f,
-                                 hold_height, segment_end - segment_start, note_color);
-                        DrawCubeWires({center_x, 0.30f, (segment_start + segment_end) * 0.5f},
-                                      g_settings.lane_width * 0.94f, hold_wire_height, segment_end - segment_start + 0.04f,
-                                      note_outline);
+                        draw_note_plane(center_x, kHoldNoteY, (segment_start + segment_end) * 0.5f,
+                                        g_settings.lane_width * 0.92f, segment_end - segment_start, note_color);
                     }
                 }
 
                 if (note_state.note_ref.type == note_type::tap) {
-                    DrawCube({center_x, 0.22f, head_z}, g_settings.lane_width * 0.92f,
-                             kTapNoteBaseHeight * g_settings.note_height,
-                             kTapNoteBaseLength * g_settings.note_height, note_color);
-                    DrawCubeWires({center_x, 0.22f, head_z}, g_settings.lane_width * 0.92f,
-                                  kTapNoteWireHeight * g_settings.note_height,
-                                  kTapNoteWireLength * g_settings.note_height, note_outline);
+                    draw_note_plane(center_x, kTapNoteY, head_z,
+                                    g_settings.lane_width * 0.92f, kTapNoteBaseLength * g_settings.note_height, note_color);
                 }
             }
         }

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -38,7 +38,7 @@ double calculate_song_end_ms(const chart_data& chart, const timing_engine& engin
         last_tick = std::max(last_tick, note.type == note_type::hold ? note.end_tick : note.tick);
     }
 
-    return std::max(engine.tick_to_ms(last_tick) + 2000.0, audio.get_bgm_length_seconds() * 1000.0);
+    return std::max(engine.tick_to_ms(last_tick) + 5000.0, audio.get_bgm_length_seconds() * 1000.0);
 }
 
 int calculate_total_judge_points(const chart_data& chart) {

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -5,6 +5,7 @@
 
 #include "app_paths.h"
 #include "audio_manager.h"
+#include "audio_waveform.h"
 #include "game_settings.h"
 #include "path_utils.h"
 #include "player_note_offsets.h"
@@ -47,6 +48,18 @@ int calculate_total_judge_points(const chart_data& chart) {
         total += note.type == note_type::hold ? 2 : 1;
     }
     return total;
+}
+
+std::vector<float> build_mv_waveform(const std::filesystem::path& audio_path) {
+    constexpr std::size_t kMvWaveformSegmentCount = 512;
+
+    const audio_waveform_summary summary = audio_waveform::build(path_utils::to_utf8(audio_path), kMvWaveformSegmentCount);
+    std::vector<float> waveform;
+    waveform.reserve(summary.peaks.size());
+    for (const audio_waveform_peak& peak : summary.peaks) {
+        waveform.push_back(peak.amplitude);
+    }
+    return waveform;
 }
 
 }  // namespace
@@ -118,6 +131,7 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
     const std::filesystem::path audio_path =
         path_utils::join_utf8(state.song_data->directory, state.song_data->meta.audio_file);
     audio.load_bgm(path_utils::to_utf8(audio_path));
+    state.mv_waveform = build_mv_waveform(audio_path);
     if (state.start_ms > 0.0) {
         audio.seek_bgm(state.start_ms / 1000.0);
     }

--- a/src/scenes/play/play_session_types.h
+++ b/src/scenes/play/play_session_types.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "editor/editor_scene_types.h"
 #include "input_handler.h"
@@ -86,6 +87,7 @@ struct play_session_state {
     bool result_transition_playing = false;
     float result_transition_timer = 0.0f;
     std::string hitsound_path;
+    std::vector<float> mv_waveform;
     int start_tick = 0;
     double start_ms = 0.0;
 };

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -77,6 +77,8 @@ play_scene::play_scene(scene_manager& manager, song_data song, chart_data chart,
     request_.start_tick = std::max(0, start_tick);
 }
 
+play_scene::~play_scene() = default;
+
 void play_scene::on_enter() {
     state_ = play_session_loader::load(request_, draw_queue_);
 

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -2,11 +2,16 @@
 
 #include <algorithm>
 #include <cmath>
+#include <filesystem>
 #include <memory>
 #include <optional>
 
 #include "audio_manager.h"
+#include "core/app_paths.h"
 #include "editor_scene.h"
+#include "mv/api/mv_context.h"
+#include "mv/mv_runtime.h"
+#include "mv/render/mv_renderer.h"
 #include "play/play_flow_controller.h"
 #include "play/play_renderer.h"
 #include "play/play_session_loader.h"
@@ -74,6 +79,17 @@ play_scene::play_scene(scene_manager& manager, song_data song, chart_data chart,
 
 void play_scene::on_enter() {
     state_ = play_session_loader::load(request_, draw_queue_);
+
+    // Try to load MV script for this song
+    if (state_.song_data.has_value()) {
+        auto script_file = app_paths::script_path(state_.song_data->meta.song_id);
+        if (std::filesystem::exists(script_file)) {
+            mv_runtime_ = std::make_unique<mv::mv_runtime>();
+            if (!mv_runtime_->load_file(script_file.string())) {
+                mv_runtime_.reset(); // failed to compile, ignore
+            }
+        }
+    }
 }
 
 void play_scene::on_exit() {
@@ -206,6 +222,40 @@ void play_scene::draw() {
     }
 
     play_renderer::draw_world_background();
+
+    // MV script layer (2D, behind notes)
+    if (mv_runtime_ && mv_runtime_->is_loaded()) {
+        mv::context_input mv_input;
+        mv_input.current_ms = get_visual_ms();
+        mv_input.song_length_ms = state_.song_end_ms;
+
+        int current_tick = state_.timing_engine.ms_to_tick(state_.current_ms);
+        mv_input.bpm = state_.timing_engine.get_bpm_at(current_tick);
+
+        double beat_duration_ms = 60000.0 / mv_input.bpm;
+        if (beat_duration_ms > 0) {
+            double ms_in_beat = std::fmod(state_.current_ms, beat_duration_ms);
+            if (ms_in_beat < 0) ms_in_beat += beat_duration_ms;
+            mv_input.beat_phase = static_cast<float>(ms_in_beat / beat_duration_ms);
+            mv_input.beat_number = static_cast<int>(state_.current_ms / beat_duration_ms);
+        }
+
+        mv_input.combo = state_.combo_display;
+        mv_input.key_count = state_.key_count;
+        if (state_.chart_data.has_value()) {
+            mv_input.total_notes = static_cast<int>(state_.chart_data->notes.size());
+        }
+        mv_input.screen_w = static_cast<float>(kScreenWidth);
+        mv_input.screen_h = static_cast<float>(kScreenHeight);
+
+        auto scene_opt = mv_runtime_->tick(mv_input);
+        if (scene_opt.has_value()) {
+            virtual_screen::begin();
+            mv::render_scene(*scene_opt);
+            virtual_screen::end();
+            virtual_screen::draw_to_screen(true);
+        }
+    }
 
     const Camera3D camera = make_play_camera();
     float lane_start_z = 0.0f;

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -34,6 +34,17 @@ constexpr float kJudgeLineWorldZ = 12.0f;
 constexpr float kMaxGroundDistance = 1000.0f;
 constexpr float kMvSpectrumClampMax = 2.0f;
 
+int sample_mv_waveform_index(const std::vector<float>& waveform, double current_ms, double song_length_ms) {
+    if (waveform.empty() || song_length_ms <= 0.0) {
+        return 0;
+    }
+
+    const double progress = std::clamp(current_ms / song_length_ms, 0.0, 1.0);
+    const std::size_t last = waveform.size() - 1;
+    return static_cast<int>(std::clamp<std::size_t>(
+        static_cast<std::size_t>(progress * static_cast<double>(last)), 0, last));
+}
+
 std::vector<float> build_mv_spectrum() {
     std::array<float, 128> fft = {};
     if (!audio_manager::instance().get_bgm_fft256(fft)) {
@@ -47,6 +58,15 @@ std::vector<float> build_mv_spectrum() {
         spectrum.push_back(std::clamp(shaped, 0.0f, kMvSpectrumClampMax));
     }
     return spectrum;
+}
+
+std::vector<float> build_mv_oscilloscope() {
+    std::array<float, 256> pcm = {};
+    if (!audio_manager::instance().get_bgm_oscilloscope256(pcm)) {
+        return {};
+    }
+
+    return {pcm.begin(), pcm.end()};
 }
 
 Vector3 build_camera_forward(float camera_angle_degrees) {
@@ -273,6 +293,14 @@ void play_scene::draw() {
         mv_input.combo = state_.combo_display;
         mv_input.key_count = state_.key_count;
         mv_input.spectrum = build_mv_spectrum();
+        std::vector<float> oscilloscope = build_mv_oscilloscope();
+        mv_input.oscilloscope = &oscilloscope;
+        mv_input.waveform = &state_.mv_waveform;
+        mv_input.waveform_index =
+            sample_mv_waveform_index(state_.mv_waveform, mv_input.current_ms, mv_input.song_length_ms);
+        if (!state_.mv_waveform.empty()) {
+            mv_input.level = state_.mv_waveform[static_cast<std::size_t>(mv_input.waveform_index)];
+        }
         if (state_.chart_data.has_value()) {
             mv_input.total_notes = static_cast<int>(state_.chart_data->notes.size());
         }

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -32,6 +32,7 @@ constexpr float kCameraHeight = 42.0f;
 constexpr float kCameraFovY = 42.0f;
 constexpr float kJudgeLineWorldZ = 12.0f;
 constexpr float kMaxGroundDistance = 1000.0f;
+constexpr float kMvSpectrumClampMax = 2.0f;
 
 std::vector<float> build_mv_spectrum() {
     std::array<float, 128> fft = {};
@@ -43,7 +44,7 @@ std::vector<float> build_mv_spectrum() {
     spectrum.reserve(fft.size());
     for (float sample : fft) {
         const float shaped = std::sqrt(std::max(0.0f, sample)) * 8.0f;
-        spectrum.push_back(std::clamp(shaped, 0.0f, 1.0f));
+        spectrum.push_back(std::clamp(shaped, 0.0f, kMvSpectrumClampMax));
     }
     return spectrum;
 }

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 #include <memory>
 #include <optional>
+#include <array>
 
 #include "audio_manager.h"
 #include "core/app_paths.h"
@@ -31,6 +32,21 @@ constexpr float kCameraHeight = 42.0f;
 constexpr float kCameraFovY = 42.0f;
 constexpr float kJudgeLineWorldZ = 12.0f;
 constexpr float kMaxGroundDistance = 1000.0f;
+
+std::vector<float> build_mv_spectrum() {
+    std::array<float, 128> fft = {};
+    if (!audio_manager::instance().get_bgm_fft256(fft)) {
+        return {};
+    }
+
+    std::vector<float> spectrum;
+    spectrum.reserve(fft.size());
+    for (float sample : fft) {
+        const float shaped = std::sqrt(std::max(0.0f, sample)) * 8.0f;
+        spectrum.push_back(std::clamp(shaped, 0.0f, 1.0f));
+    }
+    return spectrum;
+}
 
 Vector3 build_camera_forward(float camera_angle_degrees) {
     const float angle_rad = std::clamp(camera_angle_degrees, 5.0f, 90.0f) * DEG2RAD;
@@ -85,12 +101,23 @@ void play_scene::on_enter() {
     // Try to load MV script for this song
     if (state_.song_data.has_value()) {
         auto script_file = app_paths::script_path(state_.song_data->meta.song_id);
+        TraceLog(LOG_INFO, "MV: looking for script at %s", script_file.string().c_str());
         if (std::filesystem::exists(script_file)) {
             mv_runtime_ = std::make_unique<mv::mv_runtime>();
             if (!mv_runtime_->load_file(script_file.string())) {
-                mv_runtime_.reset(); // failed to compile, ignore
+                TraceLog(LOG_WARNING, "MV: compile failed");
+                for (const auto& e : mv_runtime_->last_errors()) {
+                    TraceLog(LOG_WARNING, "MV:   L%d: %s (%s)", e.line, e.message.c_str(), e.phase.c_str());
+                }
+                mv_runtime_.reset();
+            } else {
+                TraceLog(LOG_INFO, "MV: script loaded OK");
             }
+        } else {
+            TraceLog(LOG_INFO, "MV: script file not found");
         }
+    } else {
+        TraceLog(LOG_INFO, "MV: no song_data, skipping script load");
     }
 }
 
@@ -244,6 +271,7 @@ void play_scene::draw() {
 
         mv_input.combo = state_.combo_display;
         mv_input.key_count = state_.key_count;
+        mv_input.spectrum = build_mv_spectrum();
         if (state_.chart_data.has_value()) {
             mv_input.total_notes = static_cast<int>(state_.chart_data->notes.size());
         }
@@ -252,10 +280,24 @@ void play_scene::draw() {
 
         auto scene_opt = mv_runtime_->tick(mv_input);
         if (scene_opt.has_value()) {
+            static int mv_log_count = 0;
+            if (mv_log_count < 3) {
+                TraceLog(LOG_INFO, "MV: tick OK, %d nodes", static_cast<int>(scene_opt->nodes.size()));
+                mv_log_count++;
+            }
             virtual_screen::begin();
             mv::render_scene(*scene_opt);
             virtual_screen::end();
             virtual_screen::draw_to_screen(true);
+        } else {
+            static int mv_fail_count = 0;
+            if (mv_fail_count < 3) {
+                TraceLog(LOG_WARNING, "MV: tick returned nullopt");
+                for (const auto& e : mv_runtime_->last_errors()) {
+                    TraceLog(LOG_WARNING, "MV:   L%d: %s (%s)", e.line, e.message.c_str(), e.phase.c_str());
+                }
+                mv_fail_count++;
+            }
         }
     }
 

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -18,6 +18,7 @@ public:
     play_scene(scene_manager& manager, song_data song, std::string chart_path, int key_count);
     play_scene(scene_manager& manager, song_data song, chart_data chart, int start_tick,
                editor_resume_state editor_resume);
+    ~play_scene() override;
 
     void on_enter() override;
     void on_exit() override;

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 #include "editor/editor_scene_types.h"
@@ -7,6 +8,8 @@
 #include "play/play_session_types.h"
 #include "raylib.h"
 #include "scene.h"
+
+namespace mv { class mv_runtime; }
 
 // プレイ画面。譜面を読み込み、ノートの描画・入力判定・スコア計算を行うメインのゲームシーン。
 class play_scene final : public scene {
@@ -31,4 +34,5 @@ private:
     play_start_request request_;
     play_session_state state_;
     play_note_draw_queue draw_queue_;
+    std::unique_ptr<mv::mv_runtime> mv_runtime_;
 };

--- a/src/scenes/song_select/song_select_navigation.cpp
+++ b/src/scenes/song_select/song_select_navigation.cpp
@@ -4,6 +4,7 @@
 #include <memory>
 
 #include "editor_scene.h"
+#include "mv_editor_scene.h"
 #include "play_scene.h"
 #include "settings_scene.h"
 #include "song_create_scene.h"
@@ -42,6 +43,10 @@ std::unique_ptr<scene> make_edit_chart_scene(scene_manager& manager, const song_
 std::unique_ptr<scene> make_play_scene(scene_manager& manager, const song_entry& song, const chart_option& chart) {
     save_last_played_selection(song.song.meta.song_id, chart.meta.chart_id);
     return std::make_unique<play_scene>(manager, song.song, chart.path, chart.meta.key_count);
+}
+
+std::unique_ptr<scene> make_mv_editor_scene(scene_manager& manager, const song_entry& song) {
+    return std::make_unique<mv_editor_scene>(manager, song.song);
 }
 
 }  // namespace song_select

--- a/src/scenes/song_select/song_select_navigation.h
+++ b/src/scenes/song_select/song_select_navigation.h
@@ -16,5 +16,6 @@ std::unique_ptr<scene> make_edit_song_scene(scene_manager& manager, const song_e
 std::unique_ptr<scene> make_new_chart_scene(scene_manager& manager, const song_entry& song, int difficulty_index);
 std::unique_ptr<scene> make_edit_chart_scene(scene_manager& manager, const song_entry& song, const chart_option& chart);
 std::unique_ptr<scene> make_play_scene(scene_manager& manager, const song_entry& song, const chart_option& chart);
+std::unique_ptr<scene> make_mv_editor_scene(scene_manager& manager, const song_entry& song);
 
 }  // namespace song_select

--- a/src/scenes/song_select/song_select_overlay_view.cpp
+++ b/src/scenes/song_select/song_select_overlay_view.cpp
@@ -1,7 +1,9 @@
 #include "song_select/song_select_overlay_view.h"
 
+#include <filesystem>
 #include <vector>
 
+#include "core/app_paths.h"
 #include "song_select/song_select_layout.h"
 #include "theme.h"
 #include "ui_draw.h"
@@ -38,11 +40,20 @@ context_menu_command draw_context_menu(const state& state) {
                                        state.songs[state.context_menu.song_index].song.source != content_source::official;
             const bool can_delete_song = valid_song &&
                                          state.songs[state.context_menu.song_index].song.can_delete;
+
+            const bool has_mv = valid_song &&
+                std::filesystem::exists(app_paths::script_path(
+                    state.songs[state.context_menu.song_index].song.meta.song_id));
+
             entries = {
                 {{"EDIT META", can_edit_song}, context_menu_command::edit_song},
                 {{"NEW CHART", can_add_chart_to_song}, context_menu_command::new_chart},
                 {{"EXPORT SONG", can_export_song}, context_menu_command::export_song},
-                {{"DELETE SONG", can_delete_song}, context_menu_command::request_delete_song}
+                {{"DELETE SONG", can_delete_song}, context_menu_command::request_delete_song},
+                {{"NEW MV", valid_song && !has_mv}, context_menu_command::new_mv},
+                {{"EDIT MV", has_mv}, context_menu_command::edit_mv},
+                {{"EXPORT MV", has_mv}, context_menu_command::export_mv},
+                {{"DELETE MV", has_mv}, context_menu_command::delete_mv},
             };
 
             break;

--- a/src/scenes/song_select/song_select_overlay_view.h
+++ b/src/scenes/song_select/song_select_overlay_view.h
@@ -17,6 +17,10 @@ enum class context_menu_command {
     edit_chart,
     export_chart,
     request_delete_chart,
+    new_mv,
+    edit_mv,
+    delete_mv,
+    export_mv,
     close_menu,
 };
 

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -41,6 +41,7 @@ enum class pending_confirmation_action {
     none,
     delete_song,
     delete_chart,
+    delete_mv,
     overwrite_song_import,
     overwrite_chart_import,
 };

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -3,8 +3,10 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <filesystem>
 #include <utility>
 
+#include "core/app_paths.h"
 #include "file_dialog.h"
 #include "player_note_offsets.h"
 #include "raylib.h"
@@ -312,7 +314,7 @@ bool song_select_scene::handle_song_list_pointer(Vector2 mouse, bool left_presse
         }
         song_select::open_song_context_menu(
             state_, hit->song_index,
-            song_select::layout::make_context_menu_rect(mouse, 4));
+            song_select::layout::make_context_menu_rect(mouse, 8));
         return true;
     }
 
@@ -422,6 +424,45 @@ void song_select_scene::apply_context_menu_command(song_select::context_menu_com
             state_.context_menu.song_index, state_.context_menu.chart_index);
         song_select::close_context_menu(state_);
         return;
+    case song_select::context_menu_command::new_mv:
+    case song_select::context_menu_command::edit_mv:
+        if (state_.context_menu.song_index >= 0 &&
+            state_.context_menu.song_index < static_cast<int>(state_.songs.size())) {
+            const auto& song = state_.songs[static_cast<size_t>(state_.context_menu.song_index)];
+            song_select::close_context_menu(state_);
+            manager_.change_scene(song_select::make_mv_editor_scene(manager_, song));
+        }
+        return;
+    case song_select::context_menu_command::delete_mv:
+        song_select::open_confirmation_dialog(
+            state_, song_select::pending_confirmation_action::delete_mv,
+            "Delete MV Script",
+            "Are you sure you want to delete this MV script?",
+            "This action cannot be undone.",
+            "DELETE",
+            state_.context_menu.song_index);
+        song_select::close_context_menu(state_);
+        return;
+    case song_select::context_menu_command::export_mv:
+        if (state_.context_menu.song_index >= 0 &&
+            state_.context_menu.song_index < static_cast<int>(state_.songs.size())) {
+            const auto& song = state_.songs[static_cast<size_t>(state_.context_menu.song_index)];
+            song_select::close_context_menu(state_);
+            const auto src = app_paths::script_path(song.song.meta.song_id);
+            if (std::filesystem::exists(src)) {
+                const std::string dest = file_dialog::save_mv_script_file(song.song.meta.song_id + ".rmv");
+                if (!dest.empty()) {
+                    std::error_code ec;
+                    std::filesystem::copy_file(src, dest, std::filesystem::copy_options::overwrite_existing, ec);
+                    if (ec) {
+                        song_select::queue_status_message(state_, "Failed to export MV script.", true);
+                    } else {
+                        song_select::queue_status_message(state_, "MV script exported.", false);
+                    }
+                }
+            }
+        }
+        return;
     }
 }
 
@@ -438,6 +479,21 @@ void song_select_scene::apply_confirmation_command(song_select::confirmation_com
         state_.confirmation_dialog = {};
         return;
     case song_select::confirmation_command::confirm:
+        if (state_.confirmation_dialog.action == song_select::pending_confirmation_action::delete_mv) {
+            const int si = state_.confirmation_dialog.song_index;
+            state_.confirmation_dialog = {};
+            if (si >= 0 && si < static_cast<int>(state_.songs.size())) {
+                const auto& song_id = state_.songs[static_cast<size_t>(si)].song.meta.song_id;
+                std::error_code ec;
+                std::filesystem::remove(app_paths::script_path(song_id), ec);
+                if (ec) {
+                    song_select::queue_status_message(state_, "Failed to delete MV script.", true);
+                } else {
+                    song_select::queue_status_message(state_, "MV script deleted.", false);
+                }
+            }
+            return;
+        }
         if (state_.confirmation_dialog.action == song_select::pending_confirmation_action::delete_song) {
             preview_controller_.stop();
             apply_delete_result(song_select::delete_song(state_, state_.confirmation_dialog.song_index));

--- a/src/scenes/theme.h
+++ b/src/scenes/theme.h
@@ -56,6 +56,7 @@ struct ui_theme {
 
     // --- プレイ画面 ゲーム要素 ---
     Color lane;
+    Color lane_pressed;
     Color lane_wire;
     Color judge_line;
     Color judge_line_glow;
@@ -129,21 +130,22 @@ inline constexpr ui_theme kLightTheme = {
     .scrollbar_thumb = {172, 178, 188, 255},
     // hud
     .hud_score = {230, 232, 238, 255},
-    .hud_time = {214, 218, 228, 255},
+    .hud_time = {236, 239, 246, 255},
     .hud_fps = {160, 166, 178, 255},
     .hud_health_label = {230, 232, 238, 255},
     .hud_health_bg = {235, 238, 242, 255},
     .hud_health_border = {230, 232, 238, 255},
-    .hud_combo = {214, 218, 228, 255},
-    .hud_combo_label = {209, 214, 224, 255},
+    .hud_combo = {236, 239, 246, 255},
+    .hud_combo_label = {230, 234, 242, 255},
     .hud_failure_text = {244, 246, 250, 255},
     // game elements
-    .lane = {164, 168, 176, 255},
+    .lane = {208, 212, 220, 255},
+    .lane_pressed = {176, 180, 190, 255},
     .lane_wire = {120, 130, 148, 180},
     .judge_line = {124, 58, 237, 120},
     .judge_line_glow = {196, 181, 253, 210},
-    .note_color = {233, 238, 244, 255},
-    .note_outline = {120, 128, 138, 255},
+    .note_color = {240, 242, 255, 255},
+    .note_outline = {120, 128, 138, 0},
     .pause_overlay = {3, 6, 10, 150},
     .pause_panel = {248, 249, 251, 245},
     .editor_grid_snap = {216, 220, 228, 42},
@@ -219,11 +221,12 @@ inline constexpr ui_theme kDarkTheme = {
     .hud_failure_text = {220, 222, 228, 255},
     // game elements
     .lane = {60, 64, 72, 255},
+    .lane_pressed = {42, 44, 52, 255},
     .lane_wire = {80, 90, 108, 180},
     .judge_line = {158, 100, 255, 135},
     .judge_line_glow = {210, 190, 255, 210},
     .note_color = {200, 208, 220, 255},
-    .note_outline = {160, 168, 178, 255},
+    .note_outline = {160, 168, 178, 0},
     .pause_overlay = {0, 0, 0, 180},
     .pause_panel = {32, 34, 38, 245},
     .editor_grid_snap = {52, 56, 64, 80},

--- a/src/tests/mv_api_smoke.cpp
+++ b/src/tests/mv_api_smoke.cpp
@@ -59,6 +59,12 @@ TEST(test_build_context) {
     input.key_count = 7;
     input.total_notes = 500;
     input.spectrum = {0.1f, 0.5f, 0.9f};
+    const std::vector<float> waveform = {0.2f, 0.4f, 0.8f, 0.3f};
+    const std::vector<float> oscilloscope = {-0.5f, 0.0f, 0.5f};
+    input.waveform = &waveform;
+    input.oscilloscope = &oscilloscope;
+    input.level = 0.8f;
+    input.waveform_index = 2;
 
     auto ctx = mv::build_context(input);
     ASSERT(ctx != nullptr);
@@ -83,6 +89,18 @@ TEST(test_build_context) {
     auto spec_val = audio->get_attr("spectrum");
     auto spec = std::get<std::shared_ptr<mv::mv_list>>(spec_val);
     ASSERT(spec->elements.size() == 3);
+
+    auto waveform_val = audio->get_attr("waveform");
+    auto waveform_list = std::get<std::shared_ptr<mv::mv_list>>(waveform_val);
+    ASSERT(waveform_list->elements.size() == 4);
+    ASSERT(std::get<double>(audio->get_attr("waveform_size")) == 4.0);
+    ASSERT(std::abs(std::get<double>(audio->get_attr("level")) - 0.8) < 0.0001);
+    ASSERT(std::get<double>(audio->get_attr("waveform_index")) == 2.0);
+
+    auto osc_val = audio->get_attr("oscilloscope");
+    auto osc = std::get<std::shared_ptr<mv::mv_list>>(osc_val);
+    ASSERT(osc->elements.size() == 3);
+    ASSERT(std::get<double>(audio->get_attr("oscilloscope_size")) == 3.0);
 }
 
 // ---- Builtins in sandbox ----
@@ -241,6 +259,56 @@ def draw(ctx):
     ASSERT(std::abs(rect->y - 75.0f) < 0.01f);
 }
 
+TEST(test_ctx_audio_waveform_access_in_draw) {
+    const char* src = R"(
+def draw(ctx):
+    x = ctx.audio.level * 100
+    y = ctx.audio.waveform[ctx.audio.waveform_index] * 100
+    Rect(x=x, y=y, w=20, h=20, fill="#ffffff")
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    const std::vector<float> waveform = {0.1f, 0.25f, 0.75f};
+    mv::context_input input;
+    input.waveform = &waveform;
+    input.level = 0.75f;
+    input.waveform_index = 2;
+
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* rect = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    ASSERT(rect != nullptr);
+    ASSERT(std::abs(rect->x - 75.0f) < 0.01f);
+    ASSERT(std::abs(rect->y - 75.0f) < 0.01f);
+}
+
+TEST(test_ctx_audio_oscilloscope_access_in_draw) {
+    const char* src = R"(
+def draw(ctx):
+    x = (ctx.audio.oscilloscope[0] + 1) * 50
+    y = (ctx.audio.oscilloscope[2] + 1) * 50
+    w = ctx.audio.oscilloscope_size * 10
+    Rect(x=x, y=y, w=w, h=20, fill="#ffffff")
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    const std::vector<float> oscilloscope = {-0.5f, 0.0f, 0.25f};
+    mv::context_input input;
+    input.oscilloscope = &oscilloscope;
+
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* rect = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    ASSERT(rect != nullptr);
+    ASSERT(std::abs(rect->x - 25.0f) < 0.01f);
+    ASSERT(std::abs(rect->y - 62.5f) < 0.01f);
+    ASSERT(std::abs(rect->w - 30.0f) < 0.01f);
+}
+
 TEST(test_imperative_draw_without_return) {
     const char* src = R"(
 def draw(ctx):
@@ -266,6 +334,15 @@ TEST(test_unknown_function_fails_compile) {
     const char* src = R"(
 def draw(ctx):
     totally_not_real(123)
+)";
+    mv::mv_runtime rt;
+    ASSERT(!rt.load_source(src));
+}
+
+TEST(test_unknown_variable_fails_compile) {
+    const char* src = R"(
+def draw(ctx):
+    a.get()
 )";
     mv::mv_runtime rt;
     ASSERT(!rt.load_source(src));
@@ -479,8 +556,11 @@ int main() {
     RUN(test_polyline_node_construction);
     RUN(test_list_append_method_builds_polyline_points);
     RUN(test_ctx_access_in_draw);
+    RUN(test_ctx_audio_waveform_access_in_draw);
+    RUN(test_ctx_audio_oscilloscope_access_in_draw);
     RUN(test_imperative_draw_without_return);
     RUN(test_unknown_function_fails_compile);
+    RUN(test_unknown_variable_fails_compile);
     RUN(test_imperative_progress_bar_draw);
     RUN(test_legacy_beat_grid_and_spectrum_bar_scene);
     RUN(test_manual_spectrum_scene_from_primitives);

--- a/src/tests/mv_api_smoke.cpp
+++ b/src/tests/mv_api_smoke.cpp
@@ -174,6 +174,49 @@ def draw(ctx):
     ASSERT(txt->font_size == 24);
 }
 
+TEST(test_polyline_node_construction) {
+    const char* src = R"(
+def draw(ctx):
+    pts = [Point(x=0, y=0), Point(x=50, y=25), Point(x=100, y=0)]
+    Polyline(points=pts, stroke="#22ddaa", thickness=3.0, opacity=0.5)
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* poly = std::get_if<mv::polyline_node>(&scene->nodes[0]);
+    ASSERT(poly != nullptr);
+    ASSERT(poly->points.size() == 3);
+    ASSERT(std::abs(poly->points[1].y - 25.0f) < 0.01f);
+    ASSERT(std::abs(poly->thickness - 3.0f) < 0.01f);
+}
+
+TEST(test_list_append_method_builds_polyline_points) {
+    const char* src = R"(
+def draw(ctx):
+    pts = []
+    pts.append(Point(x=0, y=0))
+    pts.append(Point(x=25, y=50))
+    pts.append(Point(x=50, y=0))
+    Polyline(points=pts, stroke="#22ddaa", thickness=2.0, opacity=0.5)
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* poly = std::get_if<mv::polyline_node>(&scene->nodes[0]);
+    ASSERT(poly != nullptr);
+    ASSERT(poly->points.size() == 3);
+    ASSERT(std::abs(poly->points[1].x - 25.0f) < 0.01f);
+    ASSERT(std::abs(poly->points[1].y - 50.0f) < 0.01f);
+}
+
 TEST(test_ctx_access_in_draw) {
     const char* src = R"(
 def draw(ctx):
@@ -198,7 +241,74 @@ def draw(ctx):
     ASSERT(std::abs(rect->y - 75.0f) < 0.01f);
 }
 
-TEST(test_beat_grid_and_spectrum_bar_scene) {
+TEST(test_imperative_draw_without_return) {
+    const char* src = R"(
+def draw(ctx):
+    Background(fill="#0a0a1a")
+    Circle(cx=640, cy=360, radius=80, fill="#00ccff", opacity=0.8)
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 2);
+    ASSERT(std::holds_alternative<mv::background_node>(scene->nodes[0]));
+    ASSERT(std::holds_alternative<mv::circle_node>(scene->nodes[1]));
+
+    auto* circle = std::get_if<mv::circle_node>(&scene->nodes[1]);
+    ASSERT(circle != nullptr);
+    ASSERT(std::abs(circle->radius - 80.0f) < 0.01f);
+}
+
+TEST(test_unknown_function_fails_compile) {
+    const char* src = R"(
+def draw(ctx):
+    totally_not_real(123)
+)";
+    mv::mv_runtime rt;
+    ASSERT(!rt.load_source(src));
+}
+
+TEST(test_imperative_progress_bar_draw) {
+    const char* src = R"(
+def draw(ctx):
+    bar_w = ctx.screen.w - 100
+    filled = bar_w * ctx.time.progress
+
+    Rect(x=50, y=680, w=bar_w, h=6, fill="#333333")
+    Rect(x=50, y=680, w=filled, h=6, fill="#00ff88")
+
+    pct = str(int(ctx.time.progress * 100)) + "%"
+    Text(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    input.current_ms = 60000.0;
+    input.song_length_ms = 120000.0;
+    input.screen_w = 1280.0f;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 3);
+    ASSERT(std::holds_alternative<mv::rect_node>(scene->nodes[0]));
+    ASSERT(std::holds_alternative<mv::rect_node>(scene->nodes[1]));
+    ASSERT(std::holds_alternative<mv::text_node>(scene->nodes[2]));
+
+    auto* bg_bar = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    auto* fill_bar = std::get_if<mv::rect_node>(&scene->nodes[1]);
+    auto* pct = std::get_if<mv::text_node>(&scene->nodes[2]);
+    ASSERT(bg_bar != nullptr);
+    ASSERT(fill_bar != nullptr);
+    ASSERT(pct != nullptr);
+    ASSERT(std::abs(bg_bar->w - 1180.0f) < 0.01f);
+    ASSERT(std::abs(fill_bar->w - 590.0f) < 0.01f);
+    ASSERT(pct->text == "50%");
+}
+
+TEST(test_legacy_beat_grid_and_spectrum_bar_scene) {
     const char* src = R"(
 def draw(ctx):
     bg = Background(fill="#0b0f18")
@@ -239,6 +349,38 @@ def draw(ctx):
 
     std::error_code ec;
     std::filesystem::remove(temp_path, ec);
+}
+
+TEST(test_manual_spectrum_scene_from_primitives) {
+    const char* src = R"(
+def draw(ctx):
+    Background(fill="#0b0f18")
+
+    count = min(len(ctx.audio.spectrum), 4)
+    if count > 0:
+        bar_w = 200 / count
+        for i in range(count):
+            amp = ctx.audio.spectrum[i]
+            h = 100 * amp
+            Rect(x=100 + i * bar_w, y=200 - h, w=bar_w - 2, h=h, fill="#64c8ff", opacity=0.7)
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    input.spectrum = {0.1f, 0.3f, 0.6f, 0.9f, 1.0f};
+
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 5);
+    ASSERT(std::holds_alternative<mv::background_node>(scene->nodes[0]));
+
+    auto* bar0 = std::get_if<mv::rect_node>(&scene->nodes[1]);
+    auto* bar3 = std::get_if<mv::rect_node>(&scene->nodes[4]);
+    ASSERT(bar0 != nullptr);
+    ASSERT(bar3 != nullptr);
+    ASSERT(std::abs(bar0->h - 10.0f) < 0.01f);
+    ASSERT(std::abs(bar3->h - 90.0f) < 0.01f);
 }
 
 // ---- Validator ----
@@ -334,8 +476,14 @@ int main() {
     RUN(test_builtins_scene_construction);
     RUN(test_builtins_rgb_color);
     RUN(test_builtins_multiple_node_types);
+    RUN(test_polyline_node_construction);
+    RUN(test_list_append_method_builds_polyline_points);
     RUN(test_ctx_access_in_draw);
-    RUN(test_beat_grid_and_spectrum_bar_scene);
+    RUN(test_imperative_draw_without_return);
+    RUN(test_unknown_function_fails_compile);
+    RUN(test_imperative_progress_bar_draw);
+    RUN(test_legacy_beat_grid_and_spectrum_bar_scene);
+    RUN(test_manual_spectrum_scene_from_primitives);
     RUN(test_validator_truncates_nodes);
     RUN(test_validator_sanitizes_nan);
     RUN(test_scene_clear_color);

--- a/src/tests/mv_api_smoke.cpp
+++ b/src/tests/mv_api_smoke.cpp
@@ -1,6 +1,8 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
+#include <filesystem>
+#include <fstream>
 #include <string>
 #include <vector>
 
@@ -196,6 +198,49 @@ def draw(ctx):
     ASSERT(std::abs(rect->y - 75.0f) < 0.01f);
 }
 
+TEST(test_beat_grid_and_spectrum_bar_scene) {
+    const char* src = R"(
+def draw(ctx):
+    bg = Background(fill="#0b0f18")
+    spec = SpectrumBar(x=140, y=520, w=1000, h=180, bar_count=48, fill="#64c8ff", opacity=0.7)
+    grid = BeatGrid(stroke="#ffffff1e", thickness=1.0, beat_phase=ctx.time.beat_phase, opacity=0.4)
+    return Scene([bg, grid, spec])
+)";
+
+    const std::filesystem::path temp_path =
+        std::filesystem::temp_directory_path() / "raythm_mv_api_beat_grid_test.rmv";
+    {
+        std::ofstream ofs(temp_path);
+        ofs << src;
+    }
+
+    mv::mv_runtime rt;
+    ASSERT(rt.load_file(temp_path.string()));
+
+    mv::context_input input;
+    input.beat_phase = 0.25f;
+    input.spectrum = {0.1f, 0.3f, 0.6f};
+
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 3);
+    ASSERT(std::holds_alternative<mv::background_node>(scene->nodes[0]));
+    ASSERT(std::holds_alternative<mv::beat_grid_node>(scene->nodes[1]));
+    ASSERT(std::holds_alternative<mv::spectrum_bar_node>(scene->nodes[2]));
+
+    auto* grid = std::get_if<mv::beat_grid_node>(&scene->nodes[1]);
+    ASSERT(grid != nullptr);
+    ASSERT(std::abs(grid->beat_phase - 0.25f) < 0.01f);
+
+    auto* spec = std::get_if<mv::spectrum_bar_node>(&scene->nodes[2]);
+    ASSERT(spec != nullptr);
+    ASSERT(spec->spectrum.size() == 3);
+    ASSERT(std::abs(spec->spectrum[1] - 0.3f) < 0.01f);
+
+    std::error_code ec;
+    std::filesystem::remove(temp_path, ec);
+}
+
 // ---- Validator ----
 
 TEST(test_validator_truncates_nodes) {
@@ -290,6 +335,7 @@ int main() {
     RUN(test_builtins_rgb_color);
     RUN(test_builtins_multiple_node_types);
     RUN(test_ctx_access_in_draw);
+    RUN(test_beat_grid_and_spectrum_bar_scene);
     RUN(test_validator_truncates_nodes);
     RUN(test_validator_sanitizes_nan);
     RUN(test_scene_clear_color);

--- a/src/tests/mv_api_smoke.cpp
+++ b/src/tests/mv_api_smoke.cpp
@@ -1,0 +1,301 @@
+#include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <string>
+#include <vector>
+
+#include "mv/api/mv_builtins.h"
+#include "mv/api/mv_context.h"
+#include "mv/api/mv_scene.h"
+#include "mv/render/mv_validator.h"
+#include "mv/mv_runtime.h"
+
+static int tests_passed = 0;
+static int tests_failed = 0;
+
+#define TEST(name) static void name()
+#define RUN(name) do { \
+    std::printf("  %-40s", #name); \
+    try { name(); std::printf("PASS\n"); tests_passed++; } \
+    catch (...) { std::printf("FAIL\n"); tests_failed++; } \
+} while(0)
+#define ASSERT(cond) do { if (!(cond)) { std::printf("FAIL: %s line %d\n", #cond, __LINE__); throw 1; } } while(0)
+
+// ---- Color parsing ----
+
+TEST(test_parse_color_hex6) {
+    auto c = mv::parse_color("#ff8040");
+    ASSERT(c.r == 255);
+    ASSERT(c.g == 128);
+    ASSERT(c.b == 64);
+    ASSERT(c.a == 255);
+}
+
+TEST(test_parse_color_hex8) {
+    auto c = mv::parse_color("#ff804080");
+    ASSERT(c.r == 255);
+    ASSERT(c.g == 128);
+    ASSERT(c.b == 64);
+    ASSERT(c.a == 128);
+}
+
+TEST(test_parse_color_invalid) {
+    auto c = mv::parse_color("not-a-color");
+    ASSERT(c.r == 255 && c.g == 255 && c.b == 255 && c.a == 255);
+}
+
+// ---- Context builder ----
+
+TEST(test_build_context) {
+    mv::context_input input;
+    input.current_ms = 5000;
+    input.song_length_ms = 120000;
+    input.bpm = 140.0f;
+    input.beat_number = 10;
+    input.beat_phase = 0.5f;
+    input.combo = 42;
+    input.key_count = 7;
+    input.total_notes = 500;
+    input.spectrum = {0.1f, 0.5f, 0.9f};
+
+    auto ctx = mv::build_context(input);
+    ASSERT(ctx != nullptr);
+    ASSERT(ctx->type_name == "ctx");
+
+    // Check ctx.time
+    auto time_val = ctx->get_attr("time");
+    auto time = std::get<std::shared_ptr<mv::mv_object>>(time_val);
+    ASSERT(std::get<double>(time->get_attr("ms")) == 5000.0);
+    ASSERT(std::get<double>(time->get_attr("bpm")) == 140.0);
+    ASSERT(std::get<double>(time->get_attr("beat")) == 10.0);
+
+    // Check ctx.chart
+    auto chart_val = ctx->get_attr("chart");
+    auto chart = std::get<std::shared_ptr<mv::mv_object>>(chart_val);
+    ASSERT(std::get<double>(chart->get_attr("combo")) == 42.0);
+    ASSERT(std::get<double>(chart->get_attr("key_count")) == 7.0);
+
+    // Check ctx.audio.spectrum
+    auto audio_val = ctx->get_attr("audio");
+    auto audio = std::get<std::shared_ptr<mv::mv_object>>(audio_val);
+    auto spec_val = audio->get_attr("spectrum");
+    auto spec = std::get<std::shared_ptr<mv::mv_list>>(spec_val);
+    ASSERT(spec->elements.size() == 3);
+}
+
+// ---- Builtins in sandbox ----
+
+TEST(test_builtins_math) {
+    const char* src = R"(
+def draw(ctx):
+    x = sin(0)
+    y = cos(0)
+    z = clamp(5, 0, 3)
+    w = lerp(0, 10, 0.5)
+    return [x, y, z, w]
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+    mv::context_input input;
+    // tick will fail because draw returns a list not a Scene, but compilation succeeds
+    ASSERT(rt.is_loaded());
+}
+
+TEST(test_builtins_scene_construction) {
+    const char* src = R"(
+def draw(ctx):
+    r = Rect(x=10, y=20, w=100, h=50, fill="#ff0000")
+    nodes = [r]
+    return Scene(nodes)
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* rect = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    ASSERT(rect != nullptr);
+    ASSERT(rect->x == 10.0f);
+    ASSERT(rect->y == 20.0f);
+    ASSERT(rect->w == 100.0f);
+    ASSERT(rect->fill.r == 255);
+    ASSERT(rect->fill.g == 0);
+}
+
+TEST(test_builtins_rgb_color) {
+    const char* src = R"(
+def draw(ctx):
+    c = rgb(100, 200, 50)
+    r = Rect(x=0, y=0, w=10, h=10, fill=c)
+    return Scene([r])
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* rect = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    ASSERT(rect != nullptr);
+    ASSERT(rect->fill.r == 100);
+    ASSERT(rect->fill.g == 200);
+    ASSERT(rect->fill.b == 50);
+}
+
+TEST(test_builtins_multiple_node_types) {
+    const char* src = R"(
+def draw(ctx):
+    bg = Background(fill="#111111")
+    line = Line(x1=0, y1=0, x2=100, y2=100, thickness=3)
+    txt = Text(text="hello", x=50, y=50, font_size=24)
+    circ = Circle(cx=200, cy=200, radius=30)
+    return Scene([bg, line, txt, circ])
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 4);
+
+    ASSERT(std::holds_alternative<mv::background_node>(scene->nodes[0]));
+    ASSERT(std::holds_alternative<mv::line_node>(scene->nodes[1]));
+    ASSERT(std::holds_alternative<mv::text_node>(scene->nodes[2]));
+    ASSERT(std::holds_alternative<mv::circle_node>(scene->nodes[3]));
+
+    auto* txt = std::get_if<mv::text_node>(&scene->nodes[2]);
+    ASSERT(txt->text == "hello");
+    ASSERT(txt->font_size == 24);
+}
+
+TEST(test_ctx_access_in_draw) {
+    const char* src = R"(
+def draw(ctx):
+    bpm = ctx.time.bpm
+    beat = ctx.time.beat_phase
+    r = Rect(x=bpm, y=beat * 100, w=50, h=50)
+    return Scene([r])
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    input.bpm = 180.0f;
+    input.beat_phase = 0.75f;
+
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 1);
+    auto* rect = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    ASSERT(rect != nullptr);
+    ASSERT(rect->x == 180.0f);
+    ASSERT(std::abs(rect->y - 75.0f) < 0.01f);
+}
+
+// ---- Validator ----
+
+TEST(test_validator_truncates_nodes) {
+    mv::scene sc;
+    for (int i = 0; i < 600; i++) {
+        sc.nodes.push_back(mv::rect_node{});
+    }
+    mv::validation_limits limits;
+    limits.max_nodes = 100;
+    auto result = mv::validate_scene(sc, limits);
+    ASSERT(sc.nodes.size() == 100);
+    ASSERT(!result.warnings.empty());
+}
+
+TEST(test_validator_sanitizes_nan) {
+    mv::scene sc;
+    mv::rect_node r;
+    r.x = std::numeric_limits<float>::quiet_NaN();
+    r.w = -10.0f;
+    sc.nodes.push_back(r);
+
+    mv::validate_scene(sc);
+    auto* rect = std::get_if<mv::rect_node>(&sc.nodes[0]);
+    ASSERT(rect->x == 0.0f); // NaN → 0
+    ASSERT(rect->w == 0.0f); // negative width → 0
+}
+
+// ---- Scene clear_color ----
+
+TEST(test_scene_clear_color) {
+    const char* src = R"(
+def draw(ctx):
+    return Scene([], clear_color="#1a2b3c")
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->clear_color.r == 0x1a);
+    ASSERT(scene->clear_color.g == 0x2b);
+    ASSERT(scene->clear_color.b == 0x3c);
+}
+
+// ---- Runtime: missing draw ----
+
+TEST(test_runtime_no_draw_function) {
+    const char* src = R"(
+x = 42
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(!scene.has_value()); // no draw function → no scene
+}
+
+// ---- Range + for loop with nodes ----
+
+TEST(test_for_loop_builds_nodes) {
+    const char* src = R"(
+def draw(ctx):
+    nodes = []
+    for i in range(5):
+        nodes = nodes + [Rect(x=i * 10, y=0, w=10, h=10)]
+    return Scene(nodes)
+)";
+    mv::mv_runtime rt;
+    ASSERT(rt.load_source(src));
+
+    mv::context_input input;
+    auto scene = rt.tick(input);
+    ASSERT(scene.has_value());
+    ASSERT(scene->nodes.size() == 5);
+    auto* r0 = std::get_if<mv::rect_node>(&scene->nodes[0]);
+    auto* r4 = std::get_if<mv::rect_node>(&scene->nodes[4]);
+    ASSERT(r0 && r0->x == 0.0f);
+    ASSERT(r4 && r4->x == 40.0f);
+}
+
+int main() {
+    std::printf("=== MV API Smoke Tests ===\n");
+
+    RUN(test_parse_color_hex6);
+    RUN(test_parse_color_hex8);
+    RUN(test_parse_color_invalid);
+    RUN(test_build_context);
+    RUN(test_builtins_math);
+    RUN(test_builtins_scene_construction);
+    RUN(test_builtins_rgb_color);
+    RUN(test_builtins_multiple_node_types);
+    RUN(test_ctx_access_in_draw);
+    RUN(test_validator_truncates_nodes);
+    RUN(test_validator_sanitizes_nan);
+    RUN(test_scene_clear_color);
+    RUN(test_runtime_no_draw_function);
+    RUN(test_for_loop_builds_nodes);
+
+    std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
+    return tests_failed > 0 ? 1 : 0;
+}

--- a/src/tests/mv_lang_smoke.cpp
+++ b/src/tests/mv_lang_smoke.cpp
@@ -1,0 +1,378 @@
+#include <cstdlib>
+#include <cmath>
+#include <iostream>
+#include <string>
+
+#include "mv/lang/mv_sandbox.h"
+
+namespace {
+
+int tests_passed = 0;
+int tests_failed = 0;
+
+void check(bool condition, const std::string& name) {
+    if (condition) {
+        tests_passed++;
+    } else {
+        tests_failed++;
+        std::cerr << "FAIL: " << name << '\n';
+    }
+}
+
+void test_basic_arithmetic() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    return 1 + 2
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "basic arithmetic: compilation + execution");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 3.0, "basic arithmetic: 1 + 2 == 3");
+    }
+}
+
+void test_complex_arithmetic() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    x = 10.0
+    y = 3.0
+    return (x * y + 5) / 7.0
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "complex arithmetic: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && std::abs(*val - 5.0) < 0.001, "complex arithmetic: (10*3+5)/7 == 5");
+    }
+}
+
+void test_private_function() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def pulse(x):
+    if x < 0.0:
+        return 0.0
+    result = 1.0 - x
+    if result < 0.0:
+        return 0.0
+    return result
+
+def draw(ctx):
+    return pulse(0.3)
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "private function: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && std::abs(*val - 0.7) < 0.001, "private function: pulse(0.3) == 0.7");
+    }
+}
+
+void test_ctx_object() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    // Build ctx with nested objects
+    auto time_obj = std::make_shared<mv::mv_object>();
+    time_obj->type_name = "time";
+    time_obj->set_attr("beat", 2.5);
+    time_obj->set_attr("now", 1000.0);
+
+    auto ctx = std::make_shared<mv::mv_object>();
+    ctx->type_name = "ctx";
+    ctx->set_attr("time", mv::mv_value{time_obj});
+
+    std::string source = R"(
+def draw(ctx):
+    return ctx.time.beat * 2.0
+)";
+
+    auto result = sb.run_draw(source, mv::mv_value{ctx});
+    check(result.success, "ctx object: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 5.0, "ctx object: beat * 2 == 5");
+    }
+}
+
+void test_forbidden_import() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+import os
+
+def draw(ctx):
+    return 0
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(!result.success, "forbidden import: rejected");
+    check(!result.errors.empty(), "forbidden import: has error message");
+}
+
+void test_forbidden_class() {
+    mv::sandbox sb;
+
+    std::string source = R"(
+class Foo:
+    pass
+
+def draw(ctx):
+    return 0
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(!result.success, "forbidden class: rejected");
+}
+
+void test_step_limit() {
+    mv::sandbox sb;
+    sb.set_limits({100, 32, 1024, 1024}); // Very low step limit
+
+    std::string source = R"(
+def draw(ctx):
+    x = 0
+    for i in [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]:
+        x += i
+    return x
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(!result.success, "step limit: exceeded");
+    if (!result.errors.empty()) {
+        bool found_limit_msg = false;
+        for (auto& err : result.errors) {
+            if (err.message.find("step limit") != std::string::npos) {
+                found_limit_msg = true;
+            }
+        }
+        check(found_limit_msg, "step limit: correct error message");
+    }
+}
+
+void test_native_function() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    sb.register_native("max", [](const std::vector<mv::mv_value>& args) -> mv::mv_value {
+        if (args.size() == 2) {
+            auto* a = std::get_if<double>(&args[0]);
+            auto* b = std::get_if<double>(&args[1]);
+            if (a && b) return std::max(*a, *b);
+        }
+        return std::monostate{};
+    });
+
+    std::string source = R"(
+def draw(ctx):
+    return max(3.0, 7.0)
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "native function: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 7.0, "native function: max(3, 7) == 7");
+    }
+}
+
+void test_native_kwargs_function() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    sb.register_native_kwargs("Scene", [](
+        const std::vector<mv::mv_value>& pos_args,
+        const std::vector<std::pair<std::string, mv::mv_value>>& kwargs
+    ) -> mv::mv_value {
+        auto obj = std::make_shared<mv::mv_object>();
+        obj->type_name = "Scene";
+        for (auto& [k, v] : kwargs) {
+            obj->set_attr(k, v);
+        }
+        return obj;
+    });
+
+    std::string source = R"(
+def draw(ctx):
+    return Scene(clear="#0b0f18", nodes=[])
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "kwargs function: success");
+    if (result.success) {
+        auto* obj = std::get_if<std::shared_ptr<mv::mv_object>>(&result.value);
+        check(obj != nullptr && *obj != nullptr, "kwargs function: returns object");
+        if (obj && *obj) {
+            auto clear_val = (*obj)->get_attr("clear");
+            auto* clear_str = std::get_if<std::string>(&clear_val);
+            check(clear_str != nullptr && *clear_str == "#0b0f18", "kwargs function: clear attr");
+        }
+    }
+}
+
+void test_if_elif_else() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    x = 5
+    if x > 10:
+        return 1
+    elif x > 3:
+        return 2
+    else:
+        return 3
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "if/elif/else: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 2.0, "if/elif/else: correct branch");
+    }
+}
+
+void test_for_loop() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    total = 0
+    for x in [10, 20, 30]:
+        total += x
+    return total
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "for loop: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 60.0, "for loop: sum == 60");
+    }
+}
+
+void test_string_concat() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    return "hello" + " " + "world"
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "string concat: success");
+    if (result.success) {
+        auto* val = std::get_if<std::string>(&result.value);
+        check(val != nullptr && *val == "hello world", "string concat: result");
+    }
+}
+
+void test_bool_logic() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    a = True
+    b = False
+    if a and not b:
+        return 1
+    return 0
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "bool logic: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 1.0, "bool logic: True and not False == True");
+    }
+}
+
+void test_list_operations() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    items = [10, 20, 30]
+    return items[1]
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(result.success, "list ops: success");
+    if (result.success) {
+        auto* val = std::get_if<double>(&result.value);
+        check(val != nullptr && *val == 20.0, "list ops: items[1] == 20");
+    }
+}
+
+void test_division_by_zero() {
+    mv::sandbox sb;
+    sb.set_limits({1000000, 32, 1024, 1024});
+
+    std::string source = R"(
+def draw(ctx):
+    return 1.0 / 0.0
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(!result.success, "division by zero: detected");
+}
+
+void test_missing_draw() {
+    mv::sandbox sb;
+
+    std::string source = R"(
+def helper():
+    return 42
+)";
+
+    auto result = sb.run_draw(source, std::monostate{});
+    check(!result.success, "missing draw: error");
+}
+
+} // anonymous namespace
+
+int main() {
+    test_basic_arithmetic();
+    test_complex_arithmetic();
+    test_private_function();
+    test_ctx_object();
+    test_forbidden_import();
+    test_forbidden_class();
+    test_step_limit();
+    test_native_function();
+    test_native_kwargs_function();
+    test_if_elif_else();
+    test_for_loop();
+    test_string_concat();
+    test_bool_logic();
+    test_list_operations();
+    test_division_by_zero();
+    test_missing_draw();
+
+    std::cout << tests_passed << " passed, " << tests_failed << " failed\n";
+
+    if (tests_failed > 0) {
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "mv_lang smoke test passed\n";
+    return EXIT_SUCCESS;
+}

--- a/src/ui/ui_text_editor.cpp
+++ b/src/ui/ui_text_editor.cpp
@@ -14,8 +14,47 @@ namespace {
 
 constexpr float kGutterPadding = 6.0f;
 constexpr float kScrollbarWidth = 8.0f;
-constexpr float kLineSpacing = 4.0f;
 constexpr float kTextPadLeft = 4.0f;
+
+float measure_text_width(const std::string& text, const text_editor_style& style) {
+    if (text.empty()) {
+        return 0.0f;
+    }
+    return MeasureTextEx(GetFontDefault(), text.c_str(),
+                         static_cast<float>(style.font_size), style.letter_spacing).x;
+}
+
+float measure_line_prefix_width(const std::string& line, int prefix_len,
+                                const text_editor_style& style, text_editor_highlighter highlighter) {
+    const int clamped_prefix_len = std::clamp(prefix_len, 0, static_cast<int>(line.size()));
+    if (clamped_prefix_len == 0) {
+        return 0.0f;
+    }
+    return measure_text_width(line.substr(0, static_cast<size_t>(clamped_prefix_len)), style);
+}
+
+void draw_line_text(const std::string& line, float x, float y,
+                    const text_editor_style& style, text_editor_highlighter highlighter) {
+    if (line.empty()) {
+        return;
+    }
+    if (highlighter == nullptr) {
+        DrawTextEx(GetFontDefault(), line.c_str(), {x, y},
+                   static_cast<float>(style.font_size), style.letter_spacing, g_theme->text);
+        return;
+    }
+
+    const std::vector<text_editor_span> spans = highlighter(line);
+    int consumed = 0;
+    for (const auto& span : spans) {
+        if (!span.text.empty()) {
+            const float cursor_x = x + measure_line_prefix_width(line, consumed, style, nullptr);
+            DrawTextEx(GetFontDefault(), span.text.c_str(), {cursor_x, y},
+                       static_cast<float>(style.font_size), style.letter_spacing, span.color);
+            consumed += static_cast<int>(span.text.size());
+        }
+    }
+}
 
 void clamp_cursor(text_editor_state& state) {
     state.cursor_line = std::clamp(state.cursor_line, 0,
@@ -38,6 +77,68 @@ void ensure_cursor_visible(text_editor_state& state, float line_height, float vi
 
 bool key_action(int key) {
     return IsKeyPressed(key) || IsKeyPressedRepeat(key);
+}
+
+bool insert_text_at_cursor(text_editor_state& state, const std::string& text, int max_lines) {
+    if (text.empty()) {
+        return false;
+    }
+
+    std::string normalized;
+    normalized.reserve(text.size());
+    for (size_t i = 0; i < text.size(); ++i) {
+        if (text[i] == '\r') {
+            if (i + 1 < text.size() && text[i + 1] == '\n') {
+                continue;
+            }
+            normalized += '\n';
+        } else {
+            normalized += text[i];
+        }
+    }
+
+    if (normalized.empty()) {
+        return false;
+    }
+
+    std::vector<std::string> chunks;
+    std::istringstream stream(normalized);
+    std::string part;
+    while (std::getline(stream, part)) {
+        chunks.push_back(part);
+    }
+    if (!normalized.empty() && normalized.back() == '\n') {
+        chunks.push_back("");
+    }
+    if (chunks.empty()) {
+        chunks.push_back("");
+    }
+
+    auto& line = state.lines[state.cursor_line];
+    const std::string before = line.substr(0, state.cursor_col);
+    const std::string after = line.substr(state.cursor_col);
+
+    if (chunks.size() == 1) {
+        line = before + chunks[0] + after;
+        state.cursor_col += static_cast<int>(chunks[0].size());
+        return true;
+    }
+
+    const int available_new_lines = std::max(0, max_lines - static_cast<int>(state.lines.size()));
+    const int allowed_extra_lines = std::min(static_cast<int>(chunks.size()) - 1, available_new_lines);
+
+    line = before + chunks[0];
+    int insert_at = state.cursor_line + 1;
+    for (int i = 1; i <= allowed_extra_lines; ++i) {
+        state.lines.insert(state.lines.begin() + insert_at, chunks[static_cast<size_t>(i)]);
+        ++insert_at;
+    }
+
+    const int last_chunk_index = allowed_extra_lines;
+    state.lines[state.cursor_line + allowed_extra_lines] += after;
+    state.cursor_line += allowed_extra_lines;
+    state.cursor_col = static_cast<int>(chunks[static_cast<size_t>(last_chunk_index)].size());
+    return true;
 }
 
 } // anonymous namespace
@@ -67,10 +168,12 @@ void text_editor_set_text(text_editor_state& state, const std::string& text) {
 }
 
 text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
-                                    int font_size, int max_lines) {
+                                    int max_lines,
+                                    const text_editor_style& style,
+                                    text_editor_highlighter highlighter) {
     text_editor_result result;
-    const float line_height = font_size + kLineSpacing;
-    const float gutter_width = static_cast<float>(MeasureText("000", font_size)) + kGutterPadding * 2;
+    const float line_height = static_cast<float>(style.font_size) + style.line_spacing;
+    const float gutter_width = measure_text_width("000", style) + kGutterPadding * 2;
 
     const Rectangle scrollbar_rect = {
         rect.x + rect.width - kScrollbarWidth, rect.y, kScrollbarWidth, rect.height
@@ -106,15 +209,15 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         // Approximate column from x position
         float rel_x = mouse.x - text_rect.x - kTextPadLeft;
         if (rel_x <= 0) {
-            state.cursor_col = 0;
-        } else {
-            const std::string& line = state.lines[clicked_line];
-            int col = 0;
-            for (int c = 0; c <= static_cast<int>(line.size()); c++) {
-                float w = static_cast<float>(MeasureText(line.substr(0, c).c_str(), font_size));
-                if (w > rel_x) break;
-                col = c;
-            }
+                state.cursor_col = 0;
+            } else {
+                const std::string& line = state.lines[clicked_line];
+                int col = 0;
+                for (int c = 0; c <= static_cast<int>(line.size()); c++) {
+                    float w = measure_line_prefix_width(line, c, style, highlighter);
+                    if (w > rel_x) break;
+                    col = c;
+                }
             state.cursor_col = col;
         }
         state.last_input_time = GetTime();
@@ -133,6 +236,26 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                 state.last_input_time = GetTime();
             }
             codepoint = GetCharPressed();
+        }
+
+        // Paste
+        if ((IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)) && IsKeyPressed(KEY_V)) {
+            const char* clipboard = GetClipboardText();
+            if (clipboard != nullptr && clipboard[0] != '\0') {
+                if (insert_text_at_cursor(state, clipboard, max_lines)) {
+                    result.changed = true;
+                    state.last_input_time = GetTime();
+                }
+            }
+        }
+        if (IsKeyPressed(KEY_INSERT) && (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT))) {
+            const char* clipboard = GetClipboardText();
+            if (clipboard != nullptr && clipboard[0] != '\0') {
+                if (insert_text_at_cursor(state, clipboard, max_lines)) {
+                    result.changed = true;
+                    state.last_input_time = GetTime();
+                }
+            }
         }
 
         // Tab → 2 spaces
@@ -280,17 +403,17 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
 
         // Line number (right-aligned in gutter)
         const char* line_num_text = TextFormat("%3d", i + 1);
-        float num_width = static_cast<float>(MeasureText(line_num_text, font_size));
+        float num_width = measure_text_width(line_num_text, style);
         float num_x = rect.x + gutter_width - kGutterPadding - num_width;
-        DrawText(line_num_text, static_cast<int>(num_x), static_cast<int>(y + kLineSpacing * 0.5f),
-                 font_size, g_theme->text_dim);
+        DrawText(line_num_text, static_cast<int>(num_x), static_cast<int>(y + style.line_spacing * 0.5f),
+                 style.font_size, g_theme->text_dim);
 
         // Line text
         if (!state.lines[i].empty()) {
-            DrawText(state.lines[i].c_str(),
-                     static_cast<int>(text_rect.x + kTextPadLeft),
-                     static_cast<int>(y + kLineSpacing * 0.5f),
-                     font_size, g_theme->text);
+            draw_line_text(state.lines[i],
+                           text_rect.x + kTextPadLeft,
+                           y + style.line_spacing * 0.5f,
+                           style, highlighter);
         }
     }
 
@@ -300,9 +423,8 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         bool show_cursor = (std::fmod(blink, 1.0) < 0.6) || blink < 0.4;
         if (show_cursor) {
             const std::string& cur_line = state.lines[state.cursor_line];
-            std::string before_cursor = cur_line.substr(0, state.cursor_col);
             float cursor_x = text_rect.x + kTextPadLeft +
-                            static_cast<float>(MeasureText(before_cursor.c_str(), font_size));
+                            measure_line_prefix_width(cur_line, state.cursor_col, style, highlighter);
             float cursor_y = rect.y + state.cursor_line * line_height - state.scroll_offset;
             DrawRectangle(static_cast<int>(cursor_x), static_cast<int>(cursor_y + 1),
                           2, static_cast<int>(line_height - 2), g_theme->text);

--- a/src/ui/ui_text_editor.cpp
+++ b/src/ui/ui_text_editor.cpp
@@ -1,0 +1,321 @@
+#include "ui_text_editor.h"
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+
+#include "ui_coord.h"
+#include "ui_layout.h"
+#include "virtual_screen.h"
+
+namespace ui {
+
+namespace {
+
+constexpr float kGutterPadding = 6.0f;
+constexpr float kScrollbarWidth = 8.0f;
+constexpr float kLineSpacing = 4.0f;
+constexpr float kTextPadLeft = 4.0f;
+
+void clamp_cursor(text_editor_state& state) {
+    state.cursor_line = std::clamp(state.cursor_line, 0,
+                                   std::max(0, static_cast<int>(state.lines.size()) - 1));
+    int line_len = static_cast<int>(state.lines[state.cursor_line].size());
+    state.cursor_col = std::clamp(state.cursor_col, 0, line_len);
+}
+
+void ensure_cursor_visible(text_editor_state& state, float line_height, float view_height) {
+    float cursor_y = state.cursor_line * line_height;
+    if (cursor_y < state.scroll_offset) {
+        state.scroll_offset = cursor_y;
+    }
+    if (cursor_y + line_height > state.scroll_offset + view_height) {
+        state.scroll_offset = cursor_y + line_height - view_height;
+    }
+    float max_scroll = std::max(0.0f, static_cast<float>(state.lines.size()) * line_height - view_height);
+    state.scroll_offset = std::clamp(state.scroll_offset, 0.0f, max_scroll);
+}
+
+bool key_action(int key) {
+    return IsKeyPressed(key) || IsKeyPressedRepeat(key);
+}
+
+} // anonymous namespace
+
+std::string text_editor_get_text(const text_editor_state& state) {
+    std::string result;
+    for (size_t i = 0; i < state.lines.size(); i++) {
+        if (i > 0) result += '\n';
+        result += state.lines[i];
+    }
+    return result;
+}
+
+void text_editor_set_text(text_editor_state& state, const std::string& text) {
+    state.lines.clear();
+    std::istringstream stream(text);
+    std::string line;
+    while (std::getline(stream, line)) {
+        // Remove trailing \r if present
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        state.lines.push_back(std::move(line));
+    }
+    if (state.lines.empty()) state.lines.push_back("");
+    state.cursor_line = 0;
+    state.cursor_col = 0;
+    state.scroll_offset = 0.0f;
+}
+
+text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
+                                    int font_size, int max_lines) {
+    text_editor_result result;
+    const float line_height = font_size + kLineSpacing;
+    const float gutter_width = static_cast<float>(MeasureText("000", font_size)) + kGutterPadding * 2;
+
+    const Rectangle scrollbar_rect = {
+        rect.x + rect.width - kScrollbarWidth, rect.y, kScrollbarWidth, rect.height
+    };
+    const Rectangle gutter_rect = {rect.x, rect.y, gutter_width, rect.height};
+    const Rectangle text_rect = {
+        rect.x + gutter_width, rect.y,
+        rect.width - gutter_width - kScrollbarWidth, rect.height
+    };
+
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    const bool hovered = CheckCollisionPointRec(mouse, rect);
+
+    // Activation / deactivation
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        if (hovered) {
+            if (!state.active) {
+                state.active = true;
+                result.activated = true;
+            }
+        } else if (state.active) {
+            state.active = false;
+            result.deactivated = true;
+        }
+    }
+
+    // Click to set cursor position
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, text_rect)) {
+        int clicked_line = static_cast<int>((mouse.y - text_rect.y + state.scroll_offset) / line_height);
+        clicked_line = std::clamp(clicked_line, 0, static_cast<int>(state.lines.size()) - 1);
+        state.cursor_line = clicked_line;
+
+        // Approximate column from x position
+        float rel_x = mouse.x - text_rect.x - kTextPadLeft;
+        if (rel_x <= 0) {
+            state.cursor_col = 0;
+        } else {
+            const std::string& line = state.lines[clicked_line];
+            int col = 0;
+            for (int c = 0; c <= static_cast<int>(line.size()); c++) {
+                float w = static_cast<float>(MeasureText(line.substr(0, c).c_str(), font_size));
+                if (w > rel_x) break;
+                col = c;
+            }
+            state.cursor_col = col;
+        }
+        state.last_input_time = GetTime();
+    }
+
+    // Keyboard input
+    if (state.active) {
+        // Character input
+        int codepoint = GetCharPressed();
+        while (codepoint > 0) {
+            if (codepoint >= 32 && codepoint <= 126) {
+                auto& line = state.lines[state.cursor_line];
+                line.insert(line.begin() + state.cursor_col, static_cast<char>(codepoint));
+                state.cursor_col++;
+                result.changed = true;
+                state.last_input_time = GetTime();
+            }
+            codepoint = GetCharPressed();
+        }
+
+        // Tab → 2 spaces
+        if (IsKeyPressed(KEY_TAB)) {
+            auto& line = state.lines[state.cursor_line];
+            line.insert(state.cursor_col, "  ");
+            state.cursor_col += 2;
+            result.changed = true;
+            state.last_input_time = GetTime();
+        }
+
+        // Enter → new line
+        if (IsKeyPressed(KEY_ENTER) && static_cast<int>(state.lines.size()) < max_lines) {
+            auto& line = state.lines[state.cursor_line];
+            std::string remainder = line.substr(state.cursor_col);
+            line.erase(state.cursor_col);
+            state.lines.insert(state.lines.begin() + state.cursor_line + 1, remainder);
+            state.cursor_line++;
+            state.cursor_col = 0;
+            result.changed = true;
+            state.last_input_time = GetTime();
+        }
+
+        // Backspace
+        if (key_action(KEY_BACKSPACE)) {
+            if (state.cursor_col > 0) {
+                auto& line = state.lines[state.cursor_line];
+                line.erase(state.cursor_col - 1, 1);
+                state.cursor_col--;
+                result.changed = true;
+            } else if (state.cursor_line > 0) {
+                // Merge with previous line
+                int prev_len = static_cast<int>(state.lines[state.cursor_line - 1].size());
+                state.lines[state.cursor_line - 1] += state.lines[state.cursor_line];
+                state.lines.erase(state.lines.begin() + state.cursor_line);
+                state.cursor_line--;
+                state.cursor_col = prev_len;
+                result.changed = true;
+            }
+            state.last_input_time = GetTime();
+        }
+
+        // Delete
+        if (key_action(KEY_DELETE)) {
+            auto& line = state.lines[state.cursor_line];
+            if (state.cursor_col < static_cast<int>(line.size())) {
+                line.erase(state.cursor_col, 1);
+                result.changed = true;
+            } else if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
+                line += state.lines[state.cursor_line + 1];
+                state.lines.erase(state.lines.begin() + state.cursor_line + 1);
+                result.changed = true;
+            }
+            state.last_input_time = GetTime();
+        }
+
+        // Arrow keys
+        if (key_action(KEY_LEFT)) {
+            if (state.cursor_col > 0) {
+                state.cursor_col--;
+            } else if (state.cursor_line > 0) {
+                state.cursor_line--;
+                state.cursor_col = static_cast<int>(state.lines[state.cursor_line].size());
+            }
+            state.last_input_time = GetTime();
+        }
+        if (key_action(KEY_RIGHT)) {
+            int line_len = static_cast<int>(state.lines[state.cursor_line].size());
+            if (state.cursor_col < line_len) {
+                state.cursor_col++;
+            } else if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
+                state.cursor_line++;
+                state.cursor_col = 0;
+            }
+            state.last_input_time = GetTime();
+        }
+        if (key_action(KEY_UP)) {
+            if (state.cursor_line > 0) {
+                state.cursor_line--;
+                int line_len = static_cast<int>(state.lines[state.cursor_line].size());
+                state.cursor_col = std::min(state.cursor_col, line_len);
+            }
+            state.last_input_time = GetTime();
+        }
+        if (key_action(KEY_DOWN)) {
+            if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
+                state.cursor_line++;
+                int line_len = static_cast<int>(state.lines[state.cursor_line].size());
+                state.cursor_col = std::min(state.cursor_col, line_len);
+            }
+            state.last_input_time = GetTime();
+        }
+
+        // Home / End
+        if (IsKeyPressed(KEY_HOME)) {
+            state.cursor_col = 0;
+            state.last_input_time = GetTime();
+        }
+        if (IsKeyPressed(KEY_END)) {
+            state.cursor_col = static_cast<int>(state.lines[state.cursor_line].size());
+            state.last_input_time = GetTime();
+        }
+
+        clamp_cursor(state);
+        ensure_cursor_visible(state, line_height, rect.height);
+    }
+
+    // Mouse wheel scroll
+    if (hovered) {
+        float wheel = GetMouseWheelMove();
+        if (wheel != 0.0f) {
+            state.scroll_offset -= wheel * line_height * 3.0f;
+            float content_h = static_cast<float>(state.lines.size()) * line_height;
+            float max_scroll = std::max(0.0f, content_h - rect.height);
+            state.scroll_offset = std::clamp(state.scroll_offset, 0.0f, max_scroll);
+        }
+    }
+
+    // Scrollbar interaction
+    float content_height = static_cast<float>(state.lines.size()) * line_height;
+    auto sb = update_vertical_scrollbar(scrollbar_rect, content_height, state.scroll_offset,
+                                        state.scrollbar_dragging, state.scrollbar_drag_offset);
+    if (sb.changed) {
+        state.scroll_offset = sb.scroll_offset;
+    }
+
+    // ---- Rendering ----
+    begin_scissor_rect(rect);
+
+    // Background
+    DrawRectangleRec(rect, g_theme->section);
+    DrawRectangleLinesEx(rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
+
+    // Gutter background
+    Rectangle gutter_bg = {rect.x + 1.5f, rect.y + 1.5f, gutter_width - 1.5f, rect.height - 3.0f};
+    DrawRectangleRec(gutter_bg, with_alpha(g_theme->panel, 200));
+
+    // Visible line range
+    int first_visible = std::max(0, static_cast<int>(state.scroll_offset / line_height));
+    int last_visible = std::min(static_cast<int>(state.lines.size()) - 1,
+                                static_cast<int>((state.scroll_offset + rect.height) / line_height));
+
+    for (int i = first_visible; i <= last_visible; i++) {
+        float y = rect.y + i * line_height - state.scroll_offset;
+
+        // Line number (right-aligned in gutter)
+        const char* line_num_text = TextFormat("%3d", i + 1);
+        float num_width = static_cast<float>(MeasureText(line_num_text, font_size));
+        float num_x = rect.x + gutter_width - kGutterPadding - num_width;
+        DrawText(line_num_text, static_cast<int>(num_x), static_cast<int>(y + kLineSpacing * 0.5f),
+                 font_size, g_theme->text_dim);
+
+        // Line text
+        if (!state.lines[i].empty()) {
+            DrawText(state.lines[i].c_str(),
+                     static_cast<int>(text_rect.x + kTextPadLeft),
+                     static_cast<int>(y + kLineSpacing * 0.5f),
+                     font_size, g_theme->text);
+        }
+    }
+
+    // Cursor (blinking)
+    if (state.active) {
+        double blink = GetTime() - state.last_input_time;
+        bool show_cursor = (std::fmod(blink, 1.0) < 0.6) || blink < 0.4;
+        if (show_cursor) {
+            const std::string& cur_line = state.lines[state.cursor_line];
+            std::string before_cursor = cur_line.substr(0, state.cursor_col);
+            float cursor_x = text_rect.x + kTextPadLeft +
+                            static_cast<float>(MeasureText(before_cursor.c_str(), font_size));
+            float cursor_y = rect.y + state.cursor_line * line_height - state.scroll_offset;
+            DrawRectangle(static_cast<int>(cursor_x), static_cast<int>(cursor_y + 1),
+                          2, static_cast<int>(line_height - 2), g_theme->text);
+        }
+    }
+
+    // Scrollbar
+    draw_scrollbar(scrollbar_rect, content_height, state.scroll_offset,
+                   g_theme->scrollbar_track, g_theme->scrollbar_thumb);
+
+    EndScissorMode();
+
+    return result;
+}
+
+}  // namespace ui

--- a/src/ui/ui_text_editor.cpp
+++ b/src/ui/ui_text_editor.cpp
@@ -56,6 +56,19 @@ void draw_line_text(const std::string& line, float x, float y,
     }
 }
 
+void draw_squiggly_line(float x0, float x1, float y, Color color) {
+    constexpr float wave_width = 4.0f;
+    constexpr float wave_height = 2.0f;
+    float x = x0;
+    while (x < x1) {
+        float nx = std::min(x + wave_width * 0.5f, x1);
+        float y0 = y;
+        float y1 = y + ((static_cast<int>((x - x0) / (wave_width * 0.5f)) % 2 == 0) ? wave_height : -wave_height);
+        DrawLineEx({x, y0}, {nx, y1}, 1.5f, color);
+        x = nx;
+    }
+}
+
 void clamp_cursor(text_editor_state& state) {
     state.cursor_line = std::clamp(state.cursor_line, 0,
                                    std::max(0, static_cast<int>(state.lines.size()) - 1));
@@ -141,6 +154,74 @@ bool insert_text_at_cursor(text_editor_state& state, const std::string& text, in
     return true;
 }
 
+bool replace_range_on_line(text_editor_state& state, int line_index, int col_start, int col_end,
+                           const std::string& text) {
+    if (line_index < 0 || line_index >= static_cast<int>(state.lines.size())) {
+        return false;
+    }
+    std::string& line = state.lines[line_index];
+    const int start = std::clamp(col_start, 0, static_cast<int>(line.size()));
+    const int end = std::clamp(col_end, start, static_cast<int>(line.size()));
+    line.replace(static_cast<size_t>(start), static_cast<size_t>(end - start), text);
+    state.cursor_line = line_index;
+    state.cursor_col = start + static_cast<int>(text.size());
+    state.has_selection = false;
+    return true;
+}
+
+text_editor_cursor cursor_of(const text_editor_state& state) {
+    return {state.cursor_line, state.cursor_col};
+}
+
+std::pair<text_editor_cursor, text_editor_cursor> selection_range(const text_editor_state& state) {
+    text_editor_cursor a = state.sel_anchor;
+    text_editor_cursor b = cursor_of(state);
+    if (b < a) std::swap(a, b);
+    return {a, b};
+}
+
+std::string get_selection_text(const text_editor_state& state) {
+    if (!state.has_selection) return {};
+    auto [from, to] = selection_range(state);
+    if (from.line == to.line) {
+        return state.lines[from.line].substr(from.col, to.col - from.col);
+    }
+    std::string result = state.lines[from.line].substr(from.col) + "\n";
+    for (int i = from.line + 1; i < to.line; i++) {
+        result += state.lines[i] + "\n";
+    }
+    result += state.lines[to.line].substr(0, to.col);
+    return result;
+}
+
+void delete_selection(text_editor_state& state) {
+    if (!state.has_selection) return;
+    auto [from, to] = selection_range(state);
+    if (from.line == to.line) {
+        state.lines[from.line].erase(from.col, to.col - from.col);
+    } else {
+        std::string merged = state.lines[from.line].substr(0, from.col) +
+                             state.lines[to.line].substr(to.col);
+        state.lines.erase(state.lines.begin() + from.line, state.lines.begin() + to.line + 1);
+        state.lines.insert(state.lines.begin() + from.line, merged);
+    }
+    state.cursor_line = from.line;
+    state.cursor_col = from.col;
+    state.has_selection = false;
+    if (state.lines.empty()) state.lines.push_back("");
+}
+
+void start_selection_if_shift(text_editor_state& state, bool shift) {
+    if (shift) {
+        if (!state.has_selection) {
+            state.has_selection = true;
+            state.sel_anchor = cursor_of(state);
+        }
+    } else {
+        state.has_selection = false;
+    }
+}
+
 } // anonymous namespace
 
 std::string text_editor_get_text(const text_editor_state& state) {
@@ -170,10 +251,19 @@ void text_editor_set_text(text_editor_state& state, const std::string& text) {
 text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                                     int max_lines,
                                     const text_editor_style& style,
-                                    text_editor_highlighter highlighter) {
+                                    text_editor_highlighter highlighter,
+                                    text_editor_completer completer) {
     text_editor_result result;
+    bool should_ensure_cursor_visible = false;
     const float line_height = static_cast<float>(style.font_size) + style.line_spacing;
     const float gutter_width = measure_text_width("000", style) + kGutterPadding * 2;
+    constexpr int kMaxCompletionItems = 8;
+    constexpr float kCompletionRowHeight = 26.0f;
+    constexpr float kCompletionPadX = 8.0f;
+    constexpr float kCompletionMinWidth = 180.0f;
+    constexpr float kCompletionOffsetX = 18.0f;
+    const float completion_font_size = static_cast<float>(std::max(style.font_size - 2, 12));
+    const float completion_letter_spacing = std::max(style.letter_spacing, 1.0f);
 
     const Rectangle scrollbar_rect = {
         rect.x + rect.width - kScrollbarWidth, rect.y, kScrollbarWidth, rect.height
@@ -186,6 +276,21 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
 
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const bool hovered = CheckCollisionPointRec(mouse, rect);
+    text_editor_completion_result completion;
+    if (completer != nullptr && state.active && !state.mouse_selecting) {
+        completion = completer(state.lines, state.cursor_line, state.cursor_col);
+        if (!completion.items.empty()) {
+            if (state.completion_index < 0) {
+                state.completion_index = 0;
+            }
+            state.completion_index = std::min(state.completion_index,
+                                              static_cast<int>(completion.items.size()) - 1);
+        } else {
+            state.completion_index = 0;
+        }
+    } else {
+        state.completion_index = 0;
+    }
 
     // Activation / deactivation
     if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
@@ -200,94 +305,190 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         }
     }
 
-    // Click to set cursor position
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, text_rect)) {
-        int clicked_line = static_cast<int>((mouse.y - text_rect.y + state.scroll_offset) / line_height);
-        clicked_line = std::clamp(clicked_line, 0, static_cast<int>(state.lines.size()) - 1);
-        state.cursor_line = clicked_line;
+    // Helper: compute line/col from mouse position
+    auto mouse_to_cursor = [&](Vector2 m) -> text_editor_cursor {
+        int line = static_cast<int>((m.y - text_rect.y + state.scroll_offset) / line_height);
+        line = std::clamp(line, 0, static_cast<int>(state.lines.size()) - 1);
+        float rel_x = m.x - text_rect.x - kTextPadLeft;
+        int col = 0;
+        if (rel_x > 0) {
+            const std::string& ln = state.lines[line];
+            for (int c = 0; c <= static_cast<int>(ln.size()); c++) {
+                float w = measure_line_prefix_width(ln, c, style, highlighter);
+                if (w > rel_x) break;
+                col = c;
+            }
+        }
+        return {line, col};
+    };
 
-        // Approximate column from x position
-        float rel_x = mouse.x - text_rect.x - kTextPadLeft;
-        if (rel_x <= 0) {
-                state.cursor_col = 0;
-            } else {
-                const std::string& line = state.lines[clicked_line];
-                int col = 0;
-                for (int c = 0; c <= static_cast<int>(line.size()); c++) {
-                    float w = measure_line_prefix_width(line, c, style, highlighter);
-                    if (w > rel_x) break;
-                    col = c;
-                }
-            state.cursor_col = col;
+    // Click to set cursor position + start mouse selection
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, text_rect)) {
+        auto pos = mouse_to_cursor(mouse);
+        state.cursor_line = pos.line;
+        state.cursor_col = pos.col;
+        state.sel_anchor = pos;
+        state.has_selection = false;
+        state.mouse_selecting = true;
+        state.last_input_time = GetTime();
+        should_ensure_cursor_visible = true;
+    }
+
+    // Drag to extend selection
+    if (state.mouse_selecting && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        auto pos = mouse_to_cursor(mouse);
+        state.cursor_line = pos.line;
+        state.cursor_col = pos.col;
+        if (pos != state.sel_anchor) {
+            state.has_selection = true;
         }
         state.last_input_time = GetTime();
+        should_ensure_cursor_visible = true;
+    }
+
+    // Release mouse button ends drag
+    if (state.mouse_selecting && IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        state.mouse_selecting = false;
     }
 
     // Keyboard input
     if (state.active) {
-        // Character input
-        int codepoint = GetCharPressed();
-        while (codepoint > 0) {
-            if (codepoint >= 32 && codepoint <= 126) {
-                auto& line = state.lines[state.cursor_line];
-                line.insert(line.begin() + state.cursor_col, static_cast<char>(codepoint));
-                state.cursor_col++;
+        const bool ctrl = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
+        const bool shift = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
+        const bool has_completion = !completion.items.empty();
+        bool completion_navigation_handled = false;
+
+        auto accept_completion = [&]() -> bool {
+            if (!has_completion || state.completion_index < 0 ||
+                state.completion_index >= static_cast<int>(completion.items.size())) {
+                return false;
+            }
+            if (replace_range_on_line(state, state.cursor_line,
+                                      completion.replace_start, completion.replace_end,
+                                      completion.items[static_cast<size_t>(state.completion_index)].insert_text)) {
                 result.changed = true;
                 state.last_input_time = GetTime();
+                should_ensure_cursor_visible = true;
+                return true;
             }
-            codepoint = GetCharPressed();
+            return false;
+        };
+
+        // Select all: Ctrl+A
+        if (ctrl && IsKeyPressed(KEY_A)) {
+            state.sel_anchor = {0, 0};
+            state.cursor_line = static_cast<int>(state.lines.size()) - 1;
+            state.cursor_col = static_cast<int>(state.lines.back().size());
+            state.has_selection = true;
+            state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
 
-        // Paste
-        if ((IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL)) && IsKeyPressed(KEY_V)) {
-            const char* clipboard = GetClipboardText();
-            if (clipboard != nullptr && clipboard[0] != '\0') {
-                if (insert_text_at_cursor(state, clipboard, max_lines)) {
-                    result.changed = true;
-                    state.last_input_time = GetTime();
-                }
-            }
-        }
-        if (IsKeyPressed(KEY_INSERT) && (IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT))) {
-            const char* clipboard = GetClipboardText();
-            if (clipboard != nullptr && clipboard[0] != '\0') {
-                if (insert_text_at_cursor(state, clipboard, max_lines)) {
-                    result.changed = true;
-                    state.last_input_time = GetTime();
-                }
-            }
+        // Copy: Ctrl+C
+        if (ctrl && IsKeyPressed(KEY_C) && state.has_selection) {
+            SetClipboardText(get_selection_text(state).c_str());
         }
 
-        // Tab → 2 spaces
-        if (IsKeyPressed(KEY_TAB)) {
-            auto& line = state.lines[state.cursor_line];
-            line.insert(state.cursor_col, "  ");
-            state.cursor_col += 2;
+        // Cut: Ctrl+X
+        if (ctrl && IsKeyPressed(KEY_X) && state.has_selection) {
+            SetClipboardText(get_selection_text(state).c_str());
+            delete_selection(state);
             result.changed = true;
             state.last_input_time = GetTime();
         }
 
-        // Enter → new line
-        if (IsKeyPressed(KEY_ENTER) && static_cast<int>(state.lines.size()) < max_lines) {
-            auto& line = state.lines[state.cursor_line];
-            std::string remainder = line.substr(state.cursor_col);
-            line.erase(state.cursor_col);
-            state.lines.insert(state.lines.begin() + state.cursor_line + 1, remainder);
-            state.cursor_line++;
-            state.cursor_col = 0;
-            result.changed = true;
+        if (has_completion && IsKeyPressed(KEY_UP)) {
+            state.completion_index =
+                (state.completion_index + static_cast<int>(completion.items.size()) - 1) %
+                static_cast<int>(completion.items.size());
             state.last_input_time = GetTime();
+            completion_navigation_handled = true;
+        } else if (has_completion && IsKeyPressed(KEY_DOWN)) {
+            state.completion_index =
+                (state.completion_index + 1) % static_cast<int>(completion.items.size());
+            state.last_input_time = GetTime();
+            completion_navigation_handled = true;
+        } else if (has_completion && (IsKeyPressed(KEY_TAB) || IsKeyPressed(KEY_ENTER))) {
+            if (accept_completion()) {
+                completion = completer != nullptr
+                    ? completer(state.lines, state.cursor_line, state.cursor_col)
+                    : text_editor_completion_result{};
+            }
+        } else {
+
+            // Character input (replace selection if active)
+            int codepoint = GetCharPressed();
+            while (codepoint > 0) {
+                if (codepoint >= 32 && codepoint <= 126) {
+                    if (state.has_selection) {
+                        delete_selection(state);
+                    }
+                    auto& line = state.lines[state.cursor_line];
+                    line.insert(line.begin() + state.cursor_col, static_cast<char>(codepoint));
+                    state.cursor_col++;
+                    result.changed = true;
+                    state.last_input_time = GetTime();
+                    should_ensure_cursor_visible = true;
+                }
+                codepoint = GetCharPressed();
+            }
+
+            // Paste (replace selection if active)
+            if (ctrl && IsKeyPressed(KEY_V)) {
+                const char* clipboard = GetClipboardText();
+                if (clipboard != nullptr && clipboard[0] != '\0') {
+                    if (state.has_selection) {
+                        delete_selection(state);
+                    }
+                    if (insert_text_at_cursor(state, clipboard, max_lines)) {
+                        result.changed = true;
+                        state.last_input_time = GetTime();
+                        should_ensure_cursor_visible = true;
+                    }
+                }
+            }
+
+            // Tab → 2 spaces (replace selection if active)
+            if (IsKeyPressed(KEY_TAB)) {
+                if (state.has_selection) {
+                    delete_selection(state);
+                }
+                auto& line = state.lines[state.cursor_line];
+                line.insert(state.cursor_col, "  ");
+                state.cursor_col += 2;
+                result.changed = true;
+                state.last_input_time = GetTime();
+                should_ensure_cursor_visible = true;
+            }
+
+            // Enter → new line (replace selection if active)
+            if (IsKeyPressed(KEY_ENTER) && static_cast<int>(state.lines.size()) < max_lines) {
+                if (state.has_selection) {
+                    delete_selection(state);
+                }
+                auto& line = state.lines[state.cursor_line];
+                std::string remainder = line.substr(state.cursor_col);
+                line.erase(state.cursor_col);
+                state.lines.insert(state.lines.begin() + state.cursor_line + 1, remainder);
+                state.cursor_line++;
+                state.cursor_col = 0;
+                result.changed = true;
+                state.last_input_time = GetTime();
+                should_ensure_cursor_visible = true;
+            }
         }
 
-        // Backspace
+        // Backspace (delete selection or single char)
         if (key_action(KEY_BACKSPACE)) {
-            if (state.cursor_col > 0) {
+            if (state.has_selection) {
+                delete_selection(state);
+                result.changed = true;
+            } else if (state.cursor_col > 0) {
                 auto& line = state.lines[state.cursor_line];
                 line.erase(state.cursor_col - 1, 1);
                 state.cursor_col--;
                 result.changed = true;
             } else if (state.cursor_line > 0) {
-                // Merge with previous line
                 int prev_len = static_cast<int>(state.lines[state.cursor_line - 1].size());
                 state.lines[state.cursor_line - 1] += state.lines[state.cursor_line];
                 state.lines.erase(state.lines.begin() + state.cursor_line);
@@ -296,33 +497,44 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                 result.changed = true;
             }
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
 
-        // Delete
+        // Delete (delete selection or single char)
         if (key_action(KEY_DELETE)) {
-            auto& line = state.lines[state.cursor_line];
-            if (state.cursor_col < static_cast<int>(line.size())) {
-                line.erase(state.cursor_col, 1);
+            if (state.has_selection) {
+                delete_selection(state);
                 result.changed = true;
-            } else if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
-                line += state.lines[state.cursor_line + 1];
-                state.lines.erase(state.lines.begin() + state.cursor_line + 1);
-                result.changed = true;
+            } else {
+                auto& line = state.lines[state.cursor_line];
+                if (state.cursor_col < static_cast<int>(line.size())) {
+                    line.erase(state.cursor_col, 1);
+                    result.changed = true;
+                } else if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
+                    line += state.lines[state.cursor_line + 1];
+                    state.lines.erase(state.lines.begin() + state.cursor_line + 1);
+                    result.changed = true;
+                }
             }
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
 
-        // Arrow keys
+        // Arrow keys (with Shift for selection)
         if (key_action(KEY_LEFT)) {
+            start_selection_if_shift(state, shift);
             if (state.cursor_col > 0) {
                 state.cursor_col--;
             } else if (state.cursor_line > 0) {
                 state.cursor_line--;
                 state.cursor_col = static_cast<int>(state.lines[state.cursor_line].size());
             }
+            if (!shift) state.has_selection = false;
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
         if (key_action(KEY_RIGHT)) {
+            start_selection_if_shift(state, shift);
             int line_len = static_cast<int>(state.lines[state.cursor_line].size());
             if (state.cursor_col < line_len) {
                 state.cursor_col++;
@@ -330,37 +542,53 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                 state.cursor_line++;
                 state.cursor_col = 0;
             }
+            if (!shift) state.has_selection = false;
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
-        if (key_action(KEY_UP)) {
+        if (!completion_navigation_handled && key_action(KEY_UP)) {
+            start_selection_if_shift(state, shift);
             if (state.cursor_line > 0) {
                 state.cursor_line--;
                 int line_len = static_cast<int>(state.lines[state.cursor_line].size());
                 state.cursor_col = std::min(state.cursor_col, line_len);
             }
+            if (!shift) state.has_selection = false;
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
-        if (key_action(KEY_DOWN)) {
+        if (!completion_navigation_handled && key_action(KEY_DOWN)) {
+            start_selection_if_shift(state, shift);
             if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
                 state.cursor_line++;
                 int line_len = static_cast<int>(state.lines[state.cursor_line].size());
                 state.cursor_col = std::min(state.cursor_col, line_len);
             }
+            if (!shift) state.has_selection = false;
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
 
-        // Home / End
+        // Home / End (with Shift for selection)
         if (IsKeyPressed(KEY_HOME)) {
+            start_selection_if_shift(state, shift);
             state.cursor_col = 0;
+            if (!shift) state.has_selection = false;
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
         if (IsKeyPressed(KEY_END)) {
+            start_selection_if_shift(state, shift);
             state.cursor_col = static_cast<int>(state.lines[state.cursor_line].size());
+            if (!shift) state.has_selection = false;
             state.last_input_time = GetTime();
+            should_ensure_cursor_visible = true;
         }
 
         clamp_cursor(state);
-        ensure_cursor_visible(state, line_height, rect.height);
+        if (should_ensure_cursor_visible) {
+            ensure_cursor_visible(state, line_height, rect.height);
+        }
     }
 
     // Mouse wheel scroll
@@ -398,8 +626,35 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
     int last_visible = std::min(static_cast<int>(state.lines.size()) - 1,
                                 static_cast<int>((state.scroll_offset + rect.height) / line_height));
 
+    // Selection range (computed once for rendering)
+    text_editor_cursor sel_from = {}, sel_to = {};
+    if (state.has_selection) {
+        auto [a, b] = selection_range(state);
+        sel_from = a;
+        sel_to = b;
+    }
+
     for (int i = first_visible; i <= last_visible; i++) {
         float y = rect.y + i * line_height - state.scroll_offset;
+
+        // Selection highlight
+        if (state.has_selection && i >= sel_from.line && i <= sel_to.line) {
+            int line_len = static_cast<int>(state.lines[i].size());
+            int sel_start_col = (i == sel_from.line) ? sel_from.col : 0;
+            int sel_end_col = (i == sel_to.line) ? sel_to.col : line_len;
+            float x0 = text_rect.x + kTextPadLeft +
+                        measure_line_prefix_width(state.lines[i], sel_start_col, style, highlighter);
+            float x1 = text_rect.x + kTextPadLeft +
+                        measure_line_prefix_width(state.lines[i], sel_end_col, style, highlighter);
+            if (i != sel_to.line && sel_end_col == line_len) {
+                x1 += measure_text_width(" ", style);  // extend past line end
+            }
+            if (x1 > x0) {
+                DrawRectangle(static_cast<int>(x0), static_cast<int>(y),
+                              static_cast<int>(x1 - x0), static_cast<int>(line_height),
+                              Color{60, 120, 220, 80});
+            }
+        }
 
         // Line number (right-aligned in gutter)
         const char* line_num_text = TextFormat("%3d", i + 1);
@@ -414,6 +669,55 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                            text_rect.x + kTextPadLeft,
                            y + style.line_spacing * 0.5f,
                            style, highlighter);
+        }
+    }
+
+    // Error squiggly underlines
+    for (const auto& marker : state.error_markers) {
+        int line_idx = marker.line - 1;  // markers are 1-based
+        if (line_idx < first_visible || line_idx > last_visible) continue;
+        if (line_idx < 0 || line_idx >= static_cast<int>(state.lines.size())) continue;
+
+        float y = rect.y + line_idx * line_height - state.scroll_offset;
+        float underline_y = y + style.line_spacing * 0.5f + static_cast<float>(style.font_size) + 1.0f;
+
+        const std::string& ln = state.lines[line_idx];
+        int c0 = marker.col_start;
+        int c1 = marker.col_end;
+        // If col range is zero/invalid, underline the whole line
+        if (c0 == 0 && c1 == 0) {
+            // Find first non-space char
+            c0 = 0;
+            while (c0 < static_cast<int>(ln.size()) && (ln[c0] == ' ' || ln[c0] == '\t')) c0++;
+            c1 = static_cast<int>(ln.size());
+        }
+        if (c1 <= c0) c1 = std::max(c0 + 1, static_cast<int>(ln.size()));
+        c1 = std::min(c1, static_cast<int>(ln.size()));
+
+        float x0 = text_rect.x + kTextPadLeft + measure_line_prefix_width(ln, c0, style, highlighter);
+        float x1 = text_rect.x + kTextPadLeft + measure_line_prefix_width(ln, c1, style, highlighter);
+        if (x1 <= x0) x1 = x0 + measure_text_width("x", style);  // minimum width
+
+        draw_squiggly_line(x0, x1, underline_y, Color{255, 80, 80, 220});
+
+        // Check hover for tooltip
+        Rectangle squiggly_area = {x0, y, x1 - x0, line_height};
+        if (CheckCollisionPointRec(mouse, squiggly_area) && !marker.message.empty()) {
+            constexpr float kTooltipPad = 6.0f;
+            constexpr float kTooltipFontSize = 12.0f;
+            constexpr float kTooltipLetterSpacing = 0.0f;
+            const Vector2 tooltip_size = MeasureTextEx(GetFontDefault(), marker.message.c_str(),
+                                                       kTooltipFontSize, kTooltipLetterSpacing);
+            float tw = tooltip_size.x + kTooltipPad * 2.0f;
+            float th = tooltip_size.y + kTooltipPad * 2.0f;
+            float tx = std::min(mouse.x, rect.x + rect.width - tw - 4.0f);
+            tx = std::max(tx, rect.x + 4.0f);
+            float ty = underline_y + 4.0f;
+            DrawRectangleRounded({tx, ty, tw, th}, 0.2f, 4, Color{40, 40, 40, 230});
+            DrawRectangleRoundedLinesEx({tx, ty, tw, th}, 0.2f, 4, 1.0f, Color{255, 80, 80, 180});
+            DrawTextEx(GetFontDefault(), marker.message.c_str(),
+                       {tx + kTooltipPad, ty + kTooltipPad},
+                       kTooltipFontSize, kTooltipLetterSpacing, Color{255, 200, 200, 255});
         }
     }
 
@@ -436,6 +740,65 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                    g_theme->scrollbar_track, g_theme->scrollbar_thumb);
 
     EndScissorMode();
+
+    if (!completion.items.empty()) {
+        const std::string& cur_line = state.lines[state.cursor_line];
+        float cursor_x = text_rect.x + kTextPadLeft +
+                         measure_line_prefix_width(cur_line, state.cursor_col, style, highlighter);
+        float cursor_y = rect.y + state.cursor_line * line_height - state.scroll_offset;
+        const int visible_items = std::min(static_cast<int>(completion.items.size()), kMaxCompletionItems);
+
+        float menu_width = kCompletionMinWidth;
+        for (int i = 0; i < visible_items; ++i) {
+            menu_width = std::max(menu_width,
+                                  MeasureTextEx(GetFontDefault(),
+                                                completion.items[static_cast<size_t>(i)].label.c_str(),
+                                                completion_font_size, completion_letter_spacing).x +
+                                  kCompletionPadX * 2.0f);
+        }
+        Rectangle menu_rect = {
+            std::min(cursor_x + kCompletionOffsetX, text_rect.x + text_rect.width - menu_width - 4.0f),
+            std::min(cursor_y + line_height + 2.0f,
+                     rect.y + rect.height - visible_items * kCompletionRowHeight - 4.0f),
+            menu_width,
+            visible_items * kCompletionRowHeight
+        };
+        if (menu_rect.y < rect.y + 4.0f) {
+            menu_rect.y = rect.y + 4.0f;
+        }
+
+        DrawRectangleRec(menu_rect, with_alpha(g_theme->panel, 245));
+        DrawRectangleLinesEx(menu_rect, 1.0f, g_theme->border_light);
+
+        for (int i = 0; i < visible_items; ++i) {
+            Rectangle item_rect = {
+                menu_rect.x,
+                menu_rect.y + i * kCompletionRowHeight,
+                menu_rect.width,
+                kCompletionRowHeight
+            };
+            const bool hovered_item = CheckCollisionPointRec(mouse, item_rect);
+            const bool selected_item = i == state.completion_index;
+            DrawRectangleRec(item_rect,
+                             selected_item ? g_theme->row_selected :
+                             (hovered_item ? g_theme->row_hover : BLANK));
+            DrawTextEx(GetFontDefault(),
+                       completion.items[static_cast<size_t>(i)].label.c_str(),
+                       {item_rect.x + kCompletionPadX, item_rect.y + 4.0f},
+                       completion_font_size, completion_letter_spacing,
+                       selected_item ? g_theme->text : g_theme->text_secondary);
+
+            if (hovered_item && IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+                state.completion_index = i;
+                if (replace_range_on_line(state, state.cursor_line,
+                                          completion.replace_start, completion.replace_end,
+                                          completion.items[static_cast<size_t>(i)].insert_text)) {
+                    result.changed = true;
+                    state.last_input_time = GetTime();
+                }
+            }
+        }
+    }
 
     return result;
 }

--- a/src/ui/ui_text_editor.h
+++ b/src/ui/ui_text_editor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "raylib.h"
+#include "ui_draw.h"
+
+namespace ui {
+
+struct text_editor_state {
+    std::vector<std::string> lines = {""};
+    int cursor_line = 0;
+    int cursor_col = 0;
+    float scroll_offset = 0.0f;
+    bool active = false;
+    bool scrollbar_dragging = false;
+    float scrollbar_drag_offset = 0.0f;
+    double last_input_time = 0.0;
+};
+
+struct text_editor_result {
+    bool changed = false;
+    bool activated = false;
+    bool deactivated = false;
+};
+
+std::string text_editor_get_text(const text_editor_state& state);
+void text_editor_set_text(text_editor_state& state, const std::string& text);
+
+text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
+                                    int font_size = 14, int max_lines = 500);
+
+}  // namespace ui

--- a/src/ui/ui_text_editor.h
+++ b/src/ui/ui_text_editor.h
@@ -8,6 +8,19 @@
 
 namespace ui {
 
+struct text_editor_style {
+    int font_size = 14;
+    float line_spacing = 4.0f;
+    float letter_spacing = 0.0f;
+};
+
+struct text_editor_span {
+    std::string text;
+    Color color;
+};
+
+using text_editor_highlighter = std::vector<text_editor_span>(*)(const std::string&);
+
 struct text_editor_state {
     std::vector<std::string> lines = {""};
     int cursor_line = 0;
@@ -29,6 +42,8 @@ std::string text_editor_get_text(const text_editor_state& state);
 void text_editor_set_text(text_editor_state& state, const std::string& text);
 
 text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
-                                    int font_size = 14, int max_lines = 500);
+                                    int max_lines = 500,
+                                    const text_editor_style& style = {},
+                                    text_editor_highlighter highlighter = nullptr);
 
 }  // namespace ui

--- a/src/ui/ui_text_editor.h
+++ b/src/ui/ui_text_editor.h
@@ -21,6 +21,34 @@ struct text_editor_span {
 
 using text_editor_highlighter = std::vector<text_editor_span>(*)(const std::string&);
 
+struct text_editor_completion_item {
+    std::string label;
+    std::string insert_text;
+};
+
+struct text_editor_completion_result {
+    int replace_start = 0;
+    int replace_end = 0;
+    std::vector<text_editor_completion_item> items;
+};
+
+using text_editor_completer = text_editor_completion_result(*)(const std::vector<std::string>&, int, int);
+
+struct text_editor_cursor {
+    int line = 0;
+    int col = 0;
+    bool operator==(const text_editor_cursor& o) const { return line == o.line && col == o.col; }
+    bool operator!=(const text_editor_cursor& o) const { return !(*this == o); }
+    bool operator<(const text_editor_cursor& o) const { return line < o.line || (line == o.line && col < o.col); }
+};
+
+struct text_editor_error_marker {
+    int line = 0;         // 1-based line number
+    int col_start = 0;    // 0-based column (0 = whole line)
+    int col_end = 0;      // 0-based end column (0 = whole line)
+    std::string message;
+};
+
 struct text_editor_state {
     std::vector<std::string> lines = {""};
     int cursor_line = 0;
@@ -30,6 +58,13 @@ struct text_editor_state {
     bool scrollbar_dragging = false;
     float scrollbar_drag_offset = 0.0f;
     double last_input_time = 0.0;
+    // Selection
+    bool has_selection = false;
+    text_editor_cursor sel_anchor = {};
+    bool mouse_selecting = false;
+    // Inline error markers (set externally)
+    std::vector<text_editor_error_marker> error_markers;
+    int completion_index = 0;
 };
 
 struct text_editor_result {
@@ -44,6 +79,7 @@ void text_editor_set_text(text_editor_state& state, const std::string& text);
 text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                                     int max_lines = 500,
                                     const text_editor_style& style = {},
-                                    text_editor_highlighter highlighter = nullptr);
+                                    text_editor_highlighter highlighter = nullptr,
+                                    text_editor_completer completer = nullptr);
 
 }  // namespace ui


### PR DESCRIPTION
## 概要
- MV Script を命令的に書けるようにし、primitives ベースの表現へ寄せました
- MV エディタに構文ハイライト、補完、波線エラー、貼り付け、選択などの編集支援を追加しました
- MV ランタイムを軽量化し、play 側から spectrum / waveform / oscilloscope を参照できるようにしました
- MV サンプルと smoke test を更新しました

## 確認
- cmake --build cmake-build-codex --target raythm mv_api_smoke -j 2
- & 'C:\Users\rento\CLionProjects\raythm\cmake-build-codex\mv_api_smoke.exe'
  - 24 passed, 0 failed

## 補足
- Lane Width 保存修正などの別件差分はこの PR には含めていません
- Dev 向けの MV 実装まとめ PR です