### PR TITLE
Fix portrait letterboxing in gameplay

### DIFF
--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -182,6 +182,7 @@ std::array<Rectangle, 3> pause_button_rects() {
 }
 
 void draw_status(const play_session_state& state) {
+    ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
     DrawText("Play", 96, 90, 44, g_theme->error);
     DrawText(state.status_text.c_str(), 96, 170, 28, g_theme->text);
@@ -189,6 +190,7 @@ void draw_status(const play_session_state& state) {
 }
 
 void draw_world_background() {
+    ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
 }
 

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -191,7 +191,7 @@ void draw_status(const play_session_state& state) {
 
 void draw_world_background() {
     ClearBackground(g_theme->bg);
-    DrawRectangleGradientV(0, 0, GetScreenWidth(), GetScreenHeight(), g_theme->bg, g_theme->bg_alt);
+    DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
 }
 
 void draw_world(const play_session_state& state, const play_note_draw_queue& draw_queue,

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -182,7 +182,6 @@ std::array<Rectangle, 3> pause_button_rects() {
 }
 
 void draw_status(const play_session_state& state) {
-    ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
     DrawText("Play", 96, 90, 44, g_theme->error);
     DrawText(state.status_text.c_str(), 96, 170, 28, g_theme->text);
@@ -190,7 +189,6 @@ void draw_status(const play_session_state& state) {
 }
 
 void draw_world_background() {
-    ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
 }
 

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -309,6 +309,7 @@ void play_scene::draw() {
         return;
     }
 
+    virtual_screen::begin();
     play_renderer::draw_world_background();
 
     // MV script layer (2D, behind notes)
@@ -376,10 +377,7 @@ void play_scene::draw() {
                 TraceLog(LOG_INFO, "MV: tick OK, %d nodes", static_cast<int>(scene_ptr->nodes.size()));
                 mv_log_count++;
             }
-            virtual_screen::begin();
             mv::render_scene(*scene_ptr);
-            virtual_screen::end();
-            virtual_screen::draw_to_screen(true);
         } else {
             static int mv_fail_count = 0;
             if (mv_fail_count < 3) {
@@ -404,15 +402,14 @@ void play_scene::draw() {
     }
     EndMode3D();
 
-    virtual_screen::begin();
     rebuild_hit_regions();
     ui::begin_draw_queue();
-    ClearBackground(BLANK);
     play_renderer::draw_overlay(state_);
     ui::flush_draw_queue();
     virtual_screen::end();
 
-    virtual_screen::draw_to_screen(true);
+    ClearBackground(BLACK);
+    virtual_screen::draw_to_screen();
 }
 
 double play_scene::get_visual_ms() const {

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -127,6 +127,11 @@ std::optional<float> ground_z_offset(float height, float angle_rad, float half_f
     return height * (cos_a + k * sin_a) / denominator;
 }
 
+void present_virtual_screen() {
+    ClearBackground(BLACK);
+    virtual_screen::draw_to_screen();
+}
+
 }  // namespace
 
 play_scene::play_scene(scene_manager& manager, int key_count) : scene(manager) {
@@ -304,18 +309,18 @@ void play_scene::draw() {
         play_renderer::draw_status(state_);
         virtual_screen::end();
 
-        ClearBackground(BLACK);
-        virtual_screen::draw_to_screen();
+        present_virtual_screen();
         return;
     }
 
     virtual_screen::begin();
     play_renderer::draw_world_background();
+    const double visual_ms = get_visual_ms();
 
     // MV script layer (2D, behind notes)
     if (mv_runtime_ && mv_runtime_->is_loaded()) {
         mv::context_input mv_input;
-        mv_input.current_ms = get_visual_ms();
+        mv_input.current_ms = visual_ms;
         mv_input.song_length_ms = state_.song_end_ms;
 
         int current_tick = state_.timing_engine.ms_to_tick(state_.current_ms);
@@ -398,7 +403,7 @@ void play_scene::draw() {
 
     BeginMode3D(camera);
     if (has_bounds) {
-        play_renderer::draw_world(state_, draw_queue_, lane_start_z, judgement_z, lane_end_z, get_visual_ms());
+        play_renderer::draw_world(state_, draw_queue_, lane_start_z, judgement_z, lane_end_z, visual_ms);
     }
     EndMode3D();
 
@@ -408,8 +413,7 @@ void play_scene::draw() {
     ui::flush_draw_queue();
     virtual_screen::end();
 
-    ClearBackground(BLACK);
-    virtual_screen::draw_to_screen();
+    present_virtual_screen();
 }
 
 double play_scene::get_visual_ms() const {


### PR DESCRIPTION
## Summary
- render the gameplay scene fully inside the 16:9 virtual screen
- keep unused portrait display space as black letterbox margins
- restore gameplay buffer clearing after the rendering refactor

## Related
- Closes #229

## Notes
- This is opened as a draft PR for interim review.
- Local CLI-side build verification in this thread was inconclusive because the execution environment differed from CLion.