### PR TITLE
コードエディタにカラーピッカーを追加

### DIFF
--- a/documents/mv-script-samples.rmv
+++ b/documents/mv-script-samples.rmv
@@ -5,32 +5,30 @@
 # MV Script Reference
 # --------------------
 # - draw(ctx) function is called every frame.
-# - You can write in two styles:
-#     1. Imperative: just place node constructors in draw(ctx)
-#     2. Explicit: return Scene([...])
-# - In imperative style, node calls are collected automatically.
-# - SpectrumBar / BeatGrid / PulseRing are deprecated compatibility helpers.
-#   They still work, but new scripts should prefer composing effects from primitives.
+# - Write draw(ctx) in imperative style:
+#     just place node constructors in draw(ctx)
+# - Node calls are collected automatically.
 # - ctx fields:
 #     ctx.time.ms, ctx.time.sec, ctx.time.length_ms,
 #     ctx.time.bpm, ctx.time.beat, ctx.time.beat_phase,
 #     ctx.time.progress
-#     ctx.audio.spectrum, ctx.audio.spectrum_size,
-#     ctx.audio.waveform, ctx.audio.waveform_size,
-#     ctx.audio.waveform_index, ctx.audio.level,
-#     ctx.audio.oscilloscope, ctx.audio.oscilloscope_size
+#     ctx.audio.analysis.level,
+#     ctx.audio.buffers.spectrum, ctx.audio.buffers.spectrum_size,
+#     ctx.audio.buffers.waveform, ctx.audio.buffers.waveform_size,
+#     ctx.audio.buffers.waveform_index,
+#     ctx.audio.buffers.oscilloscope, ctx.audio.buffers.oscilloscope_size
 #     ctx.chart.total_notes, ctx.chart.combo,
 #     ctx.chart.accuracy, ctx.chart.key_count
 #     ctx.screen.w, ctx.screen.h
 #
 # - Node types:
 #     Point(x, y)
-#     Background(fill, opacity)
-#     Rect(x, y, w, h, fill, rotation, opacity)
-#     Circle(cx, cy, radius, fill, opacity)
-#     Line(x1, y1, x2, y2, stroke, thickness, opacity)
-#     Polyline(points, stroke, thickness, opacity)
-#     Text(text, x, y, font_size, fill, opacity)
+#     DrawBackground(fill, opacity)
+#     DrawRect(x, y, w, h, fill, rotation, opacity)
+#     DrawCircle(cx, cy, radius, fill, opacity)
+#     DrawLine(x1, y1, x2, y2, stroke, thickness, opacity)
+#     DrawPolyline(points, stroke, thickness, opacity)
+#     DrawText(text, x, y, font_size, fill, opacity)
 #
 # - Built-in functions:
 #     sin, cos, abs, floor, ceil, sqrt, min, max,
@@ -43,7 +41,7 @@
 # Sample 1: Minimal (what "New MV" generates)
 # --------------------------------------------------
 def draw(ctx):
-  return Scene([])
+  DrawBackground(fill="#0a0a1a")
 
 
 # --------------------------------------------------
@@ -54,30 +52,30 @@ def draw(ctx):
   p = ctx.time.beat_phase
   r = lerp(120.0, 60.0, p)
   a = lerp(0.9, 0.2, p)
-  Background(fill="#0a0a1a")
-  Circle(cx=640, cy=360, radius=r, fill="#00ccff", opacity=a)
+  DrawBackground(fill="#0a0a1a")
+  DrawCircle(cx=640, cy=360, radius=r, fill="#00ccff", opacity=a)
 
 
 # --------------------------------------------------
 # Sample 3: Spectrum + Grid
-#   Audio-reactive bars built from Rect + Line.
+#   Audio-reactive bars built from DrawRect + DrawLine.
 # --------------------------------------------------
 def draw(ctx):
-  Background(fill="#0b0f18")
+  DrawBackground(fill="#0b0f18")
 
   spacing = 40
   offset = ctx.time.beat_phase * spacing
   for i in range(19):
     y = i * spacing - offset
-    Line(x1=0, y1=y, x2=1280, y2=y, stroke="#ffffff1e", thickness=1.0, opacity=0.4)
+    DrawLine(x1=0, y1=y, x2=1280, y2=y, stroke="#ffffff1e", thickness=1.0, opacity=0.4)
 
-  count = min(len(ctx.audio.spectrum), 48)
+  count = min(len(ctx.audio.buffers.spectrum), 48)
   if count > 0:
     bar_w = 1000 / count
     for i in range(count):
-      amp = ctx.audio.spectrum[i]
+      amp = ctx.audio.buffers.spectrum[i]
       h = 180 * amp
-      Rect(x=140 + i * bar_w, y=700 - h, w=bar_w - 2, h=h, fill="#64c8ff", opacity=0.7)
+      DrawRect(x=140 + i * bar_w, y=700 - h, w=bar_w - 2, h=h, fill="#64c8ff", opacity=0.7)
 
 
 # --------------------------------------------------
@@ -85,7 +83,7 @@ def draw(ctx):
 #   Circles that fan out when combo is high.
 # --------------------------------------------------
 def draw(ctx):
-  Background(fill="#111111")
+  DrawBackground(fill="#111111")
 
   combo = ctx.chart.combo
   count = min(int(combo / 10), 12)
@@ -96,9 +94,9 @@ def draw(ctx):
     cx = 640 + cos(angle) * dist
     cy = 360 + sin(angle) * dist
     r = 10.0 + sin(ctx.time.ms * 0.005 + i) * 6.0
-    Circle(cx=cx, cy=cy, radius=r, fill="#ff6644", opacity=0.8)
+    DrawCircle(cx=cx, cy=cy, radius=r, fill="#ff6644", opacity=0.8)
 
-  Text(text=str(int(combo)), x=600, y=330, font_size=48, fill="#ffffff")
+  DrawText(text=str(int(combo)), x=600, y=330, font_size=48, fill="#ffffff")
 
 
 # --------------------------------------------------
@@ -108,11 +106,11 @@ def draw(ctx):
 def draw(ctx):
   bar_w = ctx.screen.w - 100
   filled = bar_w * ctx.time.progress
-  Rect(x=50, y=680, w=bar_w, h=6, fill="#333333")
-  Rect(x=50, y=680, w=filled, h=6, fill="#00ff88")
+  DrawRect(x=50, y=680, w=bar_w, h=6, fill="#333333")
+  DrawRect(x=50, y=680, w=filled, h=6, fill="#00ff88")
 
   pct = str(int(ctx.time.progress * 100)) + "%"
-  Text(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")
+  DrawText(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")
 
 
 # --------------------------------------------------
@@ -120,7 +118,7 @@ def draw(ctx):
 #   Four squares rotating around the center.
 # --------------------------------------------------
 def draw(ctx):
-  Background(fill="#1a0a2e")
+  DrawBackground(fill="#1a0a2e")
 
   t = ctx.time.sec
   for i in range(4):
@@ -131,30 +129,30 @@ def draw(ctx):
     color = "#ff44cc"
     if i % 2 == 0:
       color = "#44ccff"
-    Rect(x=cx - 40, y=cy - 40, w=80, h=80, fill=color, rotation=rot, opacity=0.75)
+    DrawRect(x=cx - 40, y=cy - 40, w=80, h=80, fill=color, rotation=rot, opacity=0.75)
 
 
 # --------------------------------------------------
 # Sample 7: Manual Pulse Rings + Spectrum
-#   Rings and bars composed from Circle + Rect.
+#   Rings and bars composed from DrawCircle + DrawRect.
 # --------------------------------------------------
 def draw(ctx):
-  Background(fill="#050510")
+  DrawBackground(fill="#050510")
   bp = ctx.time.beat_phase
 
   for i in range(3):
     r = 100 + i * 80
     a = lerp(0.6, 0.1, bp) - i * 0.15
     a = max(a, 0.0)
-    Circle(cx=640, cy=360, radius=r + bp * 30, fill="#8866ff", opacity=a * 0.15)
+    DrawCircle(cx=640, cy=360, radius=r + bp * 30, fill="#8866ff", opacity=a * 0.15)
 
-  count = min(len(ctx.audio.spectrum), 32)
+  count = min(len(ctx.audio.buffers.spectrum), 32)
   if count > 0:
     bar_w = 600 / count
     for i in range(count):
-      amp = ctx.audio.spectrum[i]
+      amp = ctx.audio.buffers.spectrum[i]
       h = 120 * amp
-      Rect(x=340 + i * bar_w, y=680 - h, w=bar_w - 2, h=h, fill="#8866ff", opacity=0.5)
+      DrawRect(x=340 + i * bar_w, y=680 - h, w=bar_w - 2, h=h, fill="#8866ff", opacity=0.5)
 
 
 # --------------------------------------------------
@@ -171,16 +169,16 @@ def draw(ctx):
   elif acc > 0.70:
     color = "#ff8833"
 
-  Rect(x=0, y=0, w=ctx.screen.w, h=8, fill=color, opacity=0.9)
-  Text(text=str(int(acc * 100)) + "%", x=20, y=16, font_size=20, fill=color, opacity=0.7)
+  DrawRect(x=0, y=0, w=ctx.screen.w, h=8, fill=color, opacity=0.9)
+  DrawText(text=str(int(acc * 100)) + "%", x=20, y=16, font_size=20, fill=color, opacity=0.7)
 
 
 # --------------------------------------------------
 # Sample 9: Waveform Polyline
-#   Animated wave using Point + Polyline.
+#   Animated wave using Point + DrawPolyline.
 # --------------------------------------------------
 def draw(ctx):
-  Background(fill="#0d0d1a")
+  DrawBackground(fill="#0d0d1a")
   t = ctx.time.ms * 0.002
   points = []
 
@@ -189,7 +187,7 @@ def draw(ctx):
     y = 360 + sin(t + i * 0.3) * 100
     points = points + [Point(x=x, y=y)]
 
-  Polyline(points=points, stroke="#22ddaa", thickness=2.0, opacity=0.5)
+  DrawPolyline(points=points, stroke="#22ddaa", thickness=2.0, opacity=0.5)
 
 
 # --------------------------------------------------
@@ -197,32 +195,32 @@ def draw(ctx):
 #   Combines primitive-built grid, pulse glow, combo, progress.
 # --------------------------------------------------
 def draw(ctx):
-  Background(fill="#080812")
+  DrawBackground(fill="#080812")
   bp = ctx.time.beat_phase
 
   for i in range(19):
     y = i * 40 - bp * 40
-    Line(x1=0, y1=y, x2=1280, y2=y, stroke="#ffffff10", thickness=1.0, opacity=0.3)
+    DrawLine(x1=0, y1=y, x2=1280, y2=y, stroke="#ffffff10", thickness=1.0, opacity=0.3)
 
-  Circle(cx=640, cy=340, radius=160 + bp * 24, fill="#ff66aa", opacity=0.08)
+  DrawCircle(cx=640, cy=340, radius=160 + bp * 24, fill="#ff66aa", opacity=0.08)
 
-  count = min(len(ctx.audio.spectrum), 64)
+  count = min(len(ctx.audio.buffers.spectrum), 64)
   if count > 0:
     bar_w = 1100 / count
     for i in range(count):
-      amp = ctx.audio.spectrum[i]
+      amp = ctx.audio.buffers.spectrum[i]
       h = 160 * amp
-      Rect(x=90 + i * bar_w, y=700 - h, w=bar_w - 2, h=h, fill="#4488ff", opacity=0.45)
+      DrawRect(x=90 + i * bar_w, y=700 - h, w=bar_w - 2, h=h, fill="#4488ff", opacity=0.45)
 
   combo = ctx.chart.combo
   if combo >= 10:
     scale = min(combo * 0.5, 40.0)
-    Circle(cx=640, cy=340, radius=60 + scale, fill="#ff66aa", opacity=lerp(0.3, 0.05, bp))
+    DrawCircle(cx=640, cy=340, radius=60 + scale, fill="#ff66aa", opacity=lerp(0.3, 0.05, bp))
 
   bar_w = 1000
   filled = bar_w * ctx.time.progress
-  Rect(x=140, y=700, w=bar_w, h=4, fill="#222222")
-  Rect(x=140, y=700, w=filled, h=4, fill="#44ddff")
+  DrawRect(x=140, y=700, w=bar_w, h=4, fill="#222222")
+  DrawRect(x=140, y=700, w=filled, h=4, fill="#44ddff")
 
 
 # --------------------------------------------------
@@ -236,10 +234,10 @@ def draw(ctx):
   cx = ctx.screen.w * 0.5
   cy = ctx.screen.h * 0.5
 
-  Background(fill="#060913")
+  DrawBackground(fill="#060913")
 
   glow = 0.05 + 0.03 * sin(t * 0.22)
-  Rect(x=0, y=0, w=ctx.screen.w, h=ctx.screen.h, fill="#d8f6ff", rotation=0, opacity=glow)
+  DrawRect(x=0, y=0, w=ctx.screen.w, h=ctx.screen.h, fill="#d8f6ff", rotation=0, opacity=glow)
 
   outer = []
   inner = []
@@ -265,9 +263,9 @@ def draw(ctx):
     core_y = cy + sin(a + t * 0.16) * core_r
     core.append(Point(x=core_x, y=core_y))
 
-  Polyline(points=outer, stroke="#c8f4ff", thickness=2.0, opacity=0.34)
-  Polyline(points=inner, stroke="#8ddfff", thickness=1.6, opacity=0.46)
-  Polyline(points=core, stroke="#ffffff", thickness=1.0, opacity=0.28)
+  DrawPolyline(points=outer, stroke="#c8f4ff", thickness=2.0, opacity=0.34)
+  DrawPolyline(points=inner, stroke="#8ddfff", thickness=1.6, opacity=0.46)
+  DrawPolyline(points=core, stroke="#ffffff", thickness=1.0, opacity=0.28)
 
   bridge_count = 10
   for i in range(bridge_count):
@@ -278,12 +276,12 @@ def draw(ctx):
     y1 = cy + sin(a) * r1
     x2 = cx + cos(a + 0.55 * sin(t * 0.17 + i)) * r2
     y2 = cy + sin(a + 0.55 * sin(t * 0.17 + i)) * r2
-    Line(x1=x1, y1=y1, x2=x2, y2=y2, stroke="#ffffff", thickness=1.0, opacity=0.14)
+    DrawLine(x1=x1, y1=y1, x2=x2, y2=y2, stroke="#ffffff", thickness=1.0, opacity=0.14)
 
-  count = min(ctx.audio.spectrum_size, 36)
+  count = min(ctx.audio.buffers.spectrum_size, 36)
   if count > 0:
     for i in range(count):
-      amp = ctx.audio.spectrum[i]
+      amp = ctx.audio.buffers.spectrum[i]
       band = amp * amp
       a = (i / count) * 2 * pi() - t * 0.18
       base_r = 185 + 10 * sin(t * 0.33 + i * 0.15)
@@ -293,10 +291,11 @@ def draw(ctx):
       x2 = cx + cos(a) * (base_r + h)
       y2 = cy + sin(a) * (base_r + h)
       thick = 1.0 + 1.8 * band
-      Line(x1=x1, y1=y1, x2=x2, y2=y2, stroke="#b4efff", thickness=thick, opacity=0.52)
+      DrawLine(x1=x1, y1=y1, x2=x2, y2=y2, stroke="#b4efff", thickness=thick, opacity=0.52)
 
   beat_ring = 100 + 22 * (1 - phase)
-  Circle(cx=cx, cy=cy, radius=beat_ring, fill="#ffffff", opacity=0.05)
-  Circle(cx=cx, cy=cy, radius=52 + 6 * sin(t * 0.8), fill="#0b1320", opacity=0.96)
+  DrawCircle(cx=cx, cy=cy, radius=beat_ring, fill="#ffffff", opacity=0.05)
+  DrawCircle(cx=cx, cy=cy, radius=52 + 6 * sin(t * 0.8), fill="#0b1320", opacity=0.96)
 
-  Text(text="SYZYGY DRIFT", x=cx - 118, y=cy + 242, font_size=22, fill="#f4fbff", opacity=0.44)
+  DrawText(text="SYZYGY DRIFT", x=cx - 118, y=cy + 242, font_size=22, fill="#f4fbff", opacity=0.44)
+

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -24,6 +24,7 @@ namespace {
 
 constexpr std::string_view kFileHeaderV1 = "RAYTHM_LOCAL_RANKING_V1";
 constexpr std::string_view kFileHeaderV2 = "RAYTHM_LOCAL_RANKING_V2";
+constexpr std::string_view kFileHeaderV3 = "RAYTHM_LOCAL_RANKING_V3";
 constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
 
 std::string trim(std::string_view value) {
@@ -57,16 +58,18 @@ std::string current_timestamp_utc() {
 
 std::string serialize_entries(const std::vector<ranking_service::entry>& entries) {
     std::ostringstream out;
-    out << kFileHeaderV2 << '\n';
+    out << kFileHeaderV3 << '\n';
     for (const ranking_service::entry& entry : entries) {
-        out << static_cast<int>(entry.clear_rank) << '\t'
-            << std::fixed << std::setprecision(4) << entry.accuracy << '\t'
+        out << std::fixed << std::setprecision(4) << entry.accuracy << '\t'
+            << (entry.is_full_combo ? 1 : 0) << '\t'
             << entry.max_combo << '\t'
             << entry.score << '\t'
             << entry.recorded_at << '\n';
     }
     return out.str();
 }
+
+enum class file_version { v1, v2, v3 };
 
 std::vector<ranking_service::entry> parse_entries(const std::string& content) {
     std::vector<ranking_service::entry> entries;
@@ -76,8 +79,14 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
         return entries;
     }
     const std::string header = trim(line);
-    const bool v2_format = header == kFileHeaderV2;
-    if (!v2_format && header != kFileHeaderV1) {
+    file_version version;
+    if (header == kFileHeaderV3) {
+        version = file_version::v3;
+    } else if (header == kFileHeaderV2) {
+        version = file_version::v2;
+    } else if (header == kFileHeaderV1) {
+        version = file_version::v1;
+    } else {
         return entries;
     }
 
@@ -87,36 +96,55 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
         }
 
         std::istringstream row(line);
-        std::string rank_token;
-        std::string accuracy_token;
-        std::string combo_token;
-        std::string score_token;
-        std::string timestamp_token;
-        if (!std::getline(row, rank_token, '\t') ||
-            !std::getline(row, accuracy_token, '\t')) {
-            continue;
-        }
-
-        if (v2_format) {
-            if (!std::getline(row, combo_token, '\t') ||
-                !std::getline(row, score_token, '\t') ||
-                !std::getline(row, timestamp_token)) {
-                continue;
-            }
-        } else {
-            if (!std::getline(row, score_token, '\t') ||
-                !std::getline(row, timestamp_token)) {
-                continue;
-            }
-        }
 
         try {
             ranking_service::entry entry;
-            entry.clear_rank = static_cast<rank>(std::clamp(std::stoi(trim(rank_token)), 0, 5));
-            entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
-            entry.max_combo = v2_format ? std::clamp(std::stoi(trim(combo_token)), 0, 999999) : 0;
-            entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
-            entry.recorded_at = trim(timestamp_token);
+
+            if (version == file_version::v3) {
+                // V3: accuracy \t is_full_combo \t max_combo \t score \t timestamp
+                std::string accuracy_token, fc_token, combo_token, score_token, timestamp_token;
+                if (!std::getline(row, accuracy_token, '\t') ||
+                    !std::getline(row, fc_token, '\t') ||
+                    !std::getline(row, combo_token, '\t') ||
+                    !std::getline(row, score_token, '\t') ||
+                    !std::getline(row, timestamp_token)) {
+                    continue;
+                }
+                entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
+                entry.is_full_combo = trim(fc_token) == "1";
+                entry.max_combo = std::clamp(std::stoi(trim(combo_token)), 0, 999999);
+                entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
+                entry.recorded_at = trim(timestamp_token);
+            } else {
+                // V1/V2: rank \t accuracy \t [max_combo \t] score \t timestamp
+                std::string rank_token, accuracy_token, combo_token, score_token, timestamp_token;
+                if (!std::getline(row, rank_token, '\t') ||
+                    !std::getline(row, accuracy_token, '\t')) {
+                    continue;
+                }
+                if (version == file_version::v2) {
+                    if (!std::getline(row, combo_token, '\t') ||
+                        !std::getline(row, score_token, '\t') ||
+                        !std::getline(row, timestamp_token)) {
+                        continue;
+                    }
+                } else {
+                    if (!std::getline(row, score_token, '\t') ||
+                        !std::getline(row, timestamp_token)) {
+                        continue;
+                    }
+                }
+
+                entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
+                entry.max_combo = (version == file_version::v2) ? std::clamp(std::stoi(trim(combo_token)), 0, 999999) : 0;
+                entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
+                entry.recorded_at = trim(timestamp_token);
+
+                // V1/V2 にはフルコンボ情報がないので、保存された rank が SS/S ならフルコンボとみなす。
+                const int stored_rank = std::clamp(std::stoi(trim(rank_token)), 0, 6);
+                entry.is_full_combo = (stored_rank == static_cast<int>(rank::ss) || stored_rank == static_cast<int>(rank::s));
+            }
+
             entry.verified = false;
             entries.push_back(std::move(entry));
         } catch (...) {
@@ -283,8 +311,8 @@ bool submit_local_result(const chart_meta& chart, const result_data& result) {
     std::vector<entry> entries = load_local_entries(chart.chart_id);
     entries.push_back({
         .placement = 0,
-        .clear_rank = result.clear_rank,
         .accuracy = result.accuracy,
+        .is_full_combo = result.is_full_combo,
         .max_combo = result.max_combo,
         .score = result.score,
         .recorded_at = current_timestamp_utc(),

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -14,12 +14,14 @@ enum class source {
 
 struct entry {
     int placement = 0;
-    rank clear_rank = rank::f;
     float accuracy = 0.0f;
+    bool is_full_combo = false;
     int max_combo = 0;
     int score = 0;
     std::string recorded_at;
     bool verified = false;
+
+    rank clear_rank() const { return compute_rank(accuracy, is_full_combo); }
 };
 
 struct listing {

--- a/src/gameplay/score_system.cpp
+++ b/src/gameplay/score_system.cpp
@@ -136,19 +136,7 @@ result_data score_system::get_result_data() const {
                             judge_counts_[judge_index(judge_result::perfect)] == judged_notes_;
     result.accuracy = get_live_accuracy();
 
-    if (result.is_full_combo && result.accuracy >= 100.0f) {
-        result.clear_rank = rank::ss;
-    } else if (result.is_full_combo && result.accuracy >= 95.0f) {
-        result.clear_rank = rank::s;
-    } else if (result.accuracy >= 90.0f) {
-        result.clear_rank = rank::a;
-    } else if (result.accuracy >= 80.0f) {
-        result.clear_rank = rank::b;
-    } else if (result.accuracy >= 70.0f) {
-        result.clear_rank = rank::c;
-    } else {
-        result.clear_rank = rank::f;
-    }
+    result.clear_rank = compute_rank(result.accuracy, result.is_full_combo);
 
     return result;
 }

--- a/src/gameplay/timing_engine.cpp
+++ b/src/gameplay/timing_engine.cpp
@@ -18,11 +18,15 @@ void timing_engine::init(std::vector<timing_event> events, int resolution, int o
     resolution_ = resolution;
     offset_ms_ = offset_ms;
     bpm_segments_.clear();
+    meter_segments_.clear();
 
     std::vector<timing_event> bpm_events;
+    std::vector<timing_event> meter_events;
     for (const timing_event& event : events) {
         if (event.type == timing_event_type::bpm) {
             bpm_events.push_back(event);
+        } else if (event.type == timing_event_type::meter) {
+            meter_events.push_back(event);
         }
     }
 
@@ -65,6 +69,38 @@ void timing_engine::init(std::vector<timing_event> events, int resolution, int o
     if (bpm_segments_.empty()) {
         bpm_segments_.push_back({0, 0.0, 120.0f});
     }
+
+    std::sort(meter_events.begin(), meter_events.end(), [](const timing_event& left, const timing_event& right) {
+        if (left.tick != right.tick) {
+            return left.tick < right.tick;
+        }
+        if (left.numerator != right.numerator) {
+            return left.numerator < right.numerator;
+        }
+        return left.denominator < right.denominator;
+    });
+
+    if (meter_events.empty() || meter_events.front().tick != 0) {
+        meter_segments_.push_back({0, 4, 4});
+    }
+
+    for (const timing_event& event : meter_events) {
+        if (event.numerator <= 0 || event.denominator <= 0) {
+            throw std::invalid_argument("meter values must be greater than zero");
+        }
+
+        if (!meter_segments_.empty() && meter_segments_.back().start_tick == event.tick) {
+            meter_segments_.back().numerator = event.numerator;
+            meter_segments_.back().denominator = event.denominator;
+            continue;
+        }
+
+        meter_segments_.push_back({event.tick, event.numerator, event.denominator});
+    }
+
+    if (meter_segments_.empty()) {
+        meter_segments_.push_back({0, 4, 4});
+    }
 }
 
 double timing_engine::tick_to_ms(int tick) const {
@@ -104,4 +140,28 @@ float timing_engine::get_bpm_at(int tick) const {
         [](int target_tick, const bpm_segment& segment) { return target_tick < segment.start_tick; });
     const bpm_segment& segment = upper == bpm_segments_.begin() ? bpm_segments_.front() : *std::prev(upper);
     return segment.bpm;
+}
+
+int timing_engine::get_meter_numerator_at(int tick) const {
+    if (tick < 0) {
+        throw std::invalid_argument("tick must be zero or greater");
+    }
+
+    const auto upper = std::upper_bound(
+        meter_segments_.begin(), meter_segments_.end(), tick,
+        [](int target_tick, const meter_segment& segment) { return target_tick < segment.start_tick; });
+    const meter_segment& segment = upper == meter_segments_.begin() ? meter_segments_.front() : *std::prev(upper);
+    return segment.numerator;
+}
+
+int timing_engine::get_meter_denominator_at(int tick) const {
+    if (tick < 0) {
+        throw std::invalid_argument("tick must be zero or greater");
+    }
+
+    const auto upper = std::upper_bound(
+        meter_segments_.begin(), meter_segments_.end(), tick,
+        [](int target_tick, const meter_segment& segment) { return target_tick < segment.start_tick; });
+    const meter_segment& segment = upper == meter_segments_.begin() ? meter_segments_.front() : *std::prev(upper);
+    return segment.denominator;
 }

--- a/src/gameplay/timing_engine.h
+++ b/src/gameplay/timing_engine.h
@@ -10,6 +10,8 @@ public:
     double tick_to_ms(int tick) const;
     int ms_to_tick(double ms) const;
     float get_bpm_at(int tick) const;
+    int get_meter_numerator_at(int tick) const;
+    int get_meter_denominator_at(int tick) const;
 
 private:
     struct bpm_segment {
@@ -18,7 +20,14 @@ private:
         float bpm = 120.0f;
     };
 
+    struct meter_segment {
+        int start_tick = 0;
+        int numerator = 4;
+        int denominator = 4;
+    };
+
     std::vector<bpm_segment> bpm_segments_;
+    std::vector<meter_segment> meter_segments_;
     int resolution_ = 480;
     int offset_ms_ = 0;
 };

--- a/src/models/data_models.h
+++ b/src/models/data_models.h
@@ -154,11 +154,23 @@ struct judge_event {
 enum class rank {
     ss,
     s,
+    aa,
     a,
     b,
     c,
     f
 };
+
+// accuracy と full combo 情報からランクを算出する。
+inline rank compute_rank(float accuracy, bool is_full_combo) {
+    if (is_full_combo && accuracy >= 100.0f) return rank::ss;
+    if (is_full_combo && accuracy >= 95.0f) return rank::s;
+    if (accuracy >= 95.0f) return rank::aa;
+    if (accuracy >= 90.0f) return rank::a;
+    if (accuracy >= 80.0f) return rank::b;
+    if (accuracy >= 70.0f) return rank::c;
+    return rank::f;
+}
 
 // リザルト画面で表示する集計結果。
 struct result_data {

--- a/src/mv/api/mv_builtins.cpp
+++ b/src/mv/api/mv_builtins.cpp
@@ -104,7 +104,7 @@ std::optional<vec2> build_cached_point_from_kwargs(
 std::optional<scene_node> build_cached_scene_node_from_kwargs(
     const std::string& type_name,
     const std::vector<std::pair<std::string, mv_value>>& kwargs) {
-    if (type_name == "Rect") {
+    if (type_name == "DrawRect") {
         rect_node n;
         n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
         n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
@@ -115,7 +115,7 @@ std::optional<scene_node> build_cached_scene_node_from_kwargs(
         n.fill = color_from_kwarg(kwargs, "fill", n.fill);
         return scene_node{n};
     }
-    if (type_name == "Line") {
+    if (type_name == "DrawLine") {
         line_node n;
         n.x1 = static_cast<float>(kwarg_number(kwargs, "x1", 0.0));
         n.y1 = static_cast<float>(kwarg_number(kwargs, "y1", 0.0));
@@ -126,7 +126,7 @@ std::optional<scene_node> build_cached_scene_node_from_kwargs(
         n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
         return scene_node{n};
     }
-    if (type_name == "Text") {
+    if (type_name == "DrawText") {
         text_node n;
         n.text = kwarg_string(kwargs, "text", "");
         n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
@@ -136,7 +136,7 @@ std::optional<scene_node> build_cached_scene_node_from_kwargs(
         n.fill = color_from_kwarg(kwargs, "fill", n.fill);
         return scene_node{n};
     }
-    if (type_name == "Circle") {
+    if (type_name == "DrawCircle") {
         circle_node n;
         n.cx = static_cast<float>(kwarg_number(kwargs, "cx", 0.0));
         n.cy = static_cast<float>(kwarg_number(kwargs, "cy", 0.0));
@@ -145,7 +145,7 @@ std::optional<scene_node> build_cached_scene_node_from_kwargs(
         n.fill = color_from_kwarg(kwargs, "fill", n.fill);
         return scene_node{n};
     }
-    if (type_name == "Polyline") {
+    if (type_name == "DrawPolyline") {
         polyline_node n;
         n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 2.0));
         n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
@@ -171,41 +171,7 @@ std::optional<scene_node> build_cached_scene_node_from_kwargs(
         }
         return scene_node{n};
     }
-    if (type_name == "SpectrumBar") {
-        spectrum_bar_node n;
-        n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
-        n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
-        n.w = static_cast<float>(kwarg_number(kwargs, "w", 400.0));
-        n.h = static_cast<float>(kwarg_number(kwargs, "h", 200.0));
-        n.bar_count = static_cast<int>(kwarg_number(kwargs, "bar_count", 32.0));
-        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
-        n.fill = color_from_kwarg(kwargs, "fill", n.fill);
-        return scene_node{n};
-    }
-    if (type_name == "BeatGrid") {
-        beat_grid_node n;
-        n.x = static_cast<float>(kwarg_number(kwargs, "x", 0.0));
-        n.y = static_cast<float>(kwarg_number(kwargs, "y", 0.0));
-        n.w = static_cast<float>(kwarg_number(kwargs, "w", 1280.0));
-        n.h = static_cast<float>(kwarg_number(kwargs, "h", 720.0));
-        n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 1.0));
-        n.beat_phase = static_cast<float>(kwarg_number(kwargs, "beat_phase", 0.0));
-        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
-        n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
-        return scene_node{n};
-    }
-    if (type_name == "PulseRing") {
-        pulse_ring_node n;
-        n.cx = static_cast<float>(kwarg_number(kwargs, "cx", 640.0));
-        n.cy = static_cast<float>(kwarg_number(kwargs, "cy", 360.0));
-        n.radius = static_cast<float>(kwarg_number(kwargs, "radius", 100.0));
-        n.thickness = static_cast<float>(kwarg_number(kwargs, "thickness", 3.0));
-        n.beat_phase = static_cast<float>(kwarg_number(kwargs, "beat_phase", 0.0));
-        n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
-        n.stroke = color_from_kwarg(kwargs, "stroke", n.stroke);
-        return scene_node{n};
-    }
-    if (type_name == "Background") {
+    if (type_name == "DrawBackground") {
         background_node n;
         n.opacity = static_cast<float>(kwarg_number(kwargs, "opacity", 1.0));
         n.fill = color_from_kwarg(kwargs, "fill", n.fill);
@@ -447,15 +413,12 @@ std::optional<scene_node> convert_node(const mv_value& val) {
     }
 
     const auto& type = obj->type_name;
-    if (type == "Rect")         return extract_rect(obj);
-    if (type == "Line")         return extract_line(obj);
-    if (type == "Text")         return extract_text(obj);
-    if (type == "Circle")       return extract_circle(obj);
-    if (type == "Polyline")     return extract_polyline(obj);
-    if (type == "SpectrumBar")  return extract_spectrum_bar(obj);
-    if (type == "BeatGrid")     return extract_beat_grid(obj);
-    if (type == "PulseRing")    return extract_pulse_ring(obj);
-    if (type == "Background")   return extract_background(obj);
+    if (type == "DrawRect")     return extract_rect(obj);
+    if (type == "DrawLine")     return extract_line(obj);
+    if (type == "DrawText")     return extract_text(obj);
+    if (type == "DrawCircle")   return extract_circle(obj);
+    if (type == "DrawPolyline") return extract_polyline(obj);
+    if (type == "DrawBackground") return extract_background(obj);
     return std::nullopt;
 }
 
@@ -651,27 +614,17 @@ void register_builtins_impl(Host& host) {
     auto make_node_ctor = [](const std::string& type_name) -> native_kwargs_function {
         return [type_name](const std::vector<mv_value>& args,
                           const std::vector<std::pair<std::string, mv_value>>& kwargs) -> mv_value {
-            static std::unordered_set<std::string> warned_types;
-            if ((type_name == "SpectrumBar" || type_name == "BeatGrid" || type_name == "PulseRing") &&
-                warned_types.insert(type_name).second) {
-                TraceLog(LOG_WARNING,
-                         "MV: %s is deprecated; prefer composing effects from Rect/Line/Circle/Text/Polyline",
-                         type_name.c_str());
-            }
             return make_node_kwargs(type_name, args, kwargs);
         };
     };
 
     host.register_native_kwargs("Point", make_node_ctor("Point"));
-    host.register_native_kwargs("Rect", make_node_ctor("Rect"));
-    host.register_native_kwargs("Line", make_node_ctor("Line"));
-    host.register_native_kwargs("Text", make_node_ctor("Text"));
-    host.register_native_kwargs("Circle", make_node_ctor("Circle"));
-    host.register_native_kwargs("Polyline", make_node_ctor("Polyline"));
-    host.register_native_kwargs("SpectrumBar", make_node_ctor("SpectrumBar"));
-    host.register_native_kwargs("BeatGrid", make_node_ctor("BeatGrid"));
-    host.register_native_kwargs("PulseRing", make_node_ctor("PulseRing"));
-    host.register_native_kwargs("Background", make_node_ctor("Background"));
+    host.register_native_kwargs("DrawRect", make_node_ctor("DrawRect"));
+    host.register_native_kwargs("DrawLine", make_node_ctor("DrawLine"));
+    host.register_native_kwargs("DrawText", make_node_ctor("DrawText"));
+    host.register_native_kwargs("DrawCircle", make_node_ctor("DrawCircle"));
+    host.register_native_kwargs("DrawPolyline", make_node_ctor("DrawPolyline"));
+    host.register_native_kwargs("DrawBackground", make_node_ctor("DrawBackground"));
 }
 
 void register_builtins(vm& v) { register_builtins_impl(v); }

--- a/src/mv/api/mv_context.cpp
+++ b/src/mv/api/mv_context.cpp
@@ -17,6 +17,10 @@ context_builder::context_builder()
     : ctx_(make_obj("ctx")),
       time_(make_obj("time")),
       audio_(make_obj("audio")),
+      audio_analysis_(make_obj("audio_analysis")),
+      audio_bands_(make_obj("audio_bands")),
+      audio_buffers_(make_obj("audio_buffers")),
+      song_(make_obj("song")),
       chart_(make_obj("chart")),
       screen_(make_obj("screen")),
       spectrum_(std::make_shared<mv_list>()),
@@ -24,11 +28,15 @@ context_builder::context_builder()
       oscilloscope_(std::make_shared<mv_list>()) {
     ctx_->set_attr("time", mv_value{time_});
     ctx_->set_attr("audio", mv_value{audio_});
+    ctx_->set_attr("song", mv_value{song_});
     ctx_->set_attr("chart", mv_value{chart_});
     ctx_->set_attr("screen", mv_value{screen_});
-    audio_->set_attr("spectrum", mv_value{spectrum_});
-    audio_->set_attr("waveform", mv_value{waveform_});
-    audio_->set_attr("oscilloscope", mv_value{oscilloscope_});
+    audio_->set_attr("analysis", mv_value{audio_analysis_});
+    audio_->set_attr("bands", mv_value{audio_bands_});
+    audio_->set_attr("buffers", mv_value{audio_buffers_});
+    audio_buffers_->set_attr("spectrum", mv_value{spectrum_});
+    audio_buffers_->set_attr("waveform", mv_value{waveform_});
+    audio_buffers_->set_attr("oscilloscope", mv_value{oscilloscope_});
 }
 
 std::shared_ptr<mv_object> context_builder::build(const context_input& input) {
@@ -38,6 +46,8 @@ std::shared_ptr<mv_object> context_builder::build(const context_input& input) {
     time_->set_attr("bpm", static_cast<double>(input.bpm));
     time_->set_attr("beat", static_cast<double>(input.beat_number));
     time_->set_attr("beat_phase", static_cast<double>(input.beat_phase));
+    time_->set_attr("meter_numerator", static_cast<double>(input.meter_numerator));
+    time_->set_attr("meter_denominator", static_cast<double>(input.meter_denominator));
 
     const double progress = (input.song_length_ms > 0)
         ? input.current_ms / input.song_length_ms
@@ -49,8 +59,13 @@ std::shared_ptr<mv_object> context_builder::build(const context_input& input) {
     for (float v : input.spectrum) {
         spectrum_->elements.push_back(static_cast<double>(v));
     }
-    audio_->set_attr("spectrum_size", static_cast<double>(input.spectrum.size()));
-    audio_->set_attr("level", static_cast<double>(input.level));
+    audio_analysis_->set_attr("level", static_cast<double>(input.level));
+    audio_analysis_->set_attr("rms", static_cast<double>(input.rms));
+    audio_analysis_->set_attr("peak", static_cast<double>(input.peak));
+    audio_bands_->set_attr("low", static_cast<double>(input.low));
+    audio_bands_->set_attr("mid", static_cast<double>(input.mid));
+    audio_bands_->set_attr("high", static_cast<double>(input.high));
+    audio_buffers_->set_attr("spectrum_size", static_cast<double>(input.spectrum.size()));
 
     const std::vector<float>* waveform_source = input.waveform;
     if (waveform_source_ != waveform_source) {
@@ -63,8 +78,8 @@ std::shared_ptr<mv_object> context_builder::build(const context_input& input) {
             }
         }
     }
-    audio_->set_attr("waveform_size", static_cast<double>(waveform_source != nullptr ? waveform_source->size() : 0));
-    audio_->set_attr("waveform_index", static_cast<double>(input.waveform_index));
+    audio_buffers_->set_attr("waveform_size", static_cast<double>(waveform_source != nullptr ? waveform_source->size() : 0));
+    audio_buffers_->set_attr("waveform_index", static_cast<double>(input.waveform_index));
 
     oscilloscope_->elements.clear();
     if (input.oscilloscope != nullptr) {
@@ -72,11 +87,23 @@ std::shared_ptr<mv_object> context_builder::build(const context_input& input) {
         for (float v : *input.oscilloscope) {
             oscilloscope_->elements.push_back(static_cast<double>(v));
         }
-        audio_->set_attr("oscilloscope_size", static_cast<double>(input.oscilloscope->size()));
+        audio_buffers_->set_attr("oscilloscope_size", static_cast<double>(input.oscilloscope->size()));
     } else {
-        audio_->set_attr("oscilloscope_size", 0.0);
+        audio_buffers_->set_attr("oscilloscope_size", 0.0);
     }
 
+    song_->set_attr("song_id", input.song_id);
+    song_->set_attr("title", input.song_title);
+    song_->set_attr("artist", input.song_artist);
+    song_->set_attr("base_bpm", static_cast<double>(input.song_base_bpm));
+
+    chart_->set_attr("chart_id", input.chart_id);
+    chart_->set_attr("song_id", input.chart_song_id);
+    chart_->set_attr("difficulty", input.chart_difficulty);
+    chart_->set_attr("level", static_cast<double>(input.chart_level));
+    chart_->set_attr("chart_author", input.chart_author);
+    chart_->set_attr("resolution", static_cast<double>(input.chart_resolution));
+    chart_->set_attr("offset", static_cast<double>(input.chart_offset));
     chart_->set_attr("total_notes", static_cast<double>(input.total_notes));
     chart_->set_attr("combo", static_cast<double>(input.combo));
     chart_->set_attr("accuracy", static_cast<double>(input.accuracy));

--- a/src/mv/api/mv_context.h
+++ b/src/mv/api/mv_context.h
@@ -15,15 +15,35 @@ struct context_input {
     float bpm = 120.0f;
     int beat_number = 0;      // absolute beat count from song start
     float beat_phase = 0;     // 0..1 fraction within current beat
+    int meter_numerator = 4;
+    int meter_denominator = 4;
 
     // audio
     std::vector<float> spectrum; // normalized 0..1, arbitrary bin count
     const std::vector<float>* waveform = nullptr; // normalized 0..1, precomputed song-wide envelope
     const std::vector<float>* oscilloscope = nullptr; // live PCM-ish mono samples, normalized -1..1
     float level = 0.0f;      // current song amplitude sampled from waveform/envelope
+    float rms = 0.0f;
+    float peak = 0.0f;
+    float low = 0.0f;
+    float mid = 0.0f;
+    float high = 0.0f;
     int waveform_index = 0;  // current position inside waveform/envelope
 
+    // song metadata
+    std::string song_id;
+    std::string song_title;
+    std::string song_artist;
+    float song_base_bpm = 0.0f;
+
     // chart
+    std::string chart_id;
+    std::string chart_song_id;
+    std::string chart_difficulty;
+    float chart_level = 0.0f;
+    std::string chart_author;
+    int chart_resolution = 0;
+    int chart_offset = 0;
     int total_notes = 0;
     int combo = 0;
     float accuracy = 0;       // 0..1
@@ -35,7 +55,7 @@ struct context_input {
 };
 
 // Build the ctx mv_object from context_input.
-// The returned object has sub-objects: ctx.time, ctx.audio, ctx.chart, ctx.screen
+// The returned object has sub-objects: ctx.time, ctx.audio, ctx.song, ctx.chart, ctx.screen
 std::shared_ptr<mv_object> build_context(const context_input& input);
 
 class context_builder {
@@ -48,6 +68,10 @@ private:
     std::shared_ptr<mv_object> ctx_;
     std::shared_ptr<mv_object> time_;
     std::shared_ptr<mv_object> audio_;
+    std::shared_ptr<mv_object> audio_analysis_;
+    std::shared_ptr<mv_object> audio_bands_;
+    std::shared_ptr<mv_object> audio_buffers_;
+    std::shared_ptr<mv_object> song_;
     std::shared_ptr<mv_object> chart_;
     std::shared_ptr<mv_object> screen_;
     std::shared_ptr<mv_list> spectrum_;

--- a/src/mv/lang/mv_compiler.cpp
+++ b/src/mv/lang/mv_compiler.cpp
@@ -105,8 +105,7 @@ struct compiler_state {
 
     bool is_draw_node_expr(const expr& e) const {
         static const std::vector<std::string> kNodeNames = {
-            "Background", "Rect", "Circle", "Line", "Text", "Polyline",
-            "SpectrumBar", "BeatGrid", "PulseRing"
+            "DrawBackground", "DrawRect", "DrawCircle", "DrawLine", "DrawText", "DrawPolyline"
         };
         return is_named_call(e, kNodeNames);
     }

--- a/src/mv/lang/mv_sandbox.cpp
+++ b/src/mv/lang/mv_sandbox.cpp
@@ -1,9 +1,12 @@
 #include "mv_sandbox.h"
 
 #include <cctype>
+#include <initializer_list>
 #include <optional>
 #include <sstream>
+#include <string_view>
 #include <unordered_set>
+#include <unordered_map>
 
 #include "raylib.h"
 
@@ -18,11 +21,178 @@ struct validation_error {
 };
 
 using name_set = std::unordered_set<std::string>;
+using type_map = std::unordered_map<std::string, std::string>;
+
+using member_set = std::unordered_set<std::string_view>;
+
+const std::unordered_map<std::string_view, member_set>& ctx_member_schema() {
+    static const std::unordered_map<std::string_view, member_set> schema = {
+        {"ctx", {"time", "audio", "song", "chart", "screen"}},
+        {"ctx.time", {"ms", "sec", "length_ms", "bpm", "beat", "beat_phase",
+                      "meter_numerator", "meter_denominator", "progress"}},
+        {"ctx.audio", {"analysis", "bands", "buffers"}},
+        {"ctx.audio.analysis", {"level", "rms", "peak"}},
+        {"ctx.audio.bands", {"low", "mid", "high"}},
+        {"ctx.audio.buffers", {"spectrum", "spectrum_size", "oscilloscope", "oscilloscope_size",
+                               "waveform", "waveform_size", "waveform_index"}},
+        {"ctx.song", {"song_id", "title", "artist", "base_bpm"}},
+        {"ctx.chart", {"chart_id", "song_id", "difficulty", "level", "chart_author",
+                       "resolution", "offset", "total_notes", "combo", "accuracy", "key_count"}},
+        {"ctx.screen", {"w", "h"}},
+    };
+    return schema;
+}
 
 bool is_known_name(const std::string& name,
                    const name_set& callable_names,
                    const name_set& visible_names) {
     return callable_names.contains(name) || visible_names.contains(name);
+}
+
+const std::unordered_map<std::string_view, member_set>& builtin_object_schema() {
+    static const std::unordered_map<std::string_view, member_set> schema = {
+        {"Scene", {"nodes", "clear_color"}},
+        {"Point", {"x", "y"}},
+        {"DrawRect", {"x", "y", "w", "h", "rotation", "opacity", "fill"}},
+        {"DrawLine", {"x1", "y1", "x2", "y2", "thickness", "opacity", "stroke"}},
+        {"DrawText", {"text", "x", "y", "font_size", "opacity", "fill"}},
+        {"DrawCircle", {"cx", "cy", "radius", "opacity", "fill"}},
+        {"DrawPolyline", {"points", "thickness", "opacity", "stroke"}},
+        {"DrawBackground", {"fill", "opacity"}},
+        {"Color", {"r", "g", "b", "a"}},
+        {"list", {"append"}},
+    };
+    return schema;
+}
+
+std::optional<std::string> infer_expr_type(const expr& expression, const type_map& visible_types);
+
+std::optional<std::string> ctx_object_path(const expr& expression) {
+    if (const auto* ident = std::get_if<identifier>(&expression.kind)) {
+        if (ident->name == "ctx") {
+            return ident->name;
+        }
+        return std::nullopt;
+    }
+    if (const auto* attr = std::get_if<attr_expr>(&expression.kind)) {
+        const auto base = ctx_object_path(*attr->object);
+        if (!base.has_value()) {
+            return std::nullopt;
+        }
+        return *base + "." + attr->attr;
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> infer_ctx_attr_type(std::string_view base, std::string_view attr) {
+    const std::string full = std::string(base) + "." + std::string(attr);
+    if (ctx_member_schema().contains(full)) {
+        return full;
+    }
+    if (full == "ctx.audio.buffers.spectrum" || full == "ctx.audio.buffers.waveform" ||
+        full == "ctx.audio.buffers.oscilloscope") {
+        return std::string("list");
+    }
+    return std::nullopt;
+}
+
+void validate_ctx_attr(const expr& object_expr,
+                       std::string_view attr_name,
+                       source_location loc,
+                       std::vector<validation_error>& errors) {
+    const auto base = ctx_object_path(object_expr);
+    if (!base.has_value()) {
+        return;
+    }
+
+    const auto& schema = ctx_member_schema();
+    const auto schema_it = schema.find(*base);
+    if (schema_it == schema.end()) {
+        return;
+    }
+    if (!schema_it->second.contains(attr_name)) {
+        errors.push_back({"unknown attribute '" + std::string(attr_name) + "' on " + *base,
+                          loc.line, loc.column});
+    }
+}
+
+void validate_object_attr(const expr& object_expr,
+                          std::string_view attr_name,
+                          source_location loc,
+                          const type_map& visible_types,
+                          std::vector<validation_error>& errors) {
+    if (const auto base = ctx_object_path(object_expr); base.has_value()) {
+        validate_ctx_attr(object_expr, attr_name, loc, errors);
+        return;
+    }
+
+    const auto object_type = infer_expr_type(object_expr, visible_types);
+    if (!object_type.has_value()) {
+        return;
+    }
+
+    const auto& schema = builtin_object_schema();
+    const auto schema_it = schema.find(*object_type);
+    if (schema_it == schema.end()) {
+        return;
+    }
+    if (!schema_it->second.contains(attr_name)) {
+        errors.push_back({"unknown attribute '" + std::string(attr_name) + "' on " + *object_type,
+                          loc.line, loc.column});
+    }
+}
+
+std::optional<std::string> infer_expr_type(const expr& expression, const type_map& visible_types) {
+    return std::visit([&](const auto& node) -> std::optional<std::string> {
+        using T = std::decay_t<decltype(node)>;
+        if constexpr (std::is_same_v<T, identifier>) {
+            auto it = visible_types.find(node.name);
+            if (it != visible_types.end()) {
+                return it->second;
+            }
+            return std::nullopt;
+        } else if constexpr (std::is_same_v<T, list_expr>) {
+            return "list";
+        } else if constexpr (std::is_same_v<T, attr_expr>) {
+            if (const auto base = ctx_object_path(*node.object); base.has_value()) {
+                return infer_ctx_attr_type(*base, node.attr);
+            }
+            const auto object_type = infer_expr_type(*node.object, visible_types);
+            if (!object_type.has_value()) {
+                return std::nullopt;
+            }
+            if (*object_type == "Scene" && node.attr == "nodes") return std::string("list");
+            if (*object_type == "DrawRect" && node.attr == "fill") return std::string("Color");
+            if (*object_type == "DrawLine" && node.attr == "stroke") return std::string("Color");
+            if (*object_type == "DrawText" && node.attr == "fill") return std::string("Color");
+            if (*object_type == "DrawCircle" && node.attr == "fill") return std::string("Color");
+            if (*object_type == "DrawPolyline" && node.attr == "points") return std::string("list");
+            if (*object_type == "DrawPolyline" && node.attr == "stroke") return std::string("Color");
+            if (*object_type == "DrawBackground" && node.attr == "fill") return std::string("Color");
+            return std::nullopt;
+        } else if constexpr (std::is_same_v<T, call_expr>) {
+            if (const auto* ident = std::get_if<identifier>(&node.callee->kind)) {
+                if (ident->name == "range") return std::string("list");
+                if (ident->name == "rgb") return std::string("Color");
+            }
+            if (const auto* attr = std::get_if<attr_expr>(&node.callee->kind)) {
+                if (const auto object_type = infer_expr_type(*attr->object, visible_types);
+                    object_type.has_value() && *object_type == "list" && attr->attr == "append") {
+                    return std::nullopt;
+                }
+            }
+            return std::nullopt;
+        } else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
+            if (const auto* ident = std::get_if<identifier>(&node.callee->kind)) {
+                const std::string_view name = ident->name;
+                if (builtin_object_schema().contains(name) && name != "list") {
+                    return ident->name;
+                }
+            }
+            return std::nullopt;
+        }
+        return std::nullopt;
+    }, expression.kind);
 }
 
 std::optional<script_error> parse_error_message(const std::string& phase, const std::string& message) {
@@ -102,34 +272,39 @@ void collect_function_names(const std::vector<stmt_ptr>& statements, name_set& n
 void validate_expr(const expr& expression,
                    const name_set& callable_names,
                    const name_set& visible_names,
+                   const type_map& visible_types,
                    std::vector<validation_error>& errors);
 
 void validate_expr_ptr(const expr_ptr& expression,
                        const name_set& callable_names,
                        const name_set& visible_names,
+                       const type_map& visible_types,
                        std::vector<validation_error>& errors) {
     if (expression) {
-        validate_expr(*expression, callable_names, visible_names, errors);
+        validate_expr(*expression, callable_names, visible_names, visible_types, errors);
     }
 }
 
 void validate_stmt(const stmt& statement,
                    const name_set& callable_names,
                    name_set& visible_names,
+                   type_map& visible_types,
                    std::vector<validation_error>& errors);
 
 void validate_block(const std::vector<stmt_ptr>& statements,
                     const name_set& callable_names,
                     name_set visible_names,
+                    type_map visible_types,
                     std::vector<validation_error>& errors) {
     for (const auto& statement : statements) {
-        validate_stmt(*statement, callable_names, visible_names, errors);
+        validate_stmt(*statement, callable_names, visible_names, visible_types, errors);
     }
 }
 
 void validate_expr(const expr& expression,
                    const name_set& callable_names,
                    const name_set& visible_names,
+                   const type_map& visible_types,
                    std::vector<validation_error>& errors) {
     std::visit([&](const auto& node) {
         using T = std::decay_t<decltype(node)>;
@@ -140,10 +315,10 @@ void validate_expr(const expr& expression,
             }
         } else
         if constexpr (std::is_same_v<T, binary_expr>) {
-            validate_expr_ptr(node.left, callable_names, visible_names, errors);
-            validate_expr_ptr(node.right, callable_names, visible_names, errors);
+            validate_expr_ptr(node.left, callable_names, visible_names, visible_types, errors);
+            validate_expr_ptr(node.right, callable_names, visible_names, visible_types, errors);
         } else if constexpr (std::is_same_v<T, unary_expr>) {
-            validate_expr_ptr(node.operand, callable_names, visible_names, errors);
+            validate_expr_ptr(node.operand, callable_names, visible_names, visible_types, errors);
         } else if constexpr (std::is_same_v<T, call_expr>) {
             if (auto* ident = std::get_if<identifier>(&node.callee->kind)) {
                 if (!is_known_name(ident->name, callable_names, visible_names)) {
@@ -151,10 +326,10 @@ void validate_expr(const expr& expression,
                                       expression.loc.line, expression.loc.column});
                 }
             } else {
-                validate_expr_ptr(node.callee, callable_names, visible_names, errors);
+                validate_expr_ptr(node.callee, callable_names, visible_names, visible_types, errors);
             }
             for (const auto& arg : node.args) {
-                validate_expr_ptr(arg, callable_names, visible_names, errors);
+                validate_expr_ptr(arg, callable_names, visible_names, visible_types, errors);
             }
         } else if constexpr (std::is_same_v<T, call_with_kwargs_expr>) {
             if (auto* ident = std::get_if<identifier>(&node.callee->kind)) {
@@ -163,22 +338,23 @@ void validate_expr(const expr& expression,
                                       expression.loc.line, expression.loc.column});
                 }
             } else {
-                validate_expr_ptr(node.callee, callable_names, visible_names, errors);
+                validate_expr_ptr(node.callee, callable_names, visible_names, visible_types, errors);
             }
             for (const auto& arg : node.positional_args) {
-                validate_expr_ptr(arg, callable_names, visible_names, errors);
+                validate_expr_ptr(arg, callable_names, visible_names, visible_types, errors);
             }
             for (const auto& kw : node.keyword_args) {
-                validate_expr_ptr(kw.value, callable_names, visible_names, errors);
+                validate_expr_ptr(kw.value, callable_names, visible_names, visible_types, errors);
             }
         } else if constexpr (std::is_same_v<T, attr_expr>) {
-            validate_expr_ptr(node.object, callable_names, visible_names, errors);
+            validate_expr_ptr(node.object, callable_names, visible_names, visible_types, errors);
+            validate_object_attr(*node.object, node.attr, expression.loc, visible_types, errors);
         } else if constexpr (std::is_same_v<T, index_expr>) {
-            validate_expr_ptr(node.object, callable_names, visible_names, errors);
-            validate_expr_ptr(node.index, callable_names, visible_names, errors);
+            validate_expr_ptr(node.object, callable_names, visible_names, visible_types, errors);
+            validate_expr_ptr(node.index, callable_names, visible_names, visible_types, errors);
         } else if constexpr (std::is_same_v<T, list_expr>) {
             for (const auto& item : node.elements) {
-                validate_expr_ptr(item, callable_names, visible_names, errors);
+                validate_expr_ptr(item, callable_names, visible_names, visible_types, errors);
             }
         }
     }, expression.kind);
@@ -187,47 +363,59 @@ void validate_expr(const expr& expression,
 void validate_stmt(const stmt& statement,
                    const name_set& callable_names,
                    name_set& visible_names,
+                   type_map& visible_types,
                    std::vector<validation_error>& errors) {
     std::visit([&](const auto& node) {
         using T = std::decay_t<decltype(node)>;
         if constexpr (std::is_same_v<T, expr_stmt>) {
-            validate_expr_ptr(node.expression, callable_names, visible_names, errors);
+            validate_expr_ptr(node.expression, callable_names, visible_names, visible_types, errors);
         } else if constexpr (std::is_same_v<T, assign_stmt>) {
-            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+            validate_expr_ptr(node.value, callable_names, visible_names, visible_types, errors);
             visible_names.insert(node.name);
+            if (const auto inferred = infer_expr_type(*node.value, visible_types); inferred.has_value()) {
+                visible_types[node.name] = *inferred;
+            } else {
+                visible_types.erase(node.name);
+            }
         } else if constexpr (std::is_same_v<T, attr_assign_stmt>) {
-            validate_expr_ptr(node.object, callable_names, visible_names, errors);
-            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+            validate_expr_ptr(node.object, callable_names, visible_names, visible_types, errors);
+            validate_expr_ptr(node.value, callable_names, visible_names, visible_types, errors);
+            validate_object_attr(*node.object, node.attr, statement.loc, visible_types, errors);
         } else if constexpr (std::is_same_v<T, index_assign_stmt>) {
-            validate_expr_ptr(node.object, callable_names, visible_names, errors);
-            validate_expr_ptr(node.index, callable_names, visible_names, errors);
-            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+            validate_expr_ptr(node.object, callable_names, visible_names, visible_types, errors);
+            validate_expr_ptr(node.index, callable_names, visible_names, visible_types, errors);
+            validate_expr_ptr(node.value, callable_names, visible_names, visible_types, errors);
         } else if constexpr (std::is_same_v<T, return_stmt>) {
             if (node.value.has_value()) {
-                validate_expr_ptr(*node.value, callable_names, visible_names, errors);
+                validate_expr_ptr(*node.value, callable_names, visible_names, visible_types, errors);
             }
         } else if constexpr (std::is_same_v<T, if_stmt>) {
-            validate_expr_ptr(node.main.condition, callable_names, visible_names, errors);
-            validate_block(node.main.body, callable_names, visible_names, errors);
+            validate_expr_ptr(node.main.condition, callable_names, visible_names, visible_types, errors);
+            validate_block(node.main.body, callable_names, visible_names, visible_types, errors);
             for (const auto& branch : node.elifs) {
-                validate_expr_ptr(branch.condition, callable_names, visible_names, errors);
-                validate_block(branch.body, callable_names, visible_names, errors);
+                validate_expr_ptr(branch.condition, callable_names, visible_names, visible_types, errors);
+                validate_block(branch.body, callable_names, visible_names, visible_types, errors);
             }
-            validate_block(node.else_body, callable_names, visible_names, errors);
+            validate_block(node.else_body, callable_names, visible_names, visible_types, errors);
         } else if constexpr (std::is_same_v<T, for_stmt>) {
-            validate_expr_ptr(node.iterable, callable_names, visible_names, errors);
+            validate_expr_ptr(node.iterable, callable_names, visible_names, visible_types, errors);
             name_set loop_visible = visible_names;
+            type_map loop_types = visible_types;
             loop_visible.insert(node.var_name);
-            validate_block(node.body, callable_names, loop_visible, errors);
+            loop_types.erase(node.var_name);
+            validate_block(node.body, callable_names, loop_visible, loop_types, errors);
             visible_names.insert(node.var_name);
+            visible_types.erase(node.var_name);
         } else if constexpr (std::is_same_v<T, func_def>) {
             name_set function_visible = visible_names;
+            type_map function_types = visible_types;
             for (const auto& param : node.params) {
                 function_visible.insert(param);
+                function_types.erase(param);
             }
-            validate_block(node.body, callable_names, function_visible, errors);
+            validate_block(node.body, callable_names, function_visible, function_types, errors);
         } else if constexpr (std::is_same_v<T, augmented_assign_stmt>) {
-            validate_expr_ptr(node.value, callable_names, visible_names, errors);
+            validate_expr_ptr(node.value, callable_names, visible_names, visible_types, errors);
             visible_names.insert(node.name);
         }
     }, statement.kind);
@@ -239,10 +427,14 @@ std::vector<validation_error> validate_callable_names(const program& prog,
                                                       const std::vector<std::pair<std::string, native_kwargs_function>>& natives_kwargs) {
     name_set callable_names;
     name_set visible_names;
+    type_map visible_types;
 
     for (const auto& [name, _] : globals) {
         visible_names.insert(name);
         callable_names.insert(name);
+        if (name == "ctx") {
+            visible_types.emplace(name, "ctx");
+        }
     }
     for (const auto& [name, _] : natives) {
         callable_names.insert(name);
@@ -255,7 +447,7 @@ std::vector<validation_error> validate_callable_names(const program& prog,
 
     std::vector<validation_error> errors;
     for (const auto& statement : prog.statements) {
-        validate_stmt(*statement, callable_names, visible_names, errors);
+        validate_stmt(*statement, callable_names, visible_names, visible_types, errors);
     }
     return errors;
 }

--- a/src/mv/mv_runtime.cpp
+++ b/src/mv/mv_runtime.cpp
@@ -64,17 +64,6 @@ std::optional<scene> mv_runtime::tick(const context_input& input) {
         return std::nullopt;
     }
 
-    // Inject audio spectrum into legacy SpectrumBar nodes for compatibility.
-    for (auto& node : sc->nodes) {
-        if (auto* sb = std::get_if<spectrum_bar_node>(&node)) {
-            sb->spectrum.clear();
-            sb->spectrum.reserve(input.spectrum.size());
-            for (float v : input.spectrum) {
-                sb->spectrum.push_back(v);
-            }
-        }
-    }
-
     validate_scene(*sc, validation_limits_);
     return sc;
 }

--- a/src/mv/mv_script_editor_style.cpp
+++ b/src/mv/mv_script_editor_style.cpp
@@ -253,6 +253,7 @@ void append_matches(std::vector<ui::text_editor_completion_item>& items,
                     std::unordered_set<std::string>& seen_labels) {
     for (const auto& item : source) {
         if ((prefix.empty() || item.label.rfind(prefix, 0) == 0) &&
+            !(item.label == prefix && item.insert_text == prefix) &&
             seen_labels.insert(item.label).second) {
             items.push_back(item);
         }
@@ -264,12 +265,9 @@ Color identifier_color(const std::string& ident) {
                            "True", "False", "None"})) {
         return keyword_color();
     }
-    if (is_in_list(ident, {"Scene", "Point", "Background", "Rect", "Circle", "Line", "Text",
-                           "Polyline"})) {
+    if (is_in_list(ident, {"Scene", "Point", "DrawBackground", "DrawRect", "DrawCircle", "DrawLine", "DrawText",
+                           "DrawPolyline"})) {
         return node_color();
-    }
-    if (is_in_list(ident, {"SpectrumBar", "BeatGrid", "PulseRing"})) {
-        return g_theme->text_hint;
     }
     if (is_in_list(ident, {"sin", "cos", "abs", "floor", "ceil", "sqrt", "min", "max",
                            "clamp", "lerp", "smoothstep", "rgb", "len", "range",
@@ -394,12 +392,12 @@ ui::text_editor_completion_result complete_mv_script_line(const std::vector<std:
         {"not", "not"},
         {"Scene", "Scene("},
         {"Point", "Point("},
-        {"Background", "Background("},
-        {"Rect", "Rect("},
-        {"Circle", "Circle("},
-        {"Line", "Line("},
-        {"Text", "Text("},
-        {"Polyline", "Polyline("},
+        {"DrawBackground", "DrawBackground("},
+        {"DrawRect", "DrawRect("},
+        {"DrawCircle", "DrawCircle("},
+        {"DrawLine", "DrawLine("},
+        {"DrawText", "DrawText("},
+        {"DrawPolyline", "DrawPolyline("},
         {"sin", "sin("},
         {"cos", "cos("},
         {"abs", "abs("},
@@ -424,6 +422,7 @@ ui::text_editor_completion_result complete_mv_script_line(const std::vector<std:
     static const std::vector<ui::text_editor_completion_item> kCtxItems = {
         {"ctx.time", "ctx.time"},
         {"ctx.audio", "ctx.audio"},
+        {"ctx.song", "ctx.song"},
         {"ctx.chart", "ctx.chart"},
         {"ctx.screen", "ctx.screen"},
     };
@@ -435,21 +434,54 @@ ui::text_editor_completion_result complete_mv_script_line(const std::vector<std:
         {"ctx.time.bpm", "ctx.time.bpm"},
         {"ctx.time.beat", "ctx.time.beat"},
         {"ctx.time.beat_phase", "ctx.time.beat_phase"},
+        {"ctx.time.meter_numerator", "ctx.time.meter_numerator"},
+        {"ctx.time.meter_denominator", "ctx.time.meter_denominator"},
         {"ctx.time.progress", "ctx.time.progress"},
     };
 
     static const std::vector<ui::text_editor_completion_item> kAudioItems = {
-        {"ctx.audio.spectrum", "ctx.audio.spectrum"},
-        {"ctx.audio.spectrum_size", "ctx.audio.spectrum_size"},
-        {"ctx.audio.waveform", "ctx.audio.waveform"},
-        {"ctx.audio.waveform_size", "ctx.audio.waveform_size"},
-        {"ctx.audio.waveform_index", "ctx.audio.waveform_index"},
-        {"ctx.audio.oscilloscope", "ctx.audio.oscilloscope"},
-        {"ctx.audio.oscilloscope_size", "ctx.audio.oscilloscope_size"},
-        {"ctx.audio.level", "ctx.audio.level"},
+        {"ctx.audio.analysis", "ctx.audio.analysis"},
+        {"ctx.audio.bands", "ctx.audio.bands"},
+        {"ctx.audio.buffers", "ctx.audio.buffers"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kAudioAnalysisItems = {
+        {"ctx.audio.analysis.level", "ctx.audio.analysis.level"},
+        {"ctx.audio.analysis.rms", "ctx.audio.analysis.rms"},
+        {"ctx.audio.analysis.peak", "ctx.audio.analysis.peak"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kAudioBandsItems = {
+        {"ctx.audio.bands.low", "ctx.audio.bands.low"},
+        {"ctx.audio.bands.mid", "ctx.audio.bands.mid"},
+        {"ctx.audio.bands.high", "ctx.audio.bands.high"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kAudioBufferItems = {
+        {"ctx.audio.buffers.spectrum", "ctx.audio.buffers.spectrum"},
+        {"ctx.audio.buffers.spectrum_size", "ctx.audio.buffers.spectrum_size"},
+        {"ctx.audio.buffers.oscilloscope", "ctx.audio.buffers.oscilloscope"},
+        {"ctx.audio.buffers.oscilloscope_size", "ctx.audio.buffers.oscilloscope_size"},
+        {"ctx.audio.buffers.waveform", "ctx.audio.buffers.waveform"},
+        {"ctx.audio.buffers.waveform_size", "ctx.audio.buffers.waveform_size"},
+        {"ctx.audio.buffers.waveform_index", "ctx.audio.buffers.waveform_index"},
+    };
+
+    static const std::vector<ui::text_editor_completion_item> kSongItems = {
+        {"ctx.song.song_id", "ctx.song.song_id"},
+        {"ctx.song.title", "ctx.song.title"},
+        {"ctx.song.artist", "ctx.song.artist"},
+        {"ctx.song.base_bpm", "ctx.song.base_bpm"},
     };
 
     static const std::vector<ui::text_editor_completion_item> kChartItems = {
+        {"ctx.chart.chart_id", "ctx.chart.chart_id"},
+        {"ctx.chart.song_id", "ctx.chart.song_id"},
+        {"ctx.chart.difficulty", "ctx.chart.difficulty"},
+        {"ctx.chart.level", "ctx.chart.level"},
+        {"ctx.chart.chart_author", "ctx.chart.chart_author"},
+        {"ctx.chart.resolution", "ctx.chart.resolution"},
+        {"ctx.chart.offset", "ctx.chart.offset"},
         {"ctx.chart.total_notes", "ctx.chart.total_notes"},
         {"ctx.chart.combo", "ctx.chart.combo"},
         {"ctx.chart.accuracy", "ctx.chart.accuracy"},
@@ -470,8 +502,16 @@ ui::text_editor_completion_result complete_mv_script_line(const std::vector<std:
     std::unordered_set<std::string> seen_labels;
     if (token.rfind("ctx.time.", 0) == 0) {
         append_matches(matches, kTimeItems, token, seen_labels);
+    } else if (token.rfind("ctx.audio.analysis.", 0) == 0) {
+        append_matches(matches, kAudioAnalysisItems, token, seen_labels);
+    } else if (token.rfind("ctx.audio.bands.", 0) == 0) {
+        append_matches(matches, kAudioBandsItems, token, seen_labels);
+    } else if (token.rfind("ctx.audio.buffers.", 0) == 0) {
+        append_matches(matches, kAudioBufferItems, token, seen_labels);
     } else if (token.rfind("ctx.audio.", 0) == 0) {
         append_matches(matches, kAudioItems, token, seen_labels);
+    } else if (token.rfind("ctx.song.", 0) == 0) {
+        append_matches(matches, kSongItems, token, seen_labels);
     } else if (token.rfind("ctx.chart.", 0) == 0) {
         append_matches(matches, kChartItems, token, seen_labels);
     } else if (token.rfind("ctx.screen.", 0) == 0) {
@@ -490,7 +530,7 @@ ui::text_editor_completion_result complete_mv_script_line(const std::vector<std:
         }
     } else {
         for (const auto& name : symbols.visible_names) {
-            if (token.empty() || name.rfind(token, 0) == 0) {
+            if ((token.empty() || name.rfind(token, 0) == 0) && name != token) {
                 if (seen_labels.insert(name).second) {
                     matches.push_back({name, name});
                 }

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -25,7 +25,7 @@ bool wide_text_filter(int codepoint, const std::string&) {
 }
 
 std::string default_script_source() {
-    return "def draw(ctx):\n  return Scene([])\n";
+    return "def draw(ctx):\n  DrawBackground(fill=\"#0a0a1a\")\n";
 }
 
 Rectangle tab_button_rect(int index) {

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -70,6 +70,39 @@ std::vector<float> build_mv_oscilloscope() {
     return {pcm.begin(), pcm.end()};
 }
 
+float compute_oscilloscope_rms(const std::vector<float>& oscilloscope) {
+    if (oscilloscope.empty()) {
+        return 0.0f;
+    }
+
+    double sum = 0.0;
+    for (float sample : oscilloscope) {
+        sum += static_cast<double>(sample) * static_cast<double>(sample);
+    }
+    return static_cast<float>(std::sqrt(sum / static_cast<double>(oscilloscope.size())));
+}
+
+float compute_oscilloscope_peak(const std::vector<float>& oscilloscope) {
+    float peak = 0.0f;
+    for (float sample : oscilloscope) {
+        peak = std::max(peak, std::fabs(sample));
+    }
+    return peak;
+}
+
+float compute_spectrum_band_average(const std::vector<float>& spectrum, std::size_t start, std::size_t end) {
+    if (start >= end || start >= spectrum.size()) {
+        return 0.0f;
+    }
+
+    const std::size_t clamped_end = std::min(end, spectrum.size());
+    double sum = 0.0;
+    for (std::size_t i = start; i < clamped_end; ++i) {
+        sum += spectrum[i];
+    }
+    return static_cast<float>(sum / static_cast<double>(clamped_end - start));
+}
+
 Vector3 build_camera_forward(float camera_angle_degrees) {
     const float angle_rad = std::clamp(camera_angle_degrees, 5.0f, 90.0f) * DEG2RAD;
     return Vector3{0.0f, -std::sin(angle_rad), std::cos(angle_rad)};
@@ -282,6 +315,8 @@ void play_scene::draw() {
 
         int current_tick = state_.timing_engine.ms_to_tick(state_.current_ms);
         mv_input.bpm = state_.timing_engine.get_bpm_at(current_tick);
+        mv_input.meter_numerator = state_.timing_engine.get_meter_numerator_at(current_tick);
+        mv_input.meter_denominator = state_.timing_engine.get_meter_denominator_at(current_tick);
 
         double beat_duration_ms = 60000.0 / mv_input.bpm;
         if (beat_duration_ms > 0) {
@@ -296,13 +331,34 @@ void play_scene::draw() {
         mv_input.spectrum = build_mv_spectrum();
         std::vector<float> oscilloscope = build_mv_oscilloscope();
         mv_input.oscilloscope = &oscilloscope;
+        mv_input.rms = compute_oscilloscope_rms(oscilloscope);
+        mv_input.peak = compute_oscilloscope_peak(oscilloscope);
+        const std::size_t spectrum_size = mv_input.spectrum.size();
+        const std::size_t first_split = spectrum_size / 3;
+        const std::size_t second_split = (spectrum_size * 2) / 3;
+        mv_input.low = compute_spectrum_band_average(mv_input.spectrum, 0, first_split);
+        mv_input.mid = compute_spectrum_band_average(mv_input.spectrum, first_split, second_split);
+        mv_input.high = compute_spectrum_band_average(mv_input.spectrum, second_split, spectrum_size);
         mv_input.waveform = &state_.mv_waveform;
         mv_input.waveform_index =
             sample_mv_waveform_index(state_.mv_waveform, mv_input.current_ms, mv_input.song_length_ms);
         if (!state_.mv_waveform.empty()) {
             mv_input.level = state_.mv_waveform[static_cast<std::size_t>(mv_input.waveform_index)];
         }
+        if (state_.song_data.has_value()) {
+            mv_input.song_id = state_.song_data->meta.song_id;
+            mv_input.song_title = state_.song_data->meta.title;
+            mv_input.song_artist = state_.song_data->meta.artist;
+            mv_input.song_base_bpm = state_.song_data->meta.base_bpm;
+        }
         if (state_.chart_data.has_value()) {
+            mv_input.chart_id = state_.chart_data->meta.chart_id;
+            mv_input.chart_song_id = state_.chart_data->meta.song_id;
+            mv_input.chart_difficulty = state_.chart_data->meta.difficulty;
+            mv_input.chart_level = state_.chart_data->meta.level;
+            mv_input.chart_author = state_.chart_data->meta.chart_author;
+            mv_input.chart_resolution = state_.chart_data->meta.resolution;
+            mv_input.chart_offset = state_.chart_data->meta.offset;
             mv_input.total_notes = static_cast<int>(state_.chart_data->notes.size());
         }
         mv_input.screen_w = static_cast<float>(kScreenWidth);

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -47,6 +47,7 @@ const char* rank_label(rank r) {
     switch (r) {
         case rank::ss: return "SS";
         case rank::s:  return "S";
+        case rank::aa: return "AA";
         case rank::a:  return "A";
         case rank::b:  return "B";
         case rank::c:  return "C";
@@ -59,6 +60,7 @@ Color rank_color(rank r) {
     switch (r) {
         case rank::ss: return g_theme->rank_ss;
         case rank::s:  return g_theme->rank_s;
+        case rank::aa: return g_theme->rank_aa;
         case rank::a:  return g_theme->rank_a;
         case rank::b:  return g_theme->rank_b;
         case rank::c:  return g_theme->rank_c;

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -51,7 +51,7 @@ std::optional<rank> load_best_local_rank(const std::string& chart_id) {
     if (listing.entries.empty()) {
         return std::nullopt;
     }
-    return listing.entries.front().clear_rank;
+    return listing.entries.front().clear_rank();
 }
 
 }  // namespace

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -23,6 +23,7 @@ const char* rank_label(rank value) {
     switch (value) {
         case rank::ss: return "SS";
         case rank::s: return "S";
+        case rank::aa: return "AA";
         case rank::a: return "A";
         case rank::b: return "B";
         case rank::c: return "C";
@@ -36,6 +37,7 @@ Color rank_color(rank value) {
     switch (value) {
         case rank::ss: return theme.rank_ss;
         case rank::s: return theme.rank_s;
+        case rank::aa: return theme.rank_aa;
         case rank::a: return theme.rank_a;
         case rank::b: return theme.rank_b;
         case rank::c: return theme.rank_c;

--- a/src/scenes/song_select/song_select_list_view.cpp
+++ b/src/scenes/song_select/song_select_list_view.cpp
@@ -21,6 +21,7 @@ const char* rank_label(rank value) {
     switch (value) {
         case rank::ss: return "SS";
         case rank::s: return "S";
+        case rank::aa: return "AA";
         case rank::a: return "A";
         case rank::b: return "B";
         case rank::c: return "C";
@@ -34,6 +35,7 @@ Color rank_color(rank value) {
     switch (value) {
         case rank::ss: return theme.rank_ss;
         case rank::s: return theme.rank_s;
+        case rank::aa: return theme.rank_aa;
         case rank::a: return theme.rank_a;
         case rank::b: return theme.rank_b;
         case rank::c: return theme.rank_c;
@@ -48,8 +50,8 @@ void draw_song_row(const song_select::song_entry& song, float item_y, bool is_se
                                 song_select::layout::kSongListRect.width - 28.0f, 44.0f};
     const float text_x = song_select::layout::kSongListRect.x + 30.0f;
     const float list_text_max_w = song_select::layout::kSongListRect.width - 70.0f;
-    const Rectangle title_clip_rect = {text_x, item_y, list_text_max_w, 24.0f};
-    const Rectangle artist_clip_rect = {text_x, item_y + 22.0f, list_text_max_w, 16.0f};
+    const Rectangle title_clip_rect = {text_x, item_y - 3.0f, list_text_max_w, 24.0f};
+    const Rectangle artist_clip_rect = {text_x, item_y + 19.0f, list_text_max_w, 16.0f};
 
     if (ui::is_hovered(row_rect, song_select::layout::kSceneLayer) || is_selected) {
         const ui::row_state row_state = ui::draw_selectable_row(row_rect, is_selected, 0.0f);

--- a/src/scenes/song_select/song_select_ranking_view.cpp
+++ b/src/scenes/song_select/song_select_ranking_view.cpp
@@ -23,6 +23,7 @@ const char* rank_label(rank value) {
     switch (value) {
         case rank::ss: return "SS";
         case rank::s: return "S";
+        case rank::aa: return "AA";
         case rank::a: return "A";
         case rank::b: return "B";
         case rank::c: return "C";
@@ -35,6 +36,7 @@ Color rank_color(rank value) {
     switch (value) {
         case rank::ss: return g_theme->rank_ss;
         case rank::s: return g_theme->rank_s;
+        case rank::aa: return g_theme->rank_aa;
         case rank::a: return g_theme->rank_a;
         case rank::b: return g_theme->rank_b;
         case rank::c: return g_theme->rank_c;
@@ -158,7 +160,7 @@ void draw_ranking_row(const ranking_service::entry& entry, float y, float offset
     DrawRectangleLinesEx(rank_rect, 1.5f, with_alpha(theme.border_light, alpha));
 
     ui::draw_text_in_rect(TextFormat("%02d", entry.placement), 18, placement_rect, with_alpha(theme.text, alpha), ui::text_align::center);
-    ui::draw_text_in_rect(rank_label(entry.clear_rank), 17, rank_rect, with_alpha(rank_color(entry.clear_rank), alpha), ui::text_align::center);
+    ui::draw_text_in_rect(rank_label(entry.clear_rank()), 17, rank_rect, with_alpha(rank_color(entry.clear_rank()), alpha), ui::text_align::center);
     ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), 17, accuracy_rect, with_alpha(theme.text_secondary, alpha), ui::text_align::left);
     ui::draw_text_in_rect(TextFormat("%d Combo", entry.max_combo), 14, combo_rect, with_alpha(theme.text_muted, alpha), ui::text_align::left);
     ui::draw_text_in_rect(format_relative_recorded_at(entry.recorded_at).c_str(), 14, recorded_at_rect,

--- a/src/scenes/theme.h
+++ b/src/scenes/theme.h
@@ -90,6 +90,7 @@ struct ui_theme {
     // --- ランク色 ---
     Color rank_ss;
     Color rank_s;
+    Color rank_aa;
     Color rank_a;
     Color rank_b;
     Color rank_c;
@@ -99,7 +100,7 @@ struct ui_theme {
 // ライトテーマ
 inline constexpr ui_theme kLightTheme = {
     // bg
-    .bg = {255, 255, 255, 255},
+    .bg = {248, 251, 254, 255},
     .bg_alt = {241, 243, 246, 255},
     // panel
     .panel = {248, 249, 251, 255},
@@ -139,12 +140,12 @@ inline constexpr ui_theme kLightTheme = {
     .hud_combo_label = {230, 234, 242, 255},
     .hud_failure_text = {244, 246, 250, 255},
     // game elements
-    .lane = {226, 231, 238, 255},
-    .lane_pressed = {212, 217, 224, 255},
-    .lane_wire = {108, 118, 138, 210},
+    .lane = {180, 185, 187, 255},
+    .lane_pressed = {165, 168, 170, 255},
+    .lane_wire = {92, 102, 122, 220},
     .judge_line = {124, 58, 237, 120},
     .judge_line_glow = {196, 181, 253, 210},
-    .note_color = {250, 251, 253, 255},
+    .note_color = {245, 245, 248, 255},
     .note_outline = {120, 128, 138, 0},
     .pause_overlay = {3, 6, 10, 150},
     .pause_panel = {248, 249, 251, 245},
@@ -171,7 +172,8 @@ inline constexpr ui_theme kLightTheme = {
     // rank
     .rank_ss = {200, 50, 200, 255},
     .rank_s = {200, 50, 200, 255},
-    .rank_a = {220, 50, 50, 255},
+    .rank_aa = {220, 50, 50, 255},
+    .rank_a = {240, 120, 50, 255},
     .rank_b = {50, 100, 220, 255},
     .rank_c = {210, 180, 30, 255},
     .rank_f = {120, 120, 120, 255},
@@ -252,7 +254,8 @@ inline constexpr ui_theme kDarkTheme = {
     // rank
     .rank_ss = {220, 80, 220, 255},
     .rank_s = {220, 80, 220, 255},
-    .rank_a = {240, 70, 70, 255},
+    .rank_aa = {240, 70, 70, 255},
+    .rank_a = {255, 140, 70, 255},
     .rank_b = {80, 130, 240, 255},
     .rank_c = {230, 200, 50, 255},
     .rank_f = {140, 140, 140, 255},

--- a/src/tests/mv_api_smoke.cpp
+++ b/src/tests/mv_api_smoke.cpp
@@ -83,24 +83,29 @@ TEST(test_build_context) {
     ASSERT(std::get<double>(chart->get_attr("combo")) == 42.0);
     ASSERT(std::get<double>(chart->get_attr("key_count")) == 7.0);
 
-    // Check ctx.audio.spectrum
+    // Check ctx.audio.buffers / analysis
     auto audio_val = ctx->get_attr("audio");
     auto audio = std::get<std::shared_ptr<mv::mv_object>>(audio_val);
-    auto spec_val = audio->get_attr("spectrum");
+    auto buffers_val = audio->get_attr("buffers");
+    auto buffers = std::get<std::shared_ptr<mv::mv_object>>(buffers_val);
+    auto spec_val = buffers->get_attr("spectrum");
     auto spec = std::get<std::shared_ptr<mv::mv_list>>(spec_val);
     ASSERT(spec->elements.size() == 3);
 
-    auto waveform_val = audio->get_attr("waveform");
+    auto waveform_val = buffers->get_attr("waveform");
     auto waveform_list = std::get<std::shared_ptr<mv::mv_list>>(waveform_val);
     ASSERT(waveform_list->elements.size() == 4);
-    ASSERT(std::get<double>(audio->get_attr("waveform_size")) == 4.0);
-    ASSERT(std::abs(std::get<double>(audio->get_attr("level")) - 0.8) < 0.0001);
-    ASSERT(std::get<double>(audio->get_attr("waveform_index")) == 2.0);
+    ASSERT(std::get<double>(buffers->get_attr("waveform_size")) == 4.0);
+    ASSERT(std::get<double>(buffers->get_attr("waveform_index")) == 2.0);
 
-    auto osc_val = audio->get_attr("oscilloscope");
+    auto analysis_val = audio->get_attr("analysis");
+    auto analysis = std::get<std::shared_ptr<mv::mv_object>>(analysis_val);
+    ASSERT(std::abs(std::get<double>(analysis->get_attr("level")) - 0.8) < 0.0001);
+
+    auto osc_val = buffers->get_attr("oscilloscope");
     auto osc = std::get<std::shared_ptr<mv::mv_list>>(osc_val);
     ASSERT(osc->elements.size() == 3);
-    ASSERT(std::get<double>(audio->get_attr("oscilloscope_size")) == 3.0);
+    ASSERT(std::get<double>(buffers->get_attr("oscilloscope_size")) == 3.0);
 }
 
 // ---- Builtins in sandbox ----
@@ -124,7 +129,7 @@ def draw(ctx):
 TEST(test_builtins_scene_construction) {
     const char* src = R"(
 def draw(ctx):
-    r = Rect(x=10, y=20, w=100, h=50, fill="#ff0000")
+    r = DrawRect(x=10, y=20, w=100, h=50, fill="#ff0000")
     nodes = [r]
     return Scene(nodes)
 )";
@@ -148,7 +153,7 @@ TEST(test_builtins_rgb_color) {
     const char* src = R"(
 def draw(ctx):
     c = rgb(100, 200, 50)
-    r = Rect(x=0, y=0, w=10, h=10, fill=c)
+    r = DrawRect(x=0, y=0, w=10, h=10, fill=c)
     return Scene([r])
 )";
     mv::mv_runtime rt;
@@ -168,10 +173,10 @@ def draw(ctx):
 TEST(test_builtins_multiple_node_types) {
     const char* src = R"(
 def draw(ctx):
-    bg = Background(fill="#111111")
-    line = Line(x1=0, y1=0, x2=100, y2=100, thickness=3)
-    txt = Text(text="hello", x=50, y=50, font_size=24)
-    circ = Circle(cx=200, cy=200, radius=30)
+    bg = DrawBackground(fill="#111111")
+    line = DrawLine(x1=0, y1=0, x2=100, y2=100, thickness=3)
+    txt = DrawText(text="hello", x=50, y=50, font_size=24)
+    circ = DrawCircle(cx=200, cy=200, radius=30)
     return Scene([bg, line, txt, circ])
 )";
     mv::mv_runtime rt;
@@ -196,7 +201,7 @@ TEST(test_polyline_node_construction) {
     const char* src = R"(
 def draw(ctx):
     pts = [Point(x=0, y=0), Point(x=50, y=25), Point(x=100, y=0)]
-    Polyline(points=pts, stroke="#22ddaa", thickness=3.0, opacity=0.5)
+    DrawPolyline(points=pts, stroke="#22ddaa", thickness=3.0, opacity=0.5)
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -219,7 +224,7 @@ def draw(ctx):
     pts.append(Point(x=0, y=0))
     pts.append(Point(x=25, y=50))
     pts.append(Point(x=50, y=0))
-    Polyline(points=pts, stroke="#22ddaa", thickness=2.0, opacity=0.5)
+    DrawPolyline(points=pts, stroke="#22ddaa", thickness=2.0, opacity=0.5)
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -240,7 +245,7 @@ TEST(test_ctx_access_in_draw) {
 def draw(ctx):
     bpm = ctx.time.bpm
     beat = ctx.time.beat_phase
-    r = Rect(x=bpm, y=beat * 100, w=50, h=50)
+    r = DrawRect(x=bpm, y=beat * 100, w=50, h=50)
     return Scene([r])
 )";
     mv::mv_runtime rt;
@@ -262,9 +267,9 @@ def draw(ctx):
 TEST(test_ctx_audio_waveform_access_in_draw) {
     const char* src = R"(
 def draw(ctx):
-    x = ctx.audio.level * 100
-    y = ctx.audio.waveform[ctx.audio.waveform_index] * 100
-    Rect(x=x, y=y, w=20, h=20, fill="#ffffff")
+    x = ctx.audio.analysis.level * 100
+    y = ctx.audio.buffers.waveform[ctx.audio.buffers.waveform_index] * 100
+    DrawRect(x=x, y=y, w=20, h=20, fill="#ffffff")
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -287,10 +292,10 @@ def draw(ctx):
 TEST(test_ctx_audio_oscilloscope_access_in_draw) {
     const char* src = R"(
 def draw(ctx):
-    x = (ctx.audio.oscilloscope[0] + 1) * 50
-    y = (ctx.audio.oscilloscope[2] + 1) * 50
-    w = ctx.audio.oscilloscope_size * 10
-    Rect(x=x, y=y, w=w, h=20, fill="#ffffff")
+    x = (ctx.audio.buffers.oscilloscope[0] + 1) * 50
+    y = (ctx.audio.buffers.oscilloscope[2] + 1) * 50
+    w = ctx.audio.buffers.oscilloscope_size * 10
+    DrawRect(x=x, y=y, w=w, h=20, fill="#ffffff")
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -312,8 +317,8 @@ def draw(ctx):
 TEST(test_imperative_draw_without_return) {
     const char* src = R"(
 def draw(ctx):
-    Background(fill="#0a0a1a")
-    Circle(cx=640, cy=360, radius=80, fill="#00ccff", opacity=0.8)
+    DrawBackground(fill="#0a0a1a")
+    DrawCircle(cx=640, cy=360, radius=80, fill="#00ccff", opacity=0.8)
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -354,11 +359,11 @@ def draw(ctx):
     bar_w = ctx.screen.w - 100
     filled = bar_w * ctx.time.progress
 
-    Rect(x=50, y=680, w=bar_w, h=6, fill="#333333")
-    Rect(x=50, y=680, w=filled, h=6, fill="#00ff88")
+    DrawRect(x=50, y=680, w=bar_w, h=6, fill="#333333")
+    DrawRect(x=50, y=680, w=filled, h=6, fill="#00ff88")
 
     pct = str(int(ctx.time.progress * 100)) + "%"
-    Text(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")
+    DrawText(text=pct, x=50, y=656, font_size=16, fill="#aaaaaa")
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -385,61 +390,18 @@ def draw(ctx):
     ASSERT(pct->text == "50%");
 }
 
-TEST(test_legacy_beat_grid_and_spectrum_bar_scene) {
-    const char* src = R"(
-def draw(ctx):
-    bg = Background(fill="#0b0f18")
-    spec = SpectrumBar(x=140, y=520, w=1000, h=180, bar_count=48, fill="#64c8ff", opacity=0.7)
-    grid = BeatGrid(stroke="#ffffff1e", thickness=1.0, beat_phase=ctx.time.beat_phase, opacity=0.4)
-    return Scene([bg, grid, spec])
-)";
-
-    const std::filesystem::path temp_path =
-        std::filesystem::temp_directory_path() / "raythm_mv_api_beat_grid_test.rmv";
-    {
-        std::ofstream ofs(temp_path);
-        ofs << src;
-    }
-
-    mv::mv_runtime rt;
-    ASSERT(rt.load_file(temp_path.string()));
-
-    mv::context_input input;
-    input.beat_phase = 0.25f;
-    input.spectrum = {0.1f, 0.3f, 0.6f};
-
-    auto scene = rt.tick(input);
-    ASSERT(scene.has_value());
-    ASSERT(scene->nodes.size() == 3);
-    ASSERT(std::holds_alternative<mv::background_node>(scene->nodes[0]));
-    ASSERT(std::holds_alternative<mv::beat_grid_node>(scene->nodes[1]));
-    ASSERT(std::holds_alternative<mv::spectrum_bar_node>(scene->nodes[2]));
-
-    auto* grid = std::get_if<mv::beat_grid_node>(&scene->nodes[1]);
-    ASSERT(grid != nullptr);
-    ASSERT(std::abs(grid->beat_phase - 0.25f) < 0.01f);
-
-    auto* spec = std::get_if<mv::spectrum_bar_node>(&scene->nodes[2]);
-    ASSERT(spec != nullptr);
-    ASSERT(spec->spectrum.size() == 3);
-    ASSERT(std::abs(spec->spectrum[1] - 0.3f) < 0.01f);
-
-    std::error_code ec;
-    std::filesystem::remove(temp_path, ec);
-}
-
 TEST(test_manual_spectrum_scene_from_primitives) {
     const char* src = R"(
 def draw(ctx):
-    Background(fill="#0b0f18")
+    DrawBackground(fill="#0b0f18")
 
-    count = min(len(ctx.audio.spectrum), 4)
+    count = min(len(ctx.audio.buffers.spectrum), 4)
     if count > 0:
         bar_w = 200 / count
         for i in range(count):
-            amp = ctx.audio.spectrum[i]
+            amp = ctx.audio.buffers.spectrum[i]
             h = 100 * amp
-            Rect(x=100 + i * bar_w, y=200 - h, w=bar_w - 2, h=h, fill="#64c8ff", opacity=0.7)
+            DrawRect(x=100 + i * bar_w, y=200 - h, w=bar_w - 2, h=h, fill="#64c8ff", opacity=0.7)
 )";
     mv::mv_runtime rt;
     ASSERT(rt.load_source(src));
@@ -526,7 +488,7 @@ TEST(test_for_loop_builds_nodes) {
 def draw(ctx):
     nodes = []
     for i in range(5):
-        nodes = nodes + [Rect(x=i * 10, y=0, w=10, h=10)]
+        nodes = nodes + [DrawRect(x=i * 10, y=0, w=10, h=10)]
     return Scene(nodes)
 )";
     mv::mv_runtime rt;
@@ -562,7 +524,6 @@ int main() {
     RUN(test_unknown_function_fails_compile);
     RUN(test_unknown_variable_fails_compile);
     RUN(test_imperative_progress_bar_draw);
-    RUN(test_legacy_beat_grid_and_spectrum_bar_scene);
     RUN(test_manual_spectrum_scene_from_primitives);
     RUN(test_validator_truncates_nodes);
     RUN(test_validator_sanitizes_nan);
@@ -573,3 +534,4 @@ int main() {
     std::printf("\n%d passed, %d failed\n", tests_passed, tests_failed);
     return tests_failed > 0 ? 1 : 0;
 }
+

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -27,12 +27,14 @@ int main() {
     result_data lower_result;
     lower_result.clear_rank = rank::a;
     lower_result.accuracy = 92.5f;
+    lower_result.is_full_combo = false;
     lower_result.max_combo = 321;
     lower_result.score = 654321;
 
     result_data higher_result;
     higher_result.clear_rank = rank::s;
     higher_result.accuracy = 97.25f;
+    higher_result.is_full_combo = true;
     higher_result.max_combo = 654;
     higher_result.score = 765432;
 

--- a/src/tests/score_system_smoke.cpp
+++ b/src/tests/score_system_smoke.cpp
@@ -88,8 +88,8 @@ int main() {
         non_fc_high_accuracy.on_judge({judge_result::perfect, 0.0, 0});
     }
     const result_data non_fc_result = non_fc_high_accuracy.get_result_data();
-    if (non_fc_result.accuracy < 99.0f || non_fc_result.is_full_combo || non_fc_result.clear_rank != rank::a) {
-        std::cerr << "99% without full combo should be rank A\n";
+    if (non_fc_result.accuracy < 99.0f || non_fc_result.is_full_combo || non_fc_result.clear_rank != rank::aa) {
+        std::cerr << "99% without full combo should be rank AA\n";
         return EXIT_FAILURE;
     }
 

--- a/src/ui/ui_text_editor.cpp
+++ b/src/ui/ui_text_editor.cpp
@@ -1,7 +1,9 @@
 #include "ui_text_editor.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
+#include <cstdio>
 #include <sstream>
 
 #include "ui_font.h"
@@ -16,6 +18,125 @@ namespace {
 constexpr float kGutterPadding = 6.0f;
 constexpr float kScrollbarWidth = 8.0f;
 constexpr float kTextPadLeft = 4.0f;
+constexpr size_t kMaxUndoSnapshots = 100;
+constexpr float kColorSwatchSize = 16.0f;
+constexpr float kColorSwatchGap = 6.0f;
+constexpr float kColorPickerWidth = 248.0f;
+constexpr float kColorPickerPreviewHeight = 30.0f;
+constexpr float kColorPickerRowHeight = 28.0f;
+constexpr float kColorPickerPadding = 10.0f;
+
+struct color_literal_marker {
+    int col_start = 0;
+    int col_end = 0;
+    char quote = '"';
+    bool has_alpha = false;
+    Color color = WHITE;
+};
+
+struct color_swatch_hit {
+    Rectangle rect = {};
+    color_literal_marker marker = {};
+};
+
+bool replace_range_on_line(text_editor_state& state, int line_index, int col_start, int col_end,
+                           const std::string& text);
+void push_undo_snapshot(text_editor_state& state);
+
+constexpr float color_swatch_inline_width() {
+    return kColorSwatchGap + kColorSwatchSize + kColorSwatchGap;
+}
+
+int hex_nibble(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+}
+
+bool parse_hex_byte(char hi, char lo, unsigned char& out) {
+    const int hi_value = hex_nibble(hi);
+    const int lo_value = hex_nibble(lo);
+    if (hi_value < 0 || lo_value < 0) {
+        return false;
+    }
+    out = static_cast<unsigned char>((hi_value << 4) | lo_value);
+    return true;
+}
+
+bool try_parse_color_literal_token(const std::string& token, Color& color) {
+    if (token.size() < 9) {
+        return false;
+    }
+
+    const char quote = token.front();
+    if ((quote != '"' && quote != '\'') || token.back() != quote) {
+        return false;
+    }
+
+    const std::string_view value(token.c_str() + 1, token.size() - 2);
+    if ((value.size() != 7 && value.size() != 9) || value.front() != '#') {
+        return false;
+    }
+
+    unsigned char r = 0;
+    unsigned char g = 0;
+    unsigned char b = 0;
+    unsigned char a = 255;
+    if (!parse_hex_byte(value[1], value[2], r) ||
+        !parse_hex_byte(value[3], value[4], g) ||
+        !parse_hex_byte(value[5], value[6], b)) {
+        return false;
+    }
+    if (value.size() == 9 && !parse_hex_byte(value[7], value[8], a)) {
+        return false;
+    }
+
+    color = {r, g, b, a};
+    return true;
+}
+
+std::vector<color_literal_marker> find_color_literal_markers(const std::string& line,
+                                                             text_editor_highlighter highlighter) {
+    std::vector<color_literal_marker> markers;
+    const std::vector<text_editor_span> spans =
+        highlighter != nullptr ? highlighter(line) : std::vector<text_editor_span>{{line, WHITE}};
+
+    int consumed = 0;
+    for (const auto& span : spans) {
+        if (span.text.empty()) {
+            continue;
+        }
+
+        Color color = WHITE;
+        if (try_parse_color_literal_token(span.text, color)) {
+            const char quote = span.text.front();
+            const int value_len = static_cast<int>(span.text.size()) - 2;
+            markers.push_back({
+                .col_start = consumed,
+                .col_end = consumed + static_cast<int>(span.text.size()),
+                .quote = quote,
+                .has_alpha = value_len == 9,
+                .color = color,
+            });
+        }
+        consumed += static_cast<int>(span.text.size());
+    }
+
+    return markers;
+}
+
+std::string format_color_literal_token(Color color, char quote, bool has_alpha) {
+    char buffer[16] = {};
+    if (has_alpha) {
+        std::snprintf(buffer, sizeof(buffer), "%c#%02X%02X%02X%02X%c",
+                      quote, color.r, color.g, color.b, color.a, quote);
+    } else {
+        std::snprintf(buffer, sizeof(buffer), "%c#%02X%02X%02X%c",
+                      quote, color.r, color.g, color.b, quote);
+    }
+    return buffer;
+}
 
 float measure_text_width(const std::string& text, const text_editor_style& style) {
     if (text.empty()) {
@@ -30,7 +151,61 @@ float measure_line_prefix_width(const std::string& line, int prefix_len,
     if (clamped_prefix_len == 0) {
         return 0.0f;
     }
-    return measure_text_width(line.substr(0, static_cast<size_t>(clamped_prefix_len)), style);
+    float width = measure_text_width(line.substr(0, static_cast<size_t>(clamped_prefix_len)), style);
+    if (highlighter != nullptr) {
+        const auto markers = find_color_literal_markers(line, highlighter);
+        for (const auto& marker : markers) {
+            if (marker.col_end <= clamped_prefix_len) {
+                width += color_swatch_inline_width();
+            }
+        }
+    }
+    return width;
+}
+
+float color_swatch_y(float line_y, const text_editor_style& style) {
+    return line_y + std::max(1.0f, (static_cast<float>(style.font_size) - kColorSwatchSize) * 0.5f);
+}
+
+Rectangle color_swatch_rect(const std::string& line, const color_literal_marker& marker,
+                            Rectangle text_rect, float line_y,
+                            const text_editor_style& style, text_editor_highlighter highlighter) {
+    return {
+        text_rect.x + kTextPadLeft +
+            measure_line_prefix_width(line, marker.col_end, style, highlighter) -
+            (kColorSwatchGap + kColorSwatchSize),
+        color_swatch_y(line_y, style),
+        kColorSwatchSize,
+        kColorSwatchSize
+    };
+}
+
+std::vector<color_swatch_hit> collect_visible_color_swatches(const text_editor_state& state,
+                                                             Rectangle rect, Rectangle text_rect,
+                                                             float line_height,
+                                                             const text_editor_style& style,
+                                                             text_editor_highlighter highlighter) {
+    std::vector<color_swatch_hit> hits;
+    if (highlighter == nullptr) {
+        return hits;
+    }
+
+    const int first_visible_line = std::max(0, static_cast<int>(state.scroll_offset / line_height));
+    const int last_visible_line = std::min(static_cast<int>(state.lines.size()) - 1,
+                                           static_cast<int>((state.scroll_offset + rect.height) / line_height));
+
+    for (int i = first_visible_line; i <= last_visible_line; ++i) {
+        const std::vector<color_literal_marker> markers = find_color_literal_markers(state.lines[i], highlighter);
+        const float line_y = rect.y + i * line_height - state.scroll_offset;
+        for (const auto& marker : markers) {
+            hits.push_back({
+                color_swatch_rect(state.lines[i], marker, text_rect, line_y, style, highlighter),
+                marker
+            });
+        }
+    }
+
+    return hits;
 }
 
 void draw_line_text(const std::string& line, float x, float y,
@@ -48,12 +223,220 @@ void draw_line_text(const std::string& line, float x, float y,
     int consumed = 0;
     for (const auto& span : spans) {
         if (!span.text.empty()) {
-            const float cursor_x = x + measure_line_prefix_width(line, consumed, style, nullptr);
+            const float cursor_x = x + measure_line_prefix_width(line, consumed, style, highlighter);
             draw_text_auto(span.text.c_str(), {cursor_x, y}, static_cast<float>(style.font_size),
                            style.letter_spacing, span.color);
+            const float token_width = measure_text_width(span.text, style);
+            Color swatch_color{};
+            if (try_parse_color_literal_token(span.text, swatch_color)) {
+                const Rectangle swatch_rect = {
+                    cursor_x + token_width + kColorSwatchGap,
+                    y + std::max(1.0f, (static_cast<float>(style.font_size) - kColorSwatchSize) * 0.5f),
+                    kColorSwatchSize,
+                    kColorSwatchSize
+                };
+                DrawRectangleRounded(swatch_rect, 0.22f, 4, swatch_color);
+                DrawRectangleRoundedLinesEx(swatch_rect, 0.22f, 4, 1.0f, with_alpha(g_theme->border_light, 220));
+            }
             consumed += static_cast<int>(span.text.size());
         }
     }
+}
+
+float popup_height_for_picker(const text_editor_color_picker_state& picker) {
+    return kColorPickerPadding * 2.0f + kColorPickerPreviewHeight +
+           (picker.has_alpha ? 4.0f : 0.0f) +
+           (picker.has_alpha ? 4.0f : 3.0f) * kColorPickerRowHeight;
+}
+
+Rectangle color_picker_rect(const Rectangle& editor_rect, Rectangle anchor_rect,
+                            const text_editor_color_picker_state& picker) {
+    const float height = popup_height_for_picker(picker);
+    Rectangle rect = {
+        std::clamp(anchor_rect.x,
+                   editor_rect.x + 10.0f,
+                   editor_rect.x + editor_rect.width - kColorPickerWidth - 10.0f),
+        std::clamp(anchor_rect.y - 8.0f,
+                   editor_rect.y + 10.0f,
+                   editor_rect.y + editor_rect.height - height - 10.0f),
+        kColorPickerWidth,
+        height
+    };
+    return rect;
+}
+
+bool apply_color_picker_change(text_editor_state& state) {
+    if (state.color_picker.line < 0 || state.color_picker.line >= static_cast<int>(state.lines.size())) {
+        return false;
+    }
+    const std::string token = format_color_literal_token(state.color_picker.color,
+                                                         state.color_picker.quote,
+                                                         state.color_picker.has_alpha);
+    if (replace_range_on_line(state,
+                              state.color_picker.line,
+                              state.color_picker.col_start,
+                              state.color_picker.col_end,
+                              token)) {
+        state.color_picker.col_end = state.color_picker.col_start + static_cast<int>(token.size());
+        return true;
+    }
+    return false;
+}
+
+void open_color_picker(text_editor_state& state, const color_swatch_hit& hit,
+                       Rectangle anchor_rect, float line_height, Rectangle editor_rect) {
+    state.color_picker.open = true;
+    state.color_picker.line = static_cast<int>((hit.rect.y - editor_rect.y + state.scroll_offset) / line_height);
+    state.color_picker.col_start = hit.marker.col_start;
+    state.color_picker.col_end = hit.marker.col_end;
+    state.color_picker.quote = hit.marker.quote;
+    state.color_picker.has_alpha = hit.marker.has_alpha;
+    state.color_picker.color = hit.marker.color;
+    state.color_picker.edit_started = false;
+    state.color_picker.active_channel = -1;
+    state.color_picker.anchor_rect = anchor_rect;
+    state.color_picker.has_anchor = true;
+    state.active = true;
+    state.mouse_selecting = false;
+    state.has_selection = false;
+}
+
+void close_color_picker(text_editor_state& state) {
+    state.color_picker.open = false;
+    state.color_picker.active_channel = -1;
+    state.color_picker.has_anchor = false;
+}
+
+bool ensure_color_picker_anchor(text_editor_state& state, Rectangle rect, Rectangle text_rect,
+                                float line_height, const text_editor_style& style,
+                                text_editor_highlighter highlighter, Rectangle& picker_rect) {
+    if (!state.color_picker.open ||
+        state.color_picker.line < 0 ||
+        state.color_picker.line >= static_cast<int>(state.lines.size())) {
+        if (state.color_picker.open) {
+            close_color_picker(state);
+        }
+        picker_rect = {};
+        return false;
+    }
+
+    if (!state.color_picker.has_anchor) {
+        const color_literal_marker marker{
+            .col_start = state.color_picker.col_start,
+            .col_end = state.color_picker.col_end,
+            .quote = state.color_picker.quote,
+            .has_alpha = state.color_picker.has_alpha,
+            .color = state.color_picker.color,
+        };
+        const float line_y = rect.y + state.color_picker.line * line_height - state.scroll_offset;
+        state.color_picker.anchor_rect =
+            color_swatch_rect(state.lines[state.color_picker.line], marker, text_rect, line_y, style, highlighter);
+        state.color_picker.has_anchor = true;
+    }
+
+    picker_rect = color_picker_rect(rect, state.color_picker.anchor_rect, state.color_picker);
+    return true;
+}
+
+bool draw_color_picker(Rectangle picker_rect, text_editor_state& state, text_editor_result& result,
+                       Vector2 mouse) {
+    if (!state.color_picker.open || picker_rect.width <= 0.0f || picker_rect.height <= 0.0f) {
+        return false;
+    }
+
+    const float pad = kColorPickerPadding;
+    DrawRectangleRounded(picker_rect, 0.12f, 6, with_alpha(g_theme->panel, 248));
+    DrawRectangleRoundedLinesEx(picker_rect, 0.12f, 6, 1.0f, g_theme->border_active);
+
+    const Rectangle preview_rect = {
+        picker_rect.x + pad,
+        picker_rect.y + pad,
+        34.0f,
+        kColorPickerPreviewHeight
+    };
+    DrawRectangleRounded(preview_rect, 0.18f, 4, state.color_picker.color);
+    DrawRectangleRoundedLinesEx(preview_rect, 0.18f, 4, 1.0f, with_alpha(g_theme->border_light, 220));
+
+    const std::string hex_label = format_color_literal_token(state.color_picker.color,
+                                                             state.color_picker.quote,
+                                                             state.color_picker.has_alpha);
+    draw_text_auto(hex_label.c_str(),
+                   {preview_rect.x + preview_rect.width + 10.0f, preview_rect.y + 5.0f},
+                   13.0f, 0.5f, g_theme->text);
+
+    const char channel_labels[4] = {'R', 'G', 'B', 'A'};
+    unsigned char* channel_ptrs[4] = {
+        &state.color_picker.color.r,
+        &state.color_picker.color.g,
+        &state.color_picker.color.b,
+        &state.color_picker.color.a,
+    };
+    const Color channel_colors[4] = {
+        Color{255, 90, 90, 255},
+        Color{90, 220, 120, 255},
+        Color{100, 170, 255, 255},
+        Color{220, 220, 220, 255},
+    };
+    const int channel_count = state.color_picker.has_alpha ? 4 : 3;
+    bool picker_changed = false;
+
+    if (!IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        state.color_picker.active_channel = -1;
+    }
+
+    for (int channel = 0; channel < channel_count; ++channel) {
+        const float row_y = preview_rect.y + preview_rect.height + 10.0f +
+                            channel * kColorPickerRowHeight;
+        const Rectangle track_rect = {
+            picker_rect.x + pad + 22.0f,
+            row_y + 9.0f,
+            picker_rect.width - pad * 2.0f - 58.0f,
+            10.0f
+        };
+        const Rectangle row_rect = {
+            picker_rect.x + pad,
+            row_y,
+            picker_rect.width - pad * 2.0f,
+            kColorPickerRowHeight
+        };
+
+        draw_text_auto(TextFormat("%c", channel_labels[channel]),
+                       {row_rect.x, row_rect.y + 4.0f}, 13.0f, 0.5f, g_theme->text_secondary);
+
+        DrawRectangleRec(track_rect, g_theme->slider_track);
+        const float ratio = static_cast<float>(*channel_ptrs[channel]) / 255.0f;
+        draw_rect_f(track_rect.x, track_rect.y, track_rect.width * ratio, track_rect.height, channel_colors[channel]);
+        const float knob_x = track_rect.x + track_rect.width * ratio;
+        draw_rect_f(knob_x - 5.0f, track_rect.y - 6.0f, 10.0f, 22.0f,
+                    state.color_picker.active_channel == channel ? g_theme->border_active : g_theme->slider_knob);
+
+        draw_text_auto(TextFormat("%3d", static_cast<int>(*channel_ptrs[channel])),
+                       {track_rect.x + track_rect.width + 8.0f, row_rect.y + 4.0f},
+                       13.0f, 0.5f, g_theme->text_secondary);
+
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, row_rect)) {
+            state.color_picker.active_channel = channel;
+        }
+
+        if (state.color_picker.active_channel == channel && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+            const float next_ratio = std::clamp((mouse.x - track_rect.x) / track_rect.width, 0.0f, 1.0f);
+            const unsigned char next_value = static_cast<unsigned char>(std::lround(next_ratio * 255.0f));
+            if (*channel_ptrs[channel] != next_value) {
+                if (!state.color_picker.edit_started) {
+                    push_undo_snapshot(state);
+                    state.color_picker.edit_started = true;
+                }
+                *channel_ptrs[channel] = next_value;
+                if (apply_color_picker_change(state)) {
+                    result.changed = true;
+                    state.last_input_time = GetTime();
+                    picker_changed = true;
+                }
+            }
+        }
+    }
+
+    return picker_changed;
 }
 
 void draw_squiggly_line(float x0, float x1, float y, Color color) {
@@ -222,6 +605,52 @@ void start_selection_if_shift(text_editor_state& state, bool shift) {
     }
 }
 
+text_editor_undo_snapshot make_undo_snapshot(const text_editor_state& state) {
+    return {
+        .lines = state.lines,
+        .cursor_line = state.cursor_line,
+        .cursor_col = state.cursor_col,
+        .scroll_offset = state.scroll_offset,
+        .has_selection = state.has_selection,
+        .sel_anchor = state.sel_anchor,
+    };
+}
+
+void push_undo_snapshot(text_editor_state& state) {
+    if (!state.undo_stack.empty()) {
+        const auto& last = state.undo_stack.back();
+        if (last.lines == state.lines &&
+            last.cursor_line == state.cursor_line &&
+            last.cursor_col == state.cursor_col &&
+            last.scroll_offset == state.scroll_offset &&
+            last.has_selection == state.has_selection &&
+            last.sel_anchor == state.sel_anchor) {
+            return;
+        }
+    }
+    state.undo_stack.push_back(make_undo_snapshot(state));
+    if (state.undo_stack.size() > kMaxUndoSnapshots) {
+        state.undo_stack.erase(state.undo_stack.begin());
+    }
+}
+
+bool pop_undo_snapshot(text_editor_state& state) {
+    if (state.undo_stack.empty()) {
+        return false;
+    }
+    const text_editor_undo_snapshot snapshot = std::move(state.undo_stack.back());
+    state.undo_stack.pop_back();
+    state.lines = snapshot.lines.empty() ? std::vector<std::string>{""} : snapshot.lines;
+    state.cursor_line = snapshot.cursor_line;
+    state.cursor_col = snapshot.cursor_col;
+    state.scroll_offset = snapshot.scroll_offset;
+    state.has_selection = snapshot.has_selection;
+    state.sel_anchor = snapshot.sel_anchor;
+    state.mouse_selecting = false;
+    clamp_cursor(state);
+    return true;
+}
+
 } // anonymous namespace
 
 std::string text_editor_get_text(const text_editor_state& state) {
@@ -246,6 +675,10 @@ void text_editor_set_text(text_editor_state& state, const std::string& text) {
     state.cursor_line = 0;
     state.cursor_col = 0;
     state.scroll_offset = 0.0f;
+    state.has_selection = false;
+    state.mouse_selecting = false;
+    state.undo_stack.clear();
+    state.color_picker = {};
 }
 
 text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
@@ -275,7 +708,23 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
     };
 
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
-    const bool hovered = CheckCollisionPointRec(mouse, rect);
+    const std::vector<color_swatch_hit> swatch_hits =
+        collect_visible_color_swatches(state, rect, text_rect, line_height, style, highlighter);
+    int hovered_swatch_index = -1;
+    for (int i = 0; i < static_cast<int>(swatch_hits.size()); ++i) {
+        if (CheckCollisionPointRec(mouse, swatch_hits[static_cast<size_t>(i)].rect)) {
+            hovered_swatch_index = i;
+            break;
+        }
+    }
+
+    Rectangle picker_rect = {};
+    const bool has_picker_rect =
+        ensure_color_picker_anchor(state, rect, text_rect, line_height, style, highlighter, picker_rect);
+
+    const bool pointer_on_swatch = hovered_swatch_index >= 0;
+    const bool pointer_on_picker = has_picker_rect && CheckCollisionPointRec(mouse, picker_rect);
+    const bool hovered = CheckCollisionPointRec(mouse, rect) || pointer_on_picker;
     text_editor_completion_result completion;
     if (completer != nullptr && state.active && !state.mouse_selecting) {
         completion = completer(state.lines, state.cursor_line, state.cursor_col);
@@ -323,7 +772,10 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
     };
 
     // Click to set cursor position + start mouse selection
-    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && CheckCollisionPointRec(mouse, text_rect)) {
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+        CheckCollisionPointRec(mouse, text_rect) &&
+        !pointer_on_swatch &&
+        !pointer_on_picker) {
         auto pos = mouse_to_cursor(mouse);
         state.cursor_line = pos.line;
         state.cursor_col = pos.col;
@@ -335,7 +787,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
     }
 
     // Drag to extend selection
-    if (state.mouse_selecting && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+    if (state.mouse_selecting && IsMouseButtonDown(MOUSE_BUTTON_LEFT) && !pointer_on_picker) {
         auto pos = mouse_to_cursor(mouse);
         state.cursor_line = pos.line;
         state.cursor_col = pos.col;
@@ -357,12 +809,21 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         const bool shift = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
         const bool has_completion = !completion.items.empty();
         bool completion_navigation_handled = false;
+        bool edit_snapshot_recorded = false;
+
+        auto record_edit_snapshot = [&]() {
+            if (!edit_snapshot_recorded) {
+                push_undo_snapshot(state);
+                edit_snapshot_recorded = true;
+            }
+        };
 
         auto accept_completion = [&]() -> bool {
             if (!has_completion || state.completion_index < 0 ||
                 state.completion_index >= static_cast<int>(completion.items.size())) {
                 return false;
             }
+            record_edit_snapshot();
             if (replace_range_on_line(state, state.cursor_line,
                                       completion.replace_start, completion.replace_end,
                                       completion.items[static_cast<size_t>(state.completion_index)].insert_text)) {
@@ -392,9 +853,18 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         // Cut: Ctrl+X
         if (ctrl && IsKeyPressed(KEY_X) && state.has_selection) {
             SetClipboardText(get_selection_text(state).c_str());
+            record_edit_snapshot();
             delete_selection(state);
             result.changed = true;
             state.last_input_time = GetTime();
+        }
+
+        if (ctrl && !shift && IsKeyPressed(KEY_Z)) {
+            if (pop_undo_snapshot(state)) {
+                result.changed = true;
+                state.last_input_time = GetTime();
+                should_ensure_cursor_visible = true;
+            }
         }
 
         if (has_completion && IsKeyPressed(KEY_UP)) {
@@ -420,6 +890,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
             int codepoint = GetCharPressed();
             while (codepoint > 0) {
                 if (codepoint >= 32 && codepoint <= 126) {
+                    record_edit_snapshot();
                     if (state.has_selection) {
                         delete_selection(state);
                     }
@@ -437,6 +908,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
             if (ctrl && IsKeyPressed(KEY_V)) {
                 const char* clipboard = GetClipboardText();
                 if (clipboard != nullptr && clipboard[0] != '\0') {
+                    record_edit_snapshot();
                     if (state.has_selection) {
                         delete_selection(state);
                     }
@@ -450,6 +922,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
 
             // Tab → 2 spaces (replace selection if active)
             if (IsKeyPressed(KEY_TAB)) {
+                record_edit_snapshot();
                 if (state.has_selection) {
                     delete_selection(state);
                 }
@@ -463,6 +936,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
 
             // Enter → new line (replace selection if active)
             if (IsKeyPressed(KEY_ENTER) && static_cast<int>(state.lines.size()) < max_lines) {
+                record_edit_snapshot();
                 if (state.has_selection) {
                     delete_selection(state);
                 }
@@ -481,14 +955,17 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         // Backspace (delete selection or single char)
         if (key_action(KEY_BACKSPACE)) {
             if (state.has_selection) {
+                record_edit_snapshot();
                 delete_selection(state);
                 result.changed = true;
             } else if (state.cursor_col > 0) {
+                record_edit_snapshot();
                 auto& line = state.lines[state.cursor_line];
                 line.erase(state.cursor_col - 1, 1);
                 state.cursor_col--;
                 result.changed = true;
             } else if (state.cursor_line > 0) {
+                record_edit_snapshot();
                 int prev_len = static_cast<int>(state.lines[state.cursor_line - 1].size());
                 state.lines[state.cursor_line - 1] += state.lines[state.cursor_line];
                 state.lines.erase(state.lines.begin() + state.cursor_line);
@@ -503,14 +980,17 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
         // Delete (delete selection or single char)
         if (key_action(KEY_DELETE)) {
             if (state.has_selection) {
+                record_edit_snapshot();
                 delete_selection(state);
                 result.changed = true;
             } else {
                 auto& line = state.lines[state.cursor_line];
                 if (state.cursor_col < static_cast<int>(line.size())) {
+                    record_edit_snapshot();
                     line.erase(state.cursor_col, 1);
                     result.changed = true;
                 } else if (state.cursor_line + 1 < static_cast<int>(state.lines.size())) {
+                    record_edit_snapshot();
                     line += state.lines[state.cursor_line + 1];
                     state.lines.erase(state.lines.begin() + state.cursor_line + 1);
                     result.changed = true;
@@ -608,6 +1088,24 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                                         state.scrollbar_dragging, state.scrollbar_drag_offset);
     if (sb.changed) {
         state.scroll_offset = sb.scroll_offset;
+    }
+
+    int clicked_swatch_index = -1;
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
+        clicked_swatch_index = hovered_swatch_index;
+    }
+
+    if (clicked_swatch_index >= 0) {
+        const auto& hit = swatch_hits[static_cast<size_t>(clicked_swatch_index)];
+        open_color_picker(state, hit, hit.rect, line_height, rect);
+    }
+
+    if (state.color_picker.open) {
+        if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+            clicked_swatch_index < 0 &&
+            !CheckCollisionPointRec(mouse, picker_rect)) {
+            close_color_picker(state);
+        }
     }
 
     // ---- Rendering ----
@@ -795,6 +1293,10 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                 }
             }
         }
+    }
+
+    if (draw_color_picker(picker_rect, state, result, mouse)) {
+        should_ensure_cursor_visible = true;
     }
 
     return result;

--- a/src/ui/ui_text_editor.h
+++ b/src/ui/ui_text_editor.h
@@ -49,6 +49,29 @@ struct text_editor_error_marker {
     std::string message;
 };
 
+struct text_editor_undo_snapshot {
+    std::vector<std::string> lines = {""};
+    int cursor_line = 0;
+    int cursor_col = 0;
+    float scroll_offset = 0.0f;
+    bool has_selection = false;
+    text_editor_cursor sel_anchor = {};
+};
+
+struct text_editor_color_picker_state {
+    bool open = false;
+    int line = 0;
+    int col_start = 0;
+    int col_end = 0;
+    char quote = '"';
+    bool has_alpha = false;
+    Color color = WHITE;
+    bool edit_started = false;
+    int active_channel = -1;
+    bool has_anchor = false;
+    Rectangle anchor_rect = {};
+};
+
 struct text_editor_state {
     std::vector<std::string> lines = {""};
     int cursor_line = 0;
@@ -65,6 +88,8 @@ struct text_editor_state {
     // Inline error markers (set externally)
     std::vector<text_editor_error_marker> error_markers;
     int completion_index = 0;
+    std::vector<text_editor_undo_snapshot> undo_stack;
+    text_editor_color_picker_state color_picker;
 };
 
 struct text_editor_result {


### PR DESCRIPTION
MVの描画プリミティブをDrawRect/DrawLine/DrawText/DrawCircle/DrawPolyline/DrawBackgroundにリネームし、サンプルおよび組み込み関数をそれに応じて更新する。オーディオを ctx.audio.analysis / ctx.audio.bands / ctx.audio.buffers (spectrum/waveform/oscilloscope) に再編成し、追加のフィールド (level/rms/peak/low/mid/high) および song/chart メタデータを公開する。timing_engine にメーターのサポート（メーターセグメント、解析、ゲッター）および関連するコンテキストフィールド（meter_numerator/denominator）を追加する。ランキングのシリアライズを V3 に更新（is_full_combo を永続化）、compute_rank() および AA ランクを追加、エントリ/結果モデルを調整、score_system を compute_rank を使用するように移行。その他：API の変更に対応するための sandbox/type スキーマおよびコンパイラの調整を追加。互換性および古いランキング形式のバックワードパースのためにサンプルとテストを更新。

