### PR TITLE
オンライン譜面ランキング取得を実装する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,6 +130,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/song_writer.h
         src/gameplay/timing_engine.cpp
         src/gameplay/timing_engine.h
+        src/network/auth_client.cpp
+        src/network/auth_client.h
         src/core/app_paths.cpp
         src/core/app_paths.h
         src/core/file_dialog.cpp
@@ -170,6 +172,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/song_select/song_select_detail_view.cpp
         src/scenes/song_select/song_select_detail_view.h
         src/scenes/song_select/song_select_layout.h
+        src/scenes/song_select/song_select_login_dialog.cpp
+        src/scenes/song_select/song_select_login_dialog.h
         src/scenes/song_select/song_select_list_view.cpp
         src/scenes/song_select/song_select_list_view.h
         src/scenes/song_select/song_select_navigation.cpp
@@ -653,7 +657,7 @@ target_include_directories(update_version_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_lang_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_api_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_storage_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
-target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32 crypt32)
+target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32 crypt32 winhttp)
 target_link_libraries(raythm_launcher PRIVATE winhttp)
 target_link_libraries(raythm_updater PRIVATE winhttp)
 target_link_libraries(update_version_smoke PRIVATE winhttp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/timing_engine.h
         src/network/auth_client.cpp
         src/network/auth_client.h
+        src/network/ranking_client.cpp
+        src/network/ranking_client.h
         src/core/app_paths.cpp
         src/core/app_paths.h
         src/core/file_dialog.cpp
@@ -438,6 +440,10 @@ add_executable(ranking_service_smoke
         src/models/data_models.h
         src/gameplay/ranking_service.cpp
         src/gameplay/ranking_service.h
+        src/network/auth_client.cpp
+        src/network/auth_client.h
+        src/network/ranking_client.cpp
+        src/network/ranking_client.h
         src/tests/ranking_service_smoke.cpp)
 
 add_executable(play_note_draw_queue_smoke
@@ -665,7 +671,7 @@ target_link_libraries(song_select_state_smoke PRIVATE raylib)
 target_link_libraries(settings_io_smoke PRIVATE raylib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
 target_link_libraries(judge_system_smoke PRIVATE raylib)
-target_link_libraries(ranking_service_smoke PRIVATE crypt32)
+target_link_libraries(ranking_service_smoke PRIVATE crypt32 winhttp)
 target_link_libraries(play_flow_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_timeline_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_panel_controller_smoke PRIVATE raylib)

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -94,6 +94,10 @@ std::filesystem::path chart_offsets_path() {
     return app_data_root() / "chart_offsets.txt";
 }
 
+std::filesystem::path auth_session_path() {
+    return app_data_root() / "auth_session.json";
+}
+
 std::filesystem::path mvs_root() {
     return app_data_root() / "mvs";
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -41,6 +41,9 @@ std::filesystem::path settings_path();
 // AppData/Local/raythm/chart_offsets.txt
 std::filesystem::path chart_offsets_path();
 
+// AppData/Local/raythm/auth_session.json
+std::filesystem::path auth_session_path();
+
 // AppData/Local/raythm/mvs/
 std::filesystem::path mvs_root();
 

--- a/src/core/window_dialog_support.cpp
+++ b/src/core/window_dialog_support.cpp
@@ -1,6 +1,7 @@
 #include "window_dialog_support.h"
 
 #include <algorithm>
+#include <string>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -10,6 +11,7 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+#include <shellapi.h>
 #endif
 
 extern "C" {
@@ -60,6 +62,31 @@ int current_monitor_height() {
 
 void* native_window_handle() {
     return GetWindowHandle();
+}
+
+bool open_url(std::string_view url) {
+#ifdef _WIN32
+    if (url.empty()) {
+        return false;
+    }
+
+    int utf16_length = MultiByteToWideChar(CP_UTF8, 0, url.data(), static_cast<int>(url.size()), nullptr, 0);
+    if (utf16_length <= 0) {
+        return false;
+    }
+
+    std::wstring wide_url(static_cast<size_t>(utf16_length), L'\0');
+    if (MultiByteToWideChar(CP_UTF8, 0, url.data(), static_cast<int>(url.size()),
+                            wide_url.data(), utf16_length) <= 0) {
+        return false;
+    }
+
+    const HINSTANCE result = ShellExecuteW(nullptr, L"open", wide_url.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+    return reinterpret_cast<INT_PTR>(result) > 32;
+#else
+    (void)url;
+    return false;
+#endif
 }
 
 #ifdef _WIN32

--- a/src/core/window_dialog_support.h
+++ b/src/core/window_dialog_support.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <string_view>
+
 namespace window_dialog_support {
 
 bool is_fullscreen();
@@ -10,5 +12,6 @@ void set_fullscreen(bool fullscreen, int windowed_client_width, int windowed_cli
 int current_monitor_width();
 int current_monitor_height();
 void* native_window_handle();
+bool open_url(std::string_view url);
 
 }  // namespace window_dialog_support

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -27,6 +27,7 @@ namespace {
 constexpr std::string_view kFileHeaderV1 = "RAYTHM_LOCAL_RANKING_V1";
 constexpr std::string_view kFileHeaderV2 = "RAYTHM_LOCAL_RANKING_V2";
 constexpr std::string_view kFileHeaderV3 = "RAYTHM_LOCAL_RANKING_V3";
+constexpr std::string_view kFileHeaderV4 = "RAYTHM_LOCAL_RANKING_V4";
 constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
 
 std::string trim(std::string_view value) {
@@ -58,20 +59,48 @@ std::string current_timestamp_utc() {
     return out.str();
 }
 
+std::string sanitize_player_display_name(std::string_view value) {
+    std::string sanitized;
+    sanitized.reserve(value.size());
+    for (const char ch : value) {
+        switch (ch) {
+            case '\t':
+            case '\r':
+            case '\n':
+                sanitized += ' ';
+                break;
+            default:
+                sanitized += ch;
+                break;
+        }
+    }
+    const std::string trimmed = trim(sanitized);
+    return trimmed.empty() ? "Guest" : trimmed;
+}
+
+std::string current_local_player_display_name() {
+    const auth::session_summary summary = auth::load_session_summary();
+    if (summary.logged_in && !summary.display_name.empty()) {
+        return sanitize_player_display_name(summary.display_name);
+    }
+    return "Guest";
+}
+
 std::string serialize_entries(const std::vector<ranking_service::entry>& entries) {
     std::ostringstream out;
-    out << kFileHeaderV3 << '\n';
+    out << kFileHeaderV4 << '\n';
     for (const ranking_service::entry& entry : entries) {
         out << std::fixed << std::setprecision(4) << entry.accuracy << '\t'
             << (entry.is_full_combo ? 1 : 0) << '\t'
             << entry.max_combo << '\t'
             << entry.score << '\t'
-            << entry.recorded_at << '\n';
+            << entry.recorded_at << '\t'
+            << sanitize_player_display_name(entry.player_display_name) << '\n';
     }
     return out.str();
 }
 
-enum class file_version { v1, v2, v3 };
+enum class file_version { v1, v2, v3, v4 };
 
 std::vector<ranking_service::entry> parse_entries(const std::string& content) {
     std::vector<ranking_service::entry> entries;
@@ -82,7 +111,9 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
     }
     const std::string header = trim(line);
     file_version version;
-    if (header == kFileHeaderV3) {
+    if (header == kFileHeaderV4) {
+        version = file_version::v4;
+    } else if (header == kFileHeaderV3) {
         version = file_version::v3;
     } else if (header == kFileHeaderV2) {
         version = file_version::v2;
@@ -102,21 +133,35 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
         try {
             ranking_service::entry entry;
 
-            if (version == file_version::v3) {
+            if (version == file_version::v4 || version == file_version::v3) {
                 // V3: accuracy \t is_full_combo \t max_combo \t score \t timestamp
-                std::string accuracy_token, fc_token, combo_token, score_token, timestamp_token;
+                // V4: accuracy \t is_full_combo \t max_combo \t score \t timestamp \t player_display_name
+                std::string accuracy_token, fc_token, combo_token, score_token, timestamp_token, player_token;
                 if (!std::getline(row, accuracy_token, '\t') ||
                     !std::getline(row, fc_token, '\t') ||
                     !std::getline(row, combo_token, '\t') ||
-                    !std::getline(row, score_token, '\t') ||
-                    !std::getline(row, timestamp_token)) {
+                    !std::getline(row, score_token, '\t')) {
                     continue;
+                }
+                if (version == file_version::v4) {
+                    if (!std::getline(row, timestamp_token, '\t')) {
+                        continue;
+                    }
+                } else {
+                    if (!std::getline(row, timestamp_token)) {
+                        continue;
+                    }
                 }
                 entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
                 entry.is_full_combo = trim(fc_token) == "1";
                 entry.max_combo = std::clamp(std::stoi(trim(combo_token)), 0, 999999);
                 entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
                 entry.recorded_at = trim(timestamp_token);
+                if (version == file_version::v4 && std::getline(row, player_token)) {
+                    entry.player_display_name = sanitize_player_display_name(player_token);
+                } else {
+                    entry.player_display_name = "Guest";
+                }
             } else {
                 // V1/V2: rank \t accuracy \t [max_combo \t] score \t timestamp
                 std::string rank_token, accuracy_token, combo_token, score_token, timestamp_token;
@@ -145,6 +190,7 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
                 // V1/V2 にはフルコンボ情報がないので、保存された rank が SS/S ならフルコンボとみなす。
                 const int stored_rank = std::clamp(std::stoi(trim(rank_token)), 0, 6);
                 entry.is_full_combo = (stored_rank == static_cast<int>(rank::ss) || stored_rank == static_cast<int>(rank::s));
+                entry.player_display_name = "Guest";
             }
 
             entry.verified = false;
@@ -349,6 +395,7 @@ bool submit_local_result(const chart_meta& chart, const result_data& result) {
     std::vector<entry> entries = load_local_entries(chart.chart_id);
     entries.push_back({
         .placement = 0,
+        .player_display_name = current_local_player_display_name(),
         .accuracy = result.accuracy,
         .is_full_combo = result.is_full_combo,
         .max_combo = result.max_combo,

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include "app_paths.h"
+#include "network/auth_client.h"
+#include "network/ranking_client.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -280,8 +282,44 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
     }
 
     if (ranking_source == source::online) {
-        result.available = false;
-        result.message = "Online ranking coming soon.";
+        const std::optional<auth::session> stored = auth::load_saved_session();
+        if (!stored.has_value()) {
+            result.available = false;
+            result.message = "Sign in to view online rankings.";
+            return result;
+        }
+
+        ranking_client::operation_result online_result =
+            ranking_client::fetch_chart_ranking(stored->server_url, stored->access_token, chart_id, limit);
+
+        if (online_result.unauthorized) {
+            const auth::operation_result restored = auth::restore_saved_session();
+            if (!restored.success || !restored.session_data.has_value()) {
+                result.available = false;
+                result.message = restored.message.empty()
+                    ? "Sign in to view online rankings."
+                    : restored.message;
+                return result;
+            }
+
+            online_result = ranking_client::fetch_chart_ranking(
+                restored.session_data->server_url,
+                restored.session_data->access_token,
+                chart_id,
+                limit);
+        }
+
+        if (!online_result.success || !online_result.listing.has_value()) {
+            result.available = false;
+            result.message = online_result.message.empty()
+                ? "Failed to load online rankings."
+                : online_result.message;
+            return result;
+        }
+
+        result.available = online_result.listing->available;
+        result.entries = std::move(online_result.listing->entries);
+        result.message = online_result.listing->message;
         return result;
     }
 

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -14,6 +14,7 @@ enum class source {
 
 struct entry {
     int placement = 0;
+    std::string player_display_name;
     float accuracy = 0.0f;
     bool is_full_combo = false;
     int max_combo = 0;

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -1,0 +1,799 @@
+#include "network/auth_client.h"
+
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <system_error>
+#include <utility>
+#include <vector>
+
+#include "app_paths.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
+namespace {
+namespace fs = std::filesystem;
+
+struct http_response {
+    int status_code = 0;
+    std::string body;
+    std::string error_message;
+};
+
+#ifdef _WIN32
+struct http_url_parts {
+    std::wstring host;
+    std::wstring path_and_query;
+    INTERNET_PORT port = INTERNET_DEFAULT_HTTP_PORT;
+    bool secure = false;
+};
+
+constexpr int kResolveTimeoutMs = 5000;
+constexpr int kConnectTimeoutMs = 5000;
+constexpr int kSendTimeoutMs = 5000;
+constexpr int kReceiveTimeoutMs = 5000;
+#endif
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::string escape_json_string(const std::string& value) {
+    std::string result;
+    result.reserve(value.size() + 8);
+    for (const char ch : value) {
+        switch (ch) {
+            case '\\': result += "\\\\"; break;
+            case '"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default: result += ch; break;
+        }
+    }
+    return result;
+}
+
+std::string read_file(const fs::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        return {};
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+    return key_pos + token.size();
+}
+
+std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
+    const auto key_end = find_json_key(content, key);
+    if (!key_end.has_value()) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', *key_end);
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
+        ++start;
+    }
+
+    if (start >= content.size()) {
+        return std::nullopt;
+    }
+
+    return start;
+}
+
+std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '"') {
+        return std::nullopt;
+    }
+
+    std::string result;
+    bool escaping = false;
+    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (escaping) {
+            switch (ch) {
+                case 'n': result += '\n'; break;
+                case 'r': result += '\r'; break;
+                case 't': result += '\t'; break;
+                default: result += ch; break;
+            }
+            escaping = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            return result;
+        }
+
+        result += ch;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '{') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            ++depth;
+        } else if (ch == '}') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<auth::public_user> parse_user_object(const std::string& content) {
+    const std::optional<std::string> id = extract_json_string(content, "id");
+    std::optional<std::string> email = extract_json_string(content, "email");
+    if (!email.has_value()) {
+        email = extract_json_string(content, "username");
+    }
+    const std::optional<std::string> display_name = extract_json_string(content, "displayName");
+    if (!id.has_value() || !email.has_value() || !display_name.has_value()) {
+        return std::nullopt;
+    }
+
+    return auth::public_user{
+        .id = *id,
+        .email = *email,
+        .display_name = *display_name,
+    };
+}
+
+std::optional<auth::session> parse_auth_session_response(const std::string& body, const std::string& server_url) {
+    const std::optional<std::string> access_token = extract_json_string(body, "accessToken");
+    const std::optional<std::string> refresh_token = extract_json_string(body, "refreshToken");
+    const std::optional<std::string> user_object = extract_json_object(body, "user");
+    if (!access_token.has_value() || !refresh_token.has_value() || !user_object.has_value()) {
+        return std::nullopt;
+    }
+
+    const std::optional<auth::public_user> user = parse_user_object(*user_object);
+    if (!user.has_value()) {
+        return std::nullopt;
+    }
+
+    return auth::session{
+        .server_url = server_url,
+        .access_token = *access_token,
+        .refresh_token = *refresh_token,
+        .user = *user,
+    };
+}
+
+std::optional<auth::public_user> parse_me_response(const std::string& body) {
+    const std::optional<std::string> user_object = extract_json_object(body, "user");
+    if (!user_object.has_value()) {
+        return std::nullopt;
+    }
+
+    return parse_user_object(*user_object);
+}
+
+std::string parse_error_message(const std::string& body, std::string fallback) {
+    const std::optional<std::string> message = extract_json_string(body, "message");
+    return message.value_or(std::move(fallback));
+}
+
+bool write_session_file(const auth::session& session_data) {
+    app_paths::ensure_directories();
+    std::ofstream output(app_paths::auth_session_path(), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "{\n";
+    output << "  \"serverUrl\": \"" << escape_json_string(session_data.server_url) << "\",\n";
+    output << "  \"accessToken\": \"" << escape_json_string(session_data.access_token) << "\",\n";
+    output << "  \"refreshToken\": \"" << escape_json_string(session_data.refresh_token) << "\",\n";
+    output << "  \"user\": {\n";
+    output << "    \"id\": \"" << escape_json_string(session_data.user.id) << "\",\n";
+    output << "    \"email\": \"" << escape_json_string(session_data.user.email) << "\",\n";
+    output << "    \"displayName\": \"" << escape_json_string(session_data.user.display_name) << "\"\n";
+    output << "  }\n";
+    output << "}\n";
+    return output.good();
+}
+
+#ifdef _WIN32
+std::wstring to_wstring(std::string_view value) {
+    return std::wstring(value.begin(), value.end());
+}
+
+std::string describe_winhttp_error(DWORD error_code) {
+    switch (error_code) {
+        case ERROR_WINHTTP_TIMEOUT:
+            return "The connection to raythm-Server timed out.";
+        case ERROR_WINHTTP_CANNOT_CONNECT:
+            return "Could not connect to raythm-Server.";
+        case ERROR_WINHTTP_CONNECTION_ERROR:
+            return "The connection to raythm-Server was interrupted.";
+        case ERROR_WINHTTP_NAME_NOT_RESOLVED:
+            return "The server name could not be resolved.";
+        case ERROR_WINHTTP_INVALID_URL:
+            return "The server URL is invalid.";
+        case ERROR_WINHTTP_UNRECOGNIZED_SCHEME:
+            return "The server URL scheme is not supported.";
+        case ERROR_WINHTTP_SECURE_FAILURE:
+            return "A secure connection to raythm-Server could not be established.";
+        default:
+            return "Failed to communicate with raythm-Server.";
+    }
+}
+
+std::optional<http_url_parts> parse_url_parts(const std::string& url) {
+    std::wstring wide_url = to_wstring(url);
+
+    URL_COMPONENTSW components{};
+    components.dwStructSize = sizeof(components);
+
+    wchar_t host_buffer[256];
+    wchar_t path_buffer[2048];
+    wchar_t extra_buffer[2048];
+    components.lpszHostName = host_buffer;
+    components.dwHostNameLength = sizeof(host_buffer) / sizeof(wchar_t);
+    components.lpszUrlPath = path_buffer;
+    components.dwUrlPathLength = sizeof(path_buffer) / sizeof(wchar_t);
+    components.lpszExtraInfo = extra_buffer;
+    components.dwExtraInfoLength = sizeof(extra_buffer) / sizeof(wchar_t);
+
+    if (WinHttpCrackUrl(wide_url.c_str(), static_cast<DWORD>(wide_url.size()), 0, &components) == FALSE) {
+        return std::nullopt;
+    }
+
+    http_url_parts parts;
+    parts.host.assign(components.lpszHostName, components.dwHostNameLength);
+    parts.path_and_query.assign(components.lpszUrlPath, components.dwUrlPathLength);
+    if (components.dwExtraInfoLength > 0) {
+        parts.path_and_query.append(components.lpszExtraInfo, components.dwExtraInfoLength);
+    }
+    parts.port = components.nPort;
+    parts.secure = components.nScheme == INTERNET_SCHEME_HTTPS;
+    return parts;
+}
+
+http_response send_request(const std::string& method,
+                           const std::string& url,
+                           const std::string& body,
+                           const std::vector<std::pair<std::string, std::string>>& headers) {
+    http_response response;
+
+    const std::optional<http_url_parts> parts = parse_url_parts(url);
+    if (!parts.has_value()) {
+        response.error_message = "Invalid server URL.";
+        return response;
+    }
+
+    HINTERNET session = WinHttpOpen(L"raythm/0.1",
+                                    WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                    WINHTTP_NO_PROXY_NAME,
+                                    WINHTTP_NO_PROXY_BYPASS,
+                                    0);
+    if (session == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        return response;
+    }
+
+    WinHttpSetTimeouts(session, kResolveTimeoutMs, kConnectTimeoutMs, kSendTimeoutMs, kReceiveTimeoutMs);
+
+    HINTERNET connection = WinHttpConnect(session, parts->host.c_str(), parts->port, 0);
+    if (connection == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    const DWORD request_flags = parts->secure ? WINHTTP_FLAG_SECURE : 0;
+    HINTERNET request = WinHttpOpenRequest(connection,
+                                           to_wstring(method).c_str(),
+                                           parts->path_and_query.c_str(),
+                                           nullptr,
+                                           WINHTTP_NO_REFERER,
+                                           WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                           request_flags);
+    if (request == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    std::wstring header_block;
+    for (const auto& [name, value] : headers) {
+        header_block += to_wstring(name);
+        header_block += L": ";
+        header_block += to_wstring(value);
+        header_block += L"\r\n";
+    }
+
+    LPVOID request_body = body.empty() ? WINHTTP_NO_REQUEST_DATA : const_cast<char*>(body.data());
+    DWORD request_body_size = static_cast<DWORD>(body.size());
+    const BOOL sent = WinHttpSendRequest(request,
+                                         header_block.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : header_block.c_str(),
+                                         header_block.empty() ? 0 : static_cast<DWORD>(-1L),
+                                         request_body,
+                                         request_body_size,
+                                         request_body_size,
+                                         0);
+    if (sent == FALSE || WinHttpReceiveResponse(request, nullptr) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    DWORD status_code = 0;
+    DWORD status_code_size = sizeof(status_code);
+    if (WinHttpQueryHeaders(request,
+                            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX,
+                            &status_code,
+                            &status_code_size,
+                            WINHTTP_NO_HEADER_INDEX) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    response.status_code = static_cast<int>(status_code);
+
+    DWORD available_size = 0;
+    while (WinHttpQueryDataAvailable(request, &available_size) == TRUE && available_size > 0) {
+        std::string chunk(available_size, '\0');
+        DWORD bytes_read = 0;
+        if (WinHttpReadData(request, chunk.data(), available_size, &bytes_read) == FALSE) {
+            response.error_message = describe_winhttp_error(GetLastError());
+            WinHttpCloseHandle(request);
+            WinHttpCloseHandle(connection);
+            WinHttpCloseHandle(session);
+            return response;
+        }
+
+        chunk.resize(bytes_read);
+        response.body += chunk;
+        available_size = 0;
+    }
+
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connection);
+    WinHttpCloseHandle(session);
+    return response;
+}
+#else
+http_response send_request(const std::string&,
+                           const std::string&,
+                           const std::string&,
+                           const std::vector<std::pair<std::string, std::string>>&) {
+    return {
+        .status_code = 0,
+        .body = {},
+        .error_message = "Networking is only supported on Windows in the current build.",
+    };
+}
+#endif
+
+std::string build_auth_url(const std::string& server_url, std::string_view path) {
+    return auth::normalize_server_url(server_url) + std::string(path);
+}
+
+auth::operation_result finish_with_session(auth::operation_result result, const auth::session& session_data) {
+    result.session_data = session_data;
+    return result;
+}
+
+auth::operation_result parse_auth_response(const http_response& response,
+                                           const std::string& server_url,
+                                           std::string success_message) {
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .message = parse_error_message(response.body, "Authentication request failed."),
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::optional<auth::session> session_data =
+        parse_auth_session_response(response.body, auth::normalize_server_url(server_url));
+    if (!session_data.has_value()) {
+        return {
+            .success = false,
+            .message = "Server returned an unexpected authentication response.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (!write_session_file(*session_data)) {
+        return {
+            .success = false,
+            .message = "Authentication succeeded, but the local session could not be saved.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    return finish_with_session({
+        .success = true,
+        .message = std::move(success_message),
+        .session_data = std::nullopt,
+    }, *session_data);
+}
+
+}  // namespace
+
+namespace auth {
+
+std::string normalize_server_url(const std::string& server_url) {
+    std::string normalized = trim(server_url);
+    while (!normalized.empty() && normalized.back() == '/') {
+        normalized.pop_back();
+    }
+    return normalized;
+}
+
+std::optional<session> load_saved_session() {
+    const std::string content = read_file(app_paths::auth_session_path());
+    if (content.empty()) {
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> server_url = extract_json_string(content, "serverUrl");
+    const std::optional<std::string> access_token = extract_json_string(content, "accessToken");
+    const std::optional<std::string> refresh_token = extract_json_string(content, "refreshToken");
+    const std::optional<std::string> user_object = extract_json_object(content, "user");
+    if (!server_url.has_value() || !access_token.has_value() || !refresh_token.has_value() || !user_object.has_value()) {
+        return std::nullopt;
+    }
+
+    const std::optional<public_user> user = parse_user_object(*user_object);
+    if (!user.has_value()) {
+        return std::nullopt;
+    }
+
+    return session{
+        .server_url = normalize_server_url(*server_url),
+        .access_token = *access_token,
+        .refresh_token = *refresh_token,
+        .user = *user,
+    };
+}
+
+session_summary load_session_summary() {
+    const std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        return {
+            .logged_in = false,
+            .server_url = kDefaultServerUrl,
+            .email = {},
+            .display_name = {},
+        };
+    }
+
+    return {
+        .logged_in = true,
+        .server_url = stored->server_url,
+        .email = stored->user.email,
+        .display_name = stored->user.display_name,
+    };
+}
+
+bool save_session(const session& session_data) {
+    return write_session_file(session_data);
+}
+
+void clear_saved_session() {
+    std::error_code ec;
+    fs::remove(app_paths::auth_session_path(), ec);
+}
+
+operation_result register_user(const std::string& server_url,
+                               const std::string& email,
+                               const std::string& display_name,
+                               const std::string& password) {
+    const std::string normalized_server_url = normalize_server_url(server_url);
+    if (normalized_server_url.empty()) {
+        return {
+            .success = false,
+            .message = "Server URL is required.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::string trimmed_display_name = trim(display_name);
+    const std::string body =
+        "{"
+        "\"email\":\"" + escape_json_string(trim(email)) + "\","
+        "\"displayName\":\"" + escape_json_string(trimmed_display_name) + "\","
+        "\"password\":\"" + escape_json_string(password) + "\""
+        "}";
+
+    const http_response response = send_request(
+        "POST",
+        build_auth_url(normalized_server_url, "/auth/register"),
+        body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    return parse_auth_response(response, normalized_server_url, "Account created successfully.");
+}
+
+operation_result login_user(const std::string& server_url,
+                            const std::string& email,
+                            const std::string& password) {
+    const std::string normalized_server_url = normalize_server_url(server_url);
+    if (normalized_server_url.empty()) {
+        return {
+            .success = false,
+            .message = "Server URL is required.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::string body =
+        "{"
+        "\"email\":\"" + escape_json_string(trim(email)) + "\","
+        "\"password\":\"" + escape_json_string(password) + "\""
+        "}";
+
+    const http_response response = send_request(
+        "POST",
+        build_auth_url(normalized_server_url, "/auth/login"),
+        body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    return parse_auth_response(response, normalized_server_url, "Logged in successfully.");
+}
+
+operation_result restore_saved_session() {
+    const std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        return {
+            .success = false,
+            .message = "No saved session was found.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    const http_response me_response = send_request(
+        "GET",
+        build_auth_url(stored->server_url, "/me"),
+        {},
+        {
+            {"Accept", "application/json"},
+            {"Authorization", "Bearer " + stored->access_token},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (me_response.error_message.empty() && me_response.status_code >= 200 && me_response.status_code < 300) {
+        const std::optional<public_user> user = parse_me_response(me_response.body);
+        if (user.has_value()) {
+            session restored = *stored;
+            restored.user = *user;
+            if (!write_session_file(restored)) {
+                return {
+                    .success = false,
+                    .message = "Session restored, but the local session file could not be updated.",
+                    .session_data = std::nullopt,
+                };
+            }
+
+            return finish_with_session({
+                .success = true,
+                .message = "Session restored.",
+                .session_data = std::nullopt,
+            }, restored);
+        }
+    }
+
+    if (!me_response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = me_response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (me_response.status_code != 401) {
+        return {
+            .success = false,
+            .message = parse_error_message(me_response.body, "Failed to restore session."),
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::string refresh_body =
+        "{"
+        "\"refreshToken\":\"" + escape_json_string(stored->refresh_token) + "\""
+        "}";
+
+    const http_response refresh_response = send_request(
+        "POST",
+        build_auth_url(stored->server_url, "/auth/refresh"),
+        refresh_body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!refresh_response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = refresh_response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (refresh_response.status_code < 200 || refresh_response.status_code >= 300) {
+        clear_saved_session();
+        return {
+            .success = false,
+            .message = parse_error_message(refresh_response.body, "Saved session expired."),
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::optional<session> refreshed = parse_auth_session_response(refresh_response.body, stored->server_url);
+    if (!refreshed.has_value()) {
+        clear_saved_session();
+        return {
+            .success = false,
+            .message = "Server returned an unexpected refresh response.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (!write_session_file(*refreshed)) {
+        return {
+            .success = false,
+            .message = "Session refreshed, but the local session could not be saved.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    return finish_with_session({
+        .success = true,
+        .message = "Session refreshed.",
+        .session_data = std::nullopt,
+    }, *refreshed);
+}
+
+operation_result logout_saved_session() {
+    const std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        clear_saved_session();
+        return {
+            .success = true,
+            .message = "Already logged out.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::string body =
+        "{"
+        "\"refreshToken\":\"" + escape_json_string(stored->refresh_token) + "\""
+        "}";
+
+    const http_response response = send_request(
+        "POST",
+        build_auth_url(stored->server_url, "/auth/logout"),
+        body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (response.status_code != 204 &&
+        (response.status_code < 200 || response.status_code >= 300) &&
+        response.status_code != 401) {
+        return {
+            .success = false,
+            .message = parse_error_message(response.body, "Failed to log out."),
+            .session_data = std::nullopt,
+        };
+    }
+
+    clear_saved_session();
+    return {
+        .success = true,
+        .message = "Logged out successfully.",
+        .session_data = std::nullopt,
+    };
+}
+
+}  // namespace auth

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -192,6 +192,23 @@ std::optional<std::string> extract_json_object(const std::string& content, const
     return std::nullopt;
 }
 
+std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    if (content.compare(*start_opt, 4, "true") == 0) {
+        return true;
+    }
+
+    if (content.compare(*start_opt, 5, "false") == 0) {
+        return false;
+    }
+
+    return std::nullopt;
+}
+
 std::optional<auth::public_user> parse_user_object(const std::string& content) {
     const std::optional<std::string> id = extract_json_string(content, "id");
     std::optional<std::string> email = extract_json_string(content, "email");
@@ -203,10 +220,13 @@ std::optional<auth::public_user> parse_user_object(const std::string& content) {
         return std::nullopt;
     }
 
+    const bool email_verified = extract_json_bool(content, "emailVerified").value_or(false);
+
     return auth::public_user{
         .id = *id,
         .email = *email,
         .display_name = *display_name,
+        .email_verified = email_verified,
     };
 }
 
@@ -259,7 +279,8 @@ bool write_session_file(const auth::session& session_data) {
     output << "  \"user\": {\n";
     output << "    \"id\": \"" << escape_json_string(session_data.user.id) << "\",\n";
     output << "    \"email\": \"" << escape_json_string(session_data.user.email) << "\",\n";
-    output << "    \"displayName\": \"" << escape_json_string(session_data.user.display_name) << "\"\n";
+    output << "    \"displayName\": \"" << escape_json_string(session_data.user.display_name) << "\",\n";
+    output << "    \"emailVerified\": " << (session_data.user.email_verified ? "true" : "false") << "\n";
     output << "  }\n";
     output << "}\n";
     return output.good();
@@ -545,6 +566,7 @@ session_summary load_session_summary() {
             .server_url = kDefaultServerUrl,
             .email = {},
             .display_name = {},
+            .email_verified = false,
         };
     }
 
@@ -553,6 +575,7 @@ session_summary load_session_summary() {
         .server_url = stored->server_url,
         .email = stored->user.email,
         .display_name = stored->user.display_name,
+        .email_verified = stored->user.email_verified,
     };
 }
 

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -11,6 +11,7 @@ struct public_user {
     std::string id;
     std::string email;
     std::string display_name;
+    bool email_verified = false;
 };
 
 struct session {
@@ -25,6 +26,7 @@ struct session_summary {
     std::string server_url;
     std::string email;
     std::string display_name;
+    bool email_verified = false;
 };
 
 struct operation_result {

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace auth {
+
+inline constexpr const char* kDefaultServerUrl = "http://192.168.11.22";
+
+struct public_user {
+    std::string id;
+    std::string email;
+    std::string display_name;
+};
+
+struct session {
+    std::string server_url;
+    std::string access_token;
+    std::string refresh_token;
+    public_user user;
+};
+
+struct session_summary {
+    bool logged_in = false;
+    std::string server_url;
+    std::string email;
+    std::string display_name;
+};
+
+struct operation_result {
+    bool success = false;
+    std::string message;
+    std::optional<session> session_data;
+};
+
+std::string normalize_server_url(const std::string& server_url);
+
+std::optional<session> load_saved_session();
+session_summary load_session_summary();
+bool save_session(const session& session_data);
+void clear_saved_session();
+
+operation_result register_user(const std::string& server_url,
+                               const std::string& email,
+                               const std::string& display_name,
+                               const std::string& password);
+operation_result login_user(const std::string& server_url,
+                            const std::string& email,
+                            const std::string& password);
+operation_result restore_saved_session();
+operation_result logout_saved_session();
+
+}  // namespace auth

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -116,6 +116,48 @@ std::optional<std::string> extract_json_string(const std::string& content, const
     return std::nullopt;
 }
 
+std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '{') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            ++depth;
+        } else if (ch == '}') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
 std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
     const auto start_opt = find_value_start(content, key);
     if (!start_opt.has_value()) {
@@ -451,6 +493,11 @@ http_response send_request(const std::string&,
 #endif
 
 std::optional<ranking_service::entry> parse_ranking_entry(const std::string& content) {
+    std::string player_display_name;
+    if (const auto player_object = extract_json_object(content, "player"); player_object.has_value()) {
+        player_display_name = extract_json_string(*player_object, "display_name").value_or("");
+    }
+
     const auto placement = extract_json_int(content, "placement");
     const auto accuracy = extract_json_float(content, "accuracy");
     const auto is_full_combo = extract_json_bool(content, "is_full_combo");
@@ -470,6 +517,7 @@ std::optional<ranking_service::entry> parse_ranking_entry(const std::string& con
 
     return ranking_service::entry{
         .placement = *placement,
+        .player_display_name = player_display_name,
         .accuracy = *accuracy,
         .is_full_combo = *is_full_combo,
         .max_combo = *max_combo,

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -1,0 +1,590 @@
+#include "network/ranking_client.h"
+
+#include <cctype>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
+namespace {
+
+struct http_response {
+    int status_code = 0;
+    std::string body;
+    std::string error_message;
+};
+
+#ifdef _WIN32
+struct http_url_parts {
+    std::wstring host;
+    std::wstring path_and_query;
+    INTERNET_PORT port = INTERNET_DEFAULT_HTTP_PORT;
+    bool secure = false;
+};
+
+constexpr int kResolveTimeoutMs = 5000;
+constexpr int kConnectTimeoutMs = 5000;
+constexpr int kSendTimeoutMs = 5000;
+constexpr int kReceiveTimeoutMs = 5000;
+#endif
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+    return key_pos + token.size();
+}
+
+std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
+    const auto key_end = find_json_key(content, key);
+    if (!key_end.has_value()) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', *key_end);
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
+        ++start;
+    }
+
+    if (start >= content.size()) {
+        return std::nullopt;
+    }
+
+    return start;
+}
+
+std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '"') {
+        return std::nullopt;
+    }
+
+    std::string result;
+    bool escaping = false;
+    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (escaping) {
+            switch (ch) {
+                case 'n': result += '\n'; break;
+                case 'r': result += '\r'; break;
+                case 't': result += '\t'; break;
+                default: result += ch; break;
+            }
+            escaping = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            return result;
+        }
+
+        result += ch;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    if (content.compare(*start_opt, 4, "true") == 0) {
+        return true;
+    }
+
+    if (content.compare(*start_opt, 5, "false") == 0) {
+        return false;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<int> extract_json_int(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t end = *start_opt;
+    if (content[end] == '-') {
+        ++end;
+    }
+    while (end < content.size() && std::isdigit(static_cast<unsigned char>(content[end]))) {
+        ++end;
+    }
+    if (end == *start_opt) {
+        return std::nullopt;
+    }
+
+    try {
+        return std::stoi(content.substr(*start_opt, end - *start_opt));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> extract_json_float(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t end = *start_opt;
+    if (content[end] == '-') {
+        ++end;
+    }
+    while (end < content.size()) {
+        const char ch = content[end];
+        if (!(std::isdigit(static_cast<unsigned char>(ch)) || ch == '.')) {
+            break;
+        }
+        ++end;
+    }
+    if (end == *start_opt) {
+        return std::nullopt;
+    }
+
+    try {
+        return std::stof(content.substr(*start_opt, end - *start_opt));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<std::string> extract_json_array(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '[') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '[') {
+            ++depth;
+        } else if (ch == ']') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::vector<std::string> extract_json_objects_from_array(const std::string& content) {
+    std::vector<std::string> objects;
+    bool in_string = false;
+    bool escaping = false;
+    size_t object_start = std::string::npos;
+    size_t depth = 0;
+
+    for (size_t index = 0; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            if (depth == 0) {
+                object_start = index;
+            }
+            ++depth;
+        } else if (ch == '}') {
+            if (depth == 0) {
+                continue;
+            }
+            --depth;
+            if (depth == 0 && object_start != std::string::npos) {
+                objects.push_back(content.substr(object_start, index - object_start + 1));
+                object_start = std::string::npos;
+            }
+        }
+    }
+
+    return objects;
+}
+
+#ifdef _WIN32
+std::wstring to_wstring(std::string_view value) {
+    return std::wstring(value.begin(), value.end());
+}
+
+std::string describe_winhttp_error(DWORD error_code) {
+    switch (error_code) {
+        case ERROR_WINHTTP_TIMEOUT:
+            return "The connection to raythm-Server timed out.";
+        case ERROR_WINHTTP_CANNOT_CONNECT:
+            return "Could not connect to raythm-Server.";
+        case ERROR_WINHTTP_CONNECTION_ERROR:
+            return "The connection to raythm-Server was interrupted.";
+        case ERROR_WINHTTP_NAME_NOT_RESOLVED:
+            return "The server name could not be resolved.";
+        case ERROR_WINHTTP_INVALID_URL:
+            return "The server URL is invalid.";
+        case ERROR_WINHTTP_UNRECOGNIZED_SCHEME:
+            return "The server URL scheme is not supported.";
+        case ERROR_WINHTTP_SECURE_FAILURE:
+            return "A secure connection to raythm-Server could not be established.";
+        default:
+            return "Failed to communicate with raythm-Server.";
+    }
+}
+
+std::optional<http_url_parts> parse_url_parts(const std::string& url) {
+    std::wstring wide_url = to_wstring(url);
+
+    URL_COMPONENTSW components{};
+    components.dwStructSize = sizeof(components);
+
+    wchar_t host_buffer[256];
+    wchar_t path_buffer[2048];
+    wchar_t extra_buffer[2048];
+    components.lpszHostName = host_buffer;
+    components.dwHostNameLength = sizeof(host_buffer) / sizeof(wchar_t);
+    components.lpszUrlPath = path_buffer;
+    components.dwUrlPathLength = sizeof(path_buffer) / sizeof(wchar_t);
+    components.lpszExtraInfo = extra_buffer;
+    components.dwExtraInfoLength = sizeof(extra_buffer) / sizeof(wchar_t);
+
+    if (WinHttpCrackUrl(wide_url.c_str(), static_cast<DWORD>(wide_url.size()), 0, &components) == FALSE) {
+        return std::nullopt;
+    }
+
+    http_url_parts parts;
+    parts.host.assign(components.lpszHostName, components.dwHostNameLength);
+    parts.path_and_query.assign(components.lpszUrlPath, components.dwUrlPathLength);
+    if (components.dwExtraInfoLength > 0) {
+        parts.path_and_query.append(components.lpszExtraInfo, components.dwExtraInfoLength);
+    }
+    parts.port = components.nPort;
+    parts.secure = components.nScheme == INTERNET_SCHEME_HTTPS;
+    return parts;
+}
+
+http_response send_request(const std::string& method,
+                           const std::string& url,
+                           const std::vector<std::pair<std::string, std::string>>& headers) {
+    http_response response;
+
+    const std::optional<http_url_parts> parts = parse_url_parts(url);
+    if (!parts.has_value()) {
+        response.error_message = "Invalid server URL.";
+        return response;
+    }
+
+    HINTERNET session = WinHttpOpen(L"raythm/0.1",
+                                    WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                    WINHTTP_NO_PROXY_NAME,
+                                    WINHTTP_NO_PROXY_BYPASS,
+                                    0);
+    if (session == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        return response;
+    }
+
+    WinHttpSetTimeouts(session, kResolveTimeoutMs, kConnectTimeoutMs, kSendTimeoutMs, kReceiveTimeoutMs);
+
+    HINTERNET connection = WinHttpConnect(session, parts->host.c_str(), parts->port, 0);
+    if (connection == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    const DWORD request_flags = parts->secure ? WINHTTP_FLAG_SECURE : 0;
+    HINTERNET request = WinHttpOpenRequest(connection,
+                                           to_wstring(method).c_str(),
+                                           parts->path_and_query.c_str(),
+                                           nullptr,
+                                           WINHTTP_NO_REFERER,
+                                           WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                           request_flags);
+    if (request == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    std::wstring header_block;
+    for (const auto& [name, value] : headers) {
+        header_block += to_wstring(name);
+        header_block += L": ";
+        header_block += to_wstring(value);
+        header_block += L"\r\n";
+    }
+
+    const BOOL sent = WinHttpSendRequest(request,
+                                         header_block.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : header_block.c_str(),
+                                         header_block.empty() ? 0 : static_cast<DWORD>(-1L),
+                                         WINHTTP_NO_REQUEST_DATA,
+                                         0,
+                                         0,
+                                         0);
+    if (sent == FALSE || WinHttpReceiveResponse(request, nullptr) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    DWORD status_code = 0;
+    DWORD status_code_size = sizeof(status_code);
+    if (WinHttpQueryHeaders(request,
+                            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX,
+                            &status_code,
+                            &status_code_size,
+                            WINHTTP_NO_HEADER_INDEX) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    response.status_code = static_cast<int>(status_code);
+
+    DWORD available_size = 0;
+    while (WinHttpQueryDataAvailable(request, &available_size) == TRUE && available_size > 0) {
+        std::string chunk(available_size, '\0');
+        DWORD bytes_read = 0;
+        if (WinHttpReadData(request, chunk.data(), available_size, &bytes_read) == FALSE) {
+            response.error_message = describe_winhttp_error(GetLastError());
+            WinHttpCloseHandle(request);
+            WinHttpCloseHandle(connection);
+            WinHttpCloseHandle(session);
+            return response;
+        }
+
+        chunk.resize(bytes_read);
+        response.body += chunk;
+        available_size = 0;
+    }
+
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connection);
+    WinHttpCloseHandle(session);
+    return response;
+}
+#else
+http_response send_request(const std::string&,
+                           const std::string&,
+                           const std::vector<std::pair<std::string, std::string>>&) {
+    return {
+        .status_code = 0,
+        .body = {},
+        .error_message = "Networking is only supported on Windows in the current build.",
+    };
+}
+#endif
+
+std::optional<ranking_service::entry> parse_ranking_entry(const std::string& content) {
+    const auto placement = extract_json_int(content, "placement");
+    const auto accuracy = extract_json_float(content, "accuracy");
+    const auto is_full_combo = extract_json_bool(content, "is_full_combo");
+    const auto max_combo = extract_json_int(content, "max_combo");
+    const auto score = extract_json_int(content, "score");
+    const auto recorded_at = extract_json_string(content, "recorded_at");
+    const auto verified = extract_json_bool(content, "verified");
+    if (!placement.has_value() ||
+        !accuracy.has_value() ||
+        !is_full_combo.has_value() ||
+        !max_combo.has_value() ||
+        !score.has_value() ||
+        !recorded_at.has_value() ||
+        !verified.has_value()) {
+        return std::nullopt;
+    }
+
+    return ranking_service::entry{
+        .placement = *placement,
+        .accuracy = *accuracy,
+        .is_full_combo = *is_full_combo,
+        .max_combo = *max_combo,
+        .score = *score,
+        .recorded_at = *recorded_at,
+        .verified = *verified,
+    };
+}
+
+std::optional<ranking_client::listing_response> parse_listing_response(const std::string& body) {
+    const bool available = extract_json_bool(body, "available").value_or(false);
+    const std::string message = extract_json_string(body, "message").value_or("");
+
+    ranking_client::listing_response listing;
+    listing.available = available;
+    listing.message = message;
+
+    const std::optional<std::string> entries_array = extract_json_array(body, "entries");
+    if (!entries_array.has_value()) {
+        return listing;
+    }
+
+    for (const std::string& object : extract_json_objects_from_array(*entries_array)) {
+        const auto entry = parse_ranking_entry(object);
+        if (entry.has_value()) {
+            listing.entries.push_back(*entry);
+        }
+    }
+
+    return listing;
+}
+
+std::string build_ranking_url(const std::string& server_url, const std::string& chart_id, int limit) {
+    const int clamped_limit = std::max(1, limit);
+    return server_url + "/charts/" + chart_id + "/rankings?page=1&pageSize=" + std::to_string(clamped_limit);
+}
+
+}  // namespace
+
+namespace ranking_client {
+
+operation_result fetch_chart_ranking(const std::string& server_url,
+                                     const std::string& access_token,
+                                     const std::string& chart_id,
+                                     int limit) {
+    if (server_url.empty()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = "No server URL is configured.",
+            .listing = std::nullopt,
+        };
+    }
+
+    if (access_token.empty()) {
+        return {
+            .success = false,
+            .unauthorized = true,
+            .message = "Sign in to view online rankings.",
+            .listing = std::nullopt,
+        };
+    }
+
+    const http_response response = send_request(
+        "GET",
+        build_ranking_url(server_url, chart_id, limit),
+        {
+            {"Accept", "application/json"},
+            {"Authorization", "Bearer " + access_token},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = response.error_message,
+            .listing = std::nullopt,
+        };
+    }
+
+    if (response.status_code == 401) {
+        return {
+            .success = false,
+            .unauthorized = true,
+            .message = "Sign in to view online rankings.",
+            .listing = std::nullopt,
+        };
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = extract_json_string(response.body, "message").value_or("Failed to load online rankings."),
+            .listing = std::nullopt,
+        };
+    }
+
+    const std::optional<listing_response> listing = parse_listing_response(response.body);
+    if (!listing.has_value()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = "Server returned an unexpected ranking response.",
+            .listing = std::nullopt,
+        };
+    }
+
+    return {
+        .success = true,
+        .unauthorized = false,
+        .message = listing->message,
+        .listing = listing,
+    };
+}
+
+}  // namespace ranking_client

--- a/src/network/ranking_client.h
+++ b/src/network/ranking_client.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "ranking_service.h"
+
+namespace ranking_client {
+
+struct listing_response {
+    bool available = true;
+    std::vector<ranking_service::entry> entries;
+    std::string message;
+};
+
+struct operation_result {
+    bool success = false;
+    bool unauthorized = false;
+    std::string message;
+    std::optional<listing_response> listing;
+};
+
+operation_result fetch_chart_ranking(const std::string& server_url,
+                                     const std::string& access_token,
+                                     const std::string& chart_id,
+                                     int limit = 50);
+
+}  // namespace ranking_client

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -19,6 +19,19 @@ constexpr float kHeaderHeight = 48.0f;
 constexpr float kPadding = 16.0f;
 constexpr float kBackButtonWidth = 100.0f;
 constexpr float kBackButtonHeight = 30.0f;
+constexpr float kMetadataButtonWidth = 152.0f;
+constexpr float kMetadataModalWidth = 360.0f;
+constexpr float kMetadataModalHeight = 208.0f;
+constexpr float kMetadataModalOffsetY = 18.0f;
+constexpr float kMetadataModalPaddingX = 18.0f;
+constexpr float kMetadataHeaderTop = 18.0f;
+constexpr float kMetadataTitleHeight = 26.0f;
+constexpr float kMetadataSubtitleHeight = 18.0f;
+constexpr float kMetadataHeaderGap = 6.0f;
+constexpr float kMetadataBodyTop = 78.0f;
+constexpr float kMetadataRowHeight = 36.0f;
+constexpr float kMetadataRowGap = 8.0f;
+constexpr float kMetadataButtonHeight = 36.0f;
 
 bool wide_text_filter(int codepoint, const std::string&) {
     return codepoint >= 32;
@@ -28,13 +41,33 @@ std::string default_script_source() {
     return "def draw(ctx):\n  DrawBackground(fill=\"#0a0a1a\")\n";
 }
 
-Rectangle tab_button_rect(int index) {
+Rectangle metadata_button_rect() {
     return {
-        kPadding + static_cast<float>(index) * 164.0f,
+        kPadding,
         (kHeaderHeight - kBackButtonHeight) * 0.5f,
-        152.0f,
+        kMetadataButtonWidth,
         30.0f
     };
+}
+
+float ease_out_cubic(float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    const float inv = 1.0f - clamped;
+    return 1.0f - inv * inv * inv;
+}
+
+Rectangle metadata_modal_rect(float open_anim = 1.0f) {
+    Rectangle rect = {
+        metadata_button_rect().x,
+        metadata_button_rect().y + metadata_button_rect().height + kMetadataModalOffsetY,
+        kMetadataModalWidth,
+        kMetadataModalHeight
+    };
+    rect.x = std::clamp(rect.x, 12.0f, static_cast<float>(kScreenWidth) - rect.width - 12.0f);
+    rect.y = std::clamp(rect.y, 12.0f, static_cast<float>(kScreenHeight) - rect.height - 12.0f);
+    const float anim_t = ease_out_cubic(open_anim);
+    rect.y -= (1.0f - anim_t) * 18.0f;
+    return rect;
 }
 
 }  // namespace
@@ -73,8 +106,36 @@ void mv_editor_scene::update(float dt) {
     (void)dt;
     ui::begin_hit_regions();
 
+    if (metadata_modal_open_) {
+        metadata_modal_open_anim_ = std::min(1.0f, metadata_modal_open_anim_ + dt * 8.0f);
+    } else {
+        metadata_modal_open_anim_ = 0.0f;
+    }
+
+    const Rectangle modal_rect = metadata_modal_rect(metadata_modal_open_anim_);
+    if (metadata_modal_open_) {
+        ui::register_hit_region({0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)},
+                                ui::draw_layer::overlay);
+        ui::register_hit_region(modal_rect, ui::draw_layer::modal);
+    }
+
     if (IsKeyPressed(KEY_ESCAPE)) {
+        if (metadata_modal_open_) {
+            metadata_modal_open_ = false;
+            name_input_.active = false;
+            author_input_.active = false;
+            return;
+        }
         manager_.change_scene(std::make_unique<song_select_scene>(manager_, song_.meta.song_id));
+        return;
+    }
+
+    if (metadata_modal_open_ &&
+        IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+        !CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), modal_rect)) {
+        metadata_modal_open_ = false;
+        name_input_.active = false;
+        author_input_.active = false;
         return;
     }
 
@@ -89,6 +150,10 @@ void mv_editor_scene::draw() {
     ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
     ui::begin_draw_queue();
+
+    if (metadata_modal_open_) {
+        panel_state_.editor.active = false;
+    }
 
     // Header
     Rectangle header = {0, 0, static_cast<float>(kScreenWidth), kHeaderHeight};
@@ -110,17 +175,15 @@ void mv_editor_scene::draw() {
         return;
     }
 
-    if (ui::draw_button_colored(tab_button_rect(0), "Script", 14,
-                                active_tab_ == tab::script ? g_theme->row_selected : g_theme->row,
-                                active_tab_ == tab::script ? g_theme->row_active : g_theme->row_hover,
+    if (ui::draw_button_colored(metadata_button_rect(), "Metadata", 14,
+                                metadata_modal_open_ ? g_theme->row_selected : g_theme->row,
+                                metadata_modal_open_ ? g_theme->row_active : g_theme->row_hover,
                                 g_theme->text).clicked) {
-        active_tab_ = tab::script;
-    }
-    if (ui::draw_button_colored(tab_button_rect(1), "Metadata", 14,
-                                active_tab_ == tab::metadata ? g_theme->row_selected : g_theme->row,
-                                active_tab_ == tab::metadata ? g_theme->row_active : g_theme->row_hover,
-                                g_theme->text).clicked) {
-        active_tab_ = tab::metadata;
+        metadata_modal_open_ = true;
+        metadata_modal_open_anim_ = 0.0f;
+        panel_state_.editor.active = false;
+        name_input_.active = false;
+        author_input_.active = false;
     }
 
     Rectangle content = {
@@ -129,31 +192,43 @@ void mv_editor_scene::draw() {
         static_cast<float>(kScreenHeight) - kHeaderHeight - kPadding * 2.0f
     };
 
-    if (active_tab_ == tab::script) {
-        const auto result = mv_script_panel::draw({content, virtual_screen::get_virtual_mouse()}, panel_state_);
-        if (result.text_changed) {
-            dirty_ = true;
-            last_change_time_ = GetTime();
-            pending_compile_ = true;
-        }
-    } else {
-        ui::draw_panel(content);
+    const auto result = mv_script_panel::draw({content, virtual_screen::get_virtual_mouse()}, panel_state_);
+    if (result.text_changed) {
+        dirty_ = true;
+        last_change_time_ = GetTime();
+        pending_compile_ = true;
+    }
 
+    if (metadata_modal_open_) {
+        const float anim_t = ease_out_cubic(metadata_modal_open_anim_);
+        const Rectangle modal = metadata_modal_rect(metadata_modal_open_anim_);
         const Rectangle body = {
-            content.x + 20.0f,
-            content.y + 20.0f,
-            content.width - 40.0f,
-            content.height - 40.0f
+            modal.x + kMetadataModalPaddingX,
+            modal.y + kMetadataBodyTop,
+            modal.width - kMetadataModalPaddingX * 2.0f,
+            modal.height - kMetadataBodyTop - 18.0f
         };
-
-        const Rectangle name_rect = {body.x, body.y, body.width, 42.0f};
-        const Rectangle author_rect = {body.x, body.y + 56.0f, body.width, 42.0f};
+        const Rectangle name_rect = {body.x, body.y, body.width, kMetadataRowHeight};
+        const Rectangle author_rect = {body.x, body.y + kMetadataRowHeight + kMetadataRowGap,
+                                       body.width, kMetadataRowHeight};
+        DrawRectangleRec({0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)},
+                         with_alpha(g_theme->pause_overlay, static_cast<unsigned char>(180.0f + anim_t * 40.0f)));
+        ui::draw_panel(modal);
+        ui::draw_text_in_rect("MV Metadata", 28,
+                              {modal.x + kMetadataModalPaddingX, modal.y + kMetadataHeaderTop,
+                               modal.width - kMetadataModalPaddingX * 2.0f, kMetadataTitleHeight},
+                              g_theme->text, ui::text_align::left);
+        ui::draw_text_in_rect("Update the MV title and author.", 14,
+                              {modal.x + kMetadataModalPaddingX,
+                               modal.y + kMetadataHeaderTop + kMetadataTitleHeight + kMetadataHeaderGap,
+                               modal.width - kMetadataModalPaddingX * 2.0f, kMetadataSubtitleHeight},
+                              g_theme->text_secondary, ui::text_align::left);
 
         const auto name_result = ui::draw_text_input(name_rect, name_input_, "MV Name", "Untitled MV",
-                                                     nullptr, ui::draw_layer::base, 16, 128,
+                                                     nullptr, ui::draw_layer::modal, 16, 128,
                                                      wide_text_filter, 120.0f);
         const auto author_result = ui::draw_text_input(author_rect, author_input_, "Author", "Author name",
-                                                       nullptr, ui::draw_layer::base, 16, 128,
+                                                       nullptr, ui::draw_layer::modal, 16, 128,
                                                        wide_text_filter, 120.0f);
         if (name_result.changed || author_result.changed) {
             dirty_ = true;

--- a/src/scenes/mv_editor_scene.h
+++ b/src/scenes/mv_editor_scene.h
@@ -19,11 +19,6 @@ public:
     void draw() override;
 
 private:
-    enum class tab {
-        script,
-        metadata,
-    };
-
     void compile_script();
     void save_mv();
 
@@ -32,7 +27,8 @@ private:
     mv_script_panel_state panel_state_;
     ui::text_input_state name_input_;
     ui::text_input_state author_input_;
-    tab active_tab_ = tab::script;
+    bool metadata_modal_open_ = false;
+    float metadata_modal_open_anim_ = 0.0f;
     bool dirty_ = false;
     double last_change_time_ = 0.0;
     bool pending_compile_ = false;

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -65,12 +65,13 @@ std::string format_recent_offset_label(float offset_ms) {
 
 namespace song_select {
 
-void draw_frame() {
+void draw_frame(const state& state) {
     const auto& theme = *g_theme;
     ui::draw_panel(layout::kLeftPanelRect);
     ui::draw_panel(layout::kSongListRect);
     ui::draw_text_in_rect("SONG SELECT", 30, layout::kSceneTitleRect, theme.text, ui::text_align::left);
-    ui::draw_button_colored(layout::kLoginButtonRect, "LOGIN", 20,
+    const char* login_label = state.auth.logged_in ? "ACCOUNT" : "LOGIN";
+    ui::draw_button_colored(layout::kLoginButtonRect, login_label, 20,
                             theme.row, theme.row_hover, theme.text);
     ui::draw_button_colored(layout::kSettingsButtonRect, "SETTINGS", 20,
                             theme.row, theme.row_hover, theme.text);
@@ -193,17 +194,7 @@ void draw_song_details(const state& state, const preview_controller& preview_con
 }
 
 void draw_status_message(const state& state) {
-    if (state.status_message.empty()) {
-        return;
-    }
-
-    const auto& theme = *g_theme;
-    ui::draw_text_in_rect(state.status_message.c_str(), 18,
-                          ui::place(layout::kScreenRect, 520.0f, 24.0f,
-                                    ui::anchor::bottom_right, ui::anchor::bottom_right,
-                                    {-24.0f, -10.0f}),
-                          state.status_message_is_error ? theme.error : theme.success,
-                          ui::text_align::right);
+    ui::draw_notice_queue_bottom_right(state.notices, layout::kScreenRect);
 }
 
 void draw_busy_overlay(const std::string& message) {

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -70,6 +70,8 @@ void draw_frame() {
     ui::draw_panel(layout::kLeftPanelRect);
     ui::draw_panel(layout::kSongListRect);
     ui::draw_text_in_rect("SONG SELECT", 30, layout::kSceneTitleRect, theme.text, ui::text_align::left);
+    ui::draw_button_colored(layout::kLoginButtonRect, "LOGIN", 20,
+                            theme.row, theme.row_hover, theme.text);
     ui::draw_button_colored(layout::kSettingsButtonRect, "SETTINGS", 20,
                             theme.row, theme.row_hover, theme.text);
 }

--- a/src/scenes/song_select/song_select_detail_view.h
+++ b/src/scenes/song_select/song_select_detail_view.h
@@ -5,7 +5,7 @@
 
 namespace song_select {
 
-void draw_frame();
+void draw_frame(const state& state);
 void draw_empty_state(const state& state);
 void draw_song_details(const state& state, const preview_controller& preview_controller);
 void draw_status_message(const state& state);

--- a/src/scenes/song_select/song_select_layout.h
+++ b/src/scenes/song_select/song_select_layout.h
@@ -76,6 +76,9 @@ inline constexpr float kContextMenuItemHeight = 30.0f;
 inline constexpr float kContextMenuItemSpacing = 4.0f;
 inline constexpr Rectangle kConfirmDialogRect = ui::place(kScreenRect, 480.0f, 208.0f,
                                                           ui::anchor::center, ui::anchor::center);
+inline constexpr Rectangle kLoginDialogRect = ui::place(kScreenRect, 760.0f, 560.0f,
+                                                        ui::anchor::center, ui::anchor::center,
+                                                        {0.0f, 12.0f});
 
 inline Rectangle make_context_menu_rect(Vector2 anchor, int item_count) {
     const float height = 12.0f + static_cast<float>(item_count) * kContextMenuItemHeight +

--- a/src/scenes/song_select/song_select_layout.h
+++ b/src/scenes/song_select/song_select_layout.h
@@ -18,6 +18,9 @@ inline constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreen
 inline constexpr Rectangle kSettingsButtonRect = ui::place(kScreenRect, 162.0f, 30.0f,
                                                            ui::anchor::top_right, ui::anchor::top_right,
                                                            {-24.0f, 4.0f});
+inline constexpr Rectangle kLoginButtonRect = ui::place(kSettingsButtonRect, 120.0f, 30.0f,
+                                                        ui::anchor::top_left, ui::anchor::top_right,
+                                                        {-10.0f, 0.0f});
 inline constexpr Rectangle kSongListRect = ui::place(kScreenRect, 466.0f, 660.0f,
                                                      ui::anchor::top_right, ui::anchor::top_right,
                                                      {-24.0f, 44.0f});

--- a/src/scenes/song_select/song_select_layout.h
+++ b/src/scenes/song_select/song_select_layout.h
@@ -45,7 +45,7 @@ inline constexpr Rectangle kRankingListRect = ui::scroll_view(kRankingPanelRect,
 inline constexpr Rectangle kRankingScrollbarTrackRect = ui::place(kRankingListRect, 6.0f, kRankingListRect.height,
                                                                   ui::anchor::top_right, ui::anchor::top_right,
                                                                   {-8.0f, 0.0f});
-inline constexpr float kRankingRowHeight = 42.0f;
+inline constexpr float kRankingRowHeight = 54.0f;
 inline constexpr float kDetailColumnX = kJacketRect.x + kJacketRect.width + 20.0f;
 inline constexpr float kDetailColumnWidth = kLeftPanelRect.x + kLeftPanelRect.width - kDetailColumnX - 16.0f;
 inline constexpr Rectangle kLocalOffsetLabelRect = {kDetailColumnX, kJacketRect.y + 236.0f, kDetailColumnWidth, 22.0f};

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -1,0 +1,178 @@
+#include "song_select/song_select_login_dialog.h"
+
+#include "song_select/song_select_layout.h"
+#include "theme.h"
+#include "ui_draw.h"
+
+namespace {
+
+constexpr ui::draw_layer kModalLayer = song_select::layout::kModalLayer;
+constexpr float kDialogWidth = 360.0f;
+constexpr float kLoginDialogHeight = 308.0f;
+constexpr float kAccountDialogHeight = 238.0f;
+constexpr float kDialogOffsetY = 18.0f;
+constexpr float kDialogPaddingX = 18.0f;
+constexpr float kTitleHeight = 26.0f;
+constexpr float kSubtitleHeight = 18.0f;
+constexpr float kHeaderTop = 18.0f;
+constexpr float kHeaderGap = 6.0f;
+constexpr float kBodyTop = 86.0f;
+constexpr float kRowHeight = 36.0f;
+constexpr float kRowGap = 8.0f;
+constexpr float kButtonHeight = 36.0f;
+constexpr float kButtonGap = 8.0f;
+constexpr float kPrimaryButtonWidth = 128.0f;
+constexpr float kSecondaryButtonWidth = 164.0f;
+constexpr float kHelperTextHeight = 18.0f;
+
+float ease_out_cubic(float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    const float inv = 1.0f - clamped;
+    return 1.0f - inv * inv * inv;
+}
+
+Rectangle dialog_rect_for(const song_select::state& state) {
+    const float dialog_height = state.auth.logged_in
+        ? kAccountDialogHeight
+        : kLoginDialogHeight;
+    Rectangle rect = {
+        song_select::layout::kLoginButtonRect.x + song_select::layout::kLoginButtonRect.width - kDialogWidth,
+        song_select::layout::kLoginButtonRect.y + song_select::layout::kLoginButtonRect.height + kDialogOffsetY,
+        kDialogWidth,
+        dialog_height
+    };
+    rect.x = std::clamp(rect.x, 12.0f, song_select::layout::kScreenRect.width - rect.width - 12.0f);
+    rect.y = std::clamp(rect.y, 12.0f, song_select::layout::kScreenRect.height - rect.height - 12.0f);
+    const float anim_t = ease_out_cubic(state.login_dialog.open_anim);
+    rect.y -= (1.0f - anim_t) * 18.0f;
+    return rect;
+}
+
+Rectangle make_row(const Rectangle& dialog_rect, int index) {
+    return {
+        dialog_rect.x + kDialogPaddingX,
+        dialog_rect.y + kBodyTop + static_cast<float>(index) * (kRowHeight + kRowGap),
+        dialog_rect.width - kDialogPaddingX * 2.0f,
+        kRowHeight
+    };
+}
+
+bool printable_filter(int codepoint, const std::string&) {
+    return codepoint >= 32 && codepoint != 127;
+}
+
+}  // namespace
+
+namespace song_select {
+
+void open_login_dialog(state& state, const auth::session_summary& summary) {
+    state.login_dialog.open = true;
+    state.login_dialog.open_anim = 0.0f;
+    state.login_dialog.status_message.clear();
+    state.login_dialog.status_message_is_error = false;
+    state.login_dialog.email_input.value = summary.email;
+    state.login_dialog.password_input.value.clear();
+}
+
+Rectangle login_dialog_rect(const state& state) {
+    return dialog_rect_for(state);
+}
+
+login_dialog_command draw_login_dialog(state& state, bool request_active) {
+    if (!state.login_dialog.open) {
+        return login_dialog_command::none;
+    }
+
+    const auto& theme = *g_theme;
+    const Rectangle dialog_rect = dialog_rect_for(state);
+    const float form_x = dialog_rect.x + kDialogPaddingX;
+    const float form_width = dialog_rect.width - kDialogPaddingX * 2.0f;
+    const float footer_y = dialog_rect.y + dialog_rect.height - 18.0f - kButtonHeight;
+
+    ui::draw_panel(dialog_rect);
+    ui::draw_text_in_rect("Account", 24,
+                          {dialog_rect.x + kDialogPaddingX, dialog_rect.y + kHeaderTop,
+                           dialog_rect.width - kDialogPaddingX * 2.0f, kTitleHeight},
+                          theme.text, ui::text_align::left);
+    ui::draw_text_in_rect("Connect to raythm-Server", 14,
+                          {dialog_rect.x + kDialogPaddingX, dialog_rect.y + kHeaderTop + kTitleHeight + kHeaderGap,
+                           dialog_rect.width - kDialogPaddingX * 2.0f, kSubtitleHeight},
+                          theme.text_secondary, ui::text_align::left);
+
+    if (state.auth.logged_in) {
+        const Rectangle signed_in_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 22.0f};
+        const Rectangle display_name_rect = {form_x, dialog_rect.y + kBodyTop + 28.0f, form_width, 20.0f};
+        const Rectangle email_rect = {form_x, dialog_rect.y + kBodyTop + 52.0f, form_width, 16.0f};
+        const Rectangle button_row = {form_x, footer_y, form_width, kButtonHeight};
+        constexpr float kButtonWidth = 92.0f;
+        const Rectangle logout_rect = {button_row.x + button_row.width - kButtonWidth, button_row.y, kButtonWidth, kButtonHeight};
+        const Rectangle refresh_rect = {logout_rect.x - kButtonWidth - kButtonGap, button_row.y, kButtonWidth, kButtonHeight};
+
+        ui::draw_text_in_rect("Signed in", 20, signed_in_rect, theme.success, ui::text_align::left);
+        ui::draw_text_in_rect(state.auth.display_name.empty() ? state.auth.email.c_str() : state.auth.display_name.c_str(),
+                              18,
+                              display_name_rect,
+                              theme.text_secondary,
+                              ui::text_align::left);
+        ui::draw_text_in_rect(state.auth.email.c_str(),
+                              14,
+                              email_rect,
+                              theme.text_muted,
+                              ui::text_align::left);
+
+        if (!state.login_dialog.status_message.empty()) {
+            ui::draw_text_in_rect(state.login_dialog.status_message.c_str(), 13,
+                                  {form_x, footer_y - 28.0f, form_width, 20.0f},
+                                  state.login_dialog.status_message_is_error ? theme.error : theme.success,
+                                  ui::text_align::left);
+        }
+
+        if (ui::enqueue_button(refresh_rect, "REFRESH", 14, kModalLayer, 1.5f).clicked && !request_active) {
+            return login_dialog_command::request_restore;
+        }
+        if (ui::enqueue_button(logout_rect, "LOGOUT", 14, kModalLayer, 1.5f).clicked && !request_active) {
+            return login_dialog_command::request_logout;
+        }
+        return login_dialog_command::none;
+    }
+
+    int row = 0;
+    const ui::text_input_result email_result = ui::draw_text_input(
+        make_row(dialog_rect, row++), state.login_dialog.email_input, "Email", "name@example.com",
+        nullptr, kModalLayer, 15, 64, printable_filter, 90.0f);
+
+    const ui::text_input_result password_result = ui::draw_text_input(
+        make_row(dialog_rect, row++), state.login_dialog.password_input, "Pass", "At least 8 characters",
+        nullptr, kModalLayer, 15, 64, printable_filter, 90.0f);
+
+    const float action_top = dialog_rect.y + 166.0f;
+    const Rectangle message_rect = {form_x, action_top, form_width, 18.0f};
+    const Rectangle login_button_row = {form_x, action_top + 28.0f, form_width, kButtonHeight};
+    const Rectangle helper_rect = {form_x, action_top + 72.0f, form_width, kHelperTextHeight};
+    const Rectangle web_button_row = {form_x, action_top + 94.0f, form_width, kButtonHeight};
+    const Rectangle primary_rect = ui::place(login_button_row, kPrimaryButtonWidth, kButtonHeight,
+                                             ui::anchor::center, ui::anchor::center);
+    const Rectangle web_button_rect = ui::place(web_button_row, kSecondaryButtonWidth, kButtonHeight,
+                                                ui::anchor::center, ui::anchor::center);
+
+    const bool submitted = email_result.submitted || password_result.submitted;
+
+    if (!state.login_dialog.status_message.empty()) {
+        ui::draw_text_in_rect(state.login_dialog.status_message.c_str(), 16, message_rect,
+                              state.login_dialog.status_message_is_error ? theme.error : theme.success,
+                              ui::text_align::left);
+    }
+
+    ui::enqueue_text_in_rect("New to raythm? Register on the Web.", 14, helper_rect,
+                             theme.text_muted, ui::text_align::center, kModalLayer);
+    if (ui::enqueue_button(web_button_rect, "Create Account", 15, kModalLayer, 1.5f).clicked && !request_active) {
+        return login_dialog_command::open_register_web;
+    }
+    if ((ui::enqueue_button(primary_rect, "LOGIN", 16, kModalLayer, 1.5f).clicked || submitted) && !request_active) {
+        return login_dialog_command::request_login;
+    }
+
+    return login_dialog_command::none;
+}
+
+}  // namespace song_select

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -9,7 +9,7 @@ namespace {
 constexpr ui::draw_layer kModalLayer = song_select::layout::kModalLayer;
 constexpr float kDialogWidth = 360.0f;
 constexpr float kLoginDialogHeight = 308.0f;
-constexpr float kAccountDialogHeight = 238.0f;
+constexpr float kAccountDialogHeight = 258.0f;
 constexpr float kDialogOffsetY = 18.0f;
 constexpr float kDialogPaddingX = 18.0f;
 constexpr float kTitleHeight = 26.0f;
@@ -103,6 +103,7 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
         const Rectangle signed_in_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 22.0f};
         const Rectangle display_name_rect = {form_x, dialog_rect.y + kBodyTop + 28.0f, form_width, 20.0f};
         const Rectangle email_rect = {form_x, dialog_rect.y + kBodyTop + 52.0f, form_width, 16.0f};
+        const Rectangle verify_rect = {form_x, dialog_rect.y + kBodyTop + 74.0f, form_width, 16.0f};
         const Rectangle button_row = {form_x, footer_y, form_width, kButtonHeight};
         constexpr float kButtonWidth = 92.0f;
         const Rectangle logout_rect = {button_row.x + button_row.width - kButtonWidth, button_row.y, kButtonWidth, kButtonHeight};
@@ -118,6 +119,13 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
                               14,
                               email_rect,
                               theme.text_muted,
+                              ui::text_align::left);
+        ui::draw_text_in_rect(state.auth.email_verified
+                                  ? "Email verified"
+                                  : "Verify on the Web to submit online scores.",
+                              13,
+                              verify_rect,
+                              state.auth.email_verified ? theme.success : theme.error,
                               ui::text_align::left);
 
         if (!state.login_dialog.status_message.empty()) {
@@ -165,7 +173,7 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
 
     ui::enqueue_text_in_rect("New to raythm? Register on the Web.", 14, helper_rect,
                              theme.text_muted, ui::text_align::center, kModalLayer);
-    if (ui::enqueue_button(web_button_rect, "Create Account", 15, kModalLayer, 1.5f).clicked && !request_active) {
+    if (ui::enqueue_button(web_button_rect, "Create", 15, kModalLayer, 1.5f).clicked && !request_active) {
         return login_dialog_command::open_register_web;
     }
     if ((ui::enqueue_button(primary_rect, "LOGIN", 16, kModalLayer, 1.5f).clicked || submitted) && !request_active) {

--- a/src/scenes/song_select/song_select_login_dialog.h
+++ b/src/scenes/song_select/song_select_login_dialog.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "network/auth_client.h"
+#include "song_select/song_select_state.h"
+
+namespace song_select {
+
+enum class login_dialog_command {
+    none,
+    close,
+    request_restore,
+    request_login,
+    open_register_web,
+    request_logout,
+};
+
+void open_login_dialog(state& state, const auth::session_summary& summary);
+Rectangle login_dialog_rect(const state& state);
+login_dialog_command draw_login_dialog(state& state, bool request_active);
+
+}  // namespace song_select

--- a/src/scenes/song_select/song_select_ranking_view.cpp
+++ b/src/scenes/song_select/song_select_ranking_view.cpp
@@ -168,18 +168,24 @@ void draw_ranking_row(const ranking_service::entry& entry, float y, float offset
 
     const Rectangle placement_rect = {content.x, content.y, 36.0f, content.height};
     const Rectangle rank_rect = {content.x + 52.0f, content.y, 48.0f, content.height};
-    const Rectangle accuracy_rect = {content.x + 124.0f, content.y, 108.0f, content.height};
-    const Rectangle combo_rect = {content.x + 254.0f, content.y, 104.0f, content.height};
-    const Rectangle recorded_at_rect = {content.x + 378.0f, content.y, 90.0f, content.height};
-    const Rectangle score_rect = {content.x + 476.0f, content.y, content.width - 476.0f, content.height};
+    const Rectangle name_rect = {content.x + 124.0f, content.y, 248.0f, 18.0f};
+    const Rectangle accuracy_rect = {content.x + 124.0f, content.y + 20.0f, 108.0f, 16.0f};
+    const Rectangle combo_rect = {content.x + 236.0f, content.y + 20.0f, 110.0f, 16.0f};
+    const Rectangle recorded_at_rect = {content.x + 350.0f, content.y + 20.0f, 92.0f, 16.0f};
+    const Rectangle score_rect = {content.x + 446.0f, content.y, content.width - 446.0f, content.height};
 
     DrawRectangleRec(rank_rect, with_alpha(theme.section, alpha));
     DrawRectangleLinesEx(rank_rect, 1.5f, with_alpha(theme.border_light, alpha));
 
     ui::draw_text_in_rect(TextFormat("%02d", entry.placement), 18, placement_rect, with_alpha(theme.text, alpha), ui::text_align::center);
     ui::draw_text_in_rect(rank_label(entry.clear_rank()), 17, rank_rect, with_alpha(rank_color(entry.clear_rank()), alpha), ui::text_align::center);
-    ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), 17, accuracy_rect, with_alpha(theme.text_secondary, alpha), ui::text_align::left);
-    ui::draw_text_in_rect(TextFormat("%d Combo", entry.max_combo), 14, combo_rect, with_alpha(theme.text_muted, alpha), ui::text_align::left);
+    ui::draw_text_in_rect(entry.player_display_name.empty() ? "Unknown Player" : entry.player_display_name.c_str(),
+                          15,
+                          name_rect,
+                          with_alpha(theme.text, alpha),
+                          ui::text_align::left);
+    ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), 14, accuracy_rect, with_alpha(theme.text_secondary, alpha), ui::text_align::left);
+    ui::draw_text_in_rect(TextFormat("%d Combo", entry.max_combo), 13, combo_rect, with_alpha(theme.text_muted, alpha), ui::text_align::left);
     ui::draw_text_in_rect(format_relative_recorded_at(entry.recorded_at).c_str(), 14, recorded_at_rect,
                           with_alpha(theme.text_muted, alpha), ui::text_align::left);
     const std::string score_label = format_score(entry.score);

--- a/src/scenes/song_select/song_select_ranking_view.cpp
+++ b/src/scenes/song_select/song_select_ranking_view.cpp
@@ -53,6 +53,23 @@ int source_index(ranking_service::source source) {
     return source == ranking_service::source::local ? 0 : 1;
 }
 
+void draw_static_source_dropdown(ranking_service::source source) {
+    const auto& theme = *g_theme;
+    const ui::row_state row = ui::draw_row(song_select::layout::kRankingSourceDropdownRect,
+                                           theme.row, theme.row_hover, theme.border);
+    const Rectangle content = ui::inset(row.visual, ui::edge_insets::symmetric(0.0f, 12.0f));
+    const Rectangle arrow_rect = ui::place(content, 18.0f, content.height,
+                                           ui::anchor::center_right, ui::anchor::center_right);
+    const Rectangle value_rect = {
+        content.x,
+        content.y,
+        std::max(0.0f, arrow_rect.x - content.x - 8.0f),
+        content.height
+    };
+    ui::draw_text_in_rect(source_label(source), 18, value_rect, theme.text_dim, ui::text_align::right);
+    ui::draw_text_in_rect("v", 18, arrow_rect, theme.text_dim);
+}
+
 std::optional<std::chrono::system_clock::time_point> parse_recorded_at_utc(const std::string& value) {
     if (value.empty()) {
         return std::nullopt;
@@ -180,7 +197,7 @@ float ranking_content_height(const state& state) {
     return static_cast<float>(entry_count) * layout::kRankingRowHeight + 8.0f;
 }
 
-ranking_panel_result draw_ranking_panel(const state& state) {
+ranking_panel_result draw_ranking_panel(const state& state, bool source_dropdown_interactive) {
     const auto& theme = *g_theme;
     ranking_panel_result result;
     const float chart_anim = 1.0f - state.chart_change_anim_t;
@@ -190,25 +207,29 @@ ranking_panel_result draw_ranking_panel(const state& state) {
     ui::draw_section(layout::kRankingPanelRect);
     ui::draw_text_in_rect("RANKING", 24, layout::kRankingTitleRect, theme.text, ui::text_align::left);
 
-    const ui::dropdown_state source_dropdown = ui::enqueue_dropdown(
-        layout::kRankingSourceDropdownRect,
-        layout::ranking_source_dropdown_menu_rect(),
-        "",
-        source_label(state.ranking_panel.selected_source),
-        kRankingSourceOptions,
-        source_index(state.ranking_panel.selected_source),
-        state.ranking_panel.source_dropdown_open,
-        ui::draw_layer::base,
-        ui::draw_layer::overlay,
-        18,
-        0.0f);
-    result.source_dropdown_toggled = source_dropdown.trigger.clicked;
-    result.source_clicked_index = source_dropdown.clicked_index;
-    result.source_dropdown_close_requested =
-        state.ranking_panel.source_dropdown_open &&
-        IsMouseButtonReleased(MOUSE_BUTTON_LEFT) &&
-        !ui::is_hovered(layout::kRankingSourceDropdownRect, ui::draw_layer::base) &&
-        !ui::is_hovered(layout::ranking_source_dropdown_menu_rect(), ui::draw_layer::overlay);
+    if (source_dropdown_interactive) {
+        const ui::dropdown_state source_dropdown = ui::enqueue_dropdown(
+            layout::kRankingSourceDropdownRect,
+            layout::ranking_source_dropdown_menu_rect(),
+            "",
+            source_label(state.ranking_panel.selected_source),
+            kRankingSourceOptions,
+            source_index(state.ranking_panel.selected_source),
+            state.ranking_panel.source_dropdown_open,
+            ui::draw_layer::base,
+            ui::draw_layer::overlay,
+            18,
+            0.0f);
+        result.source_dropdown_toggled = source_dropdown.trigger.clicked;
+        result.source_clicked_index = source_dropdown.clicked_index;
+        result.source_dropdown_close_requested =
+            state.ranking_panel.source_dropdown_open &&
+            IsMouseButtonReleased(MOUSE_BUTTON_LEFT) &&
+            !ui::is_hovered(layout::kRankingSourceDropdownRect, ui::draw_layer::base) &&
+            !ui::is_hovered(layout::ranking_source_dropdown_menu_rect(), ui::draw_layer::overlay);
+    } else {
+        draw_static_source_dropdown(state.ranking_panel.selected_source);
+    }
 
     ui::scoped_clip_rect clip_scope(layout::kRankingListRect);
     const float base_y = layout::kRankingListRect.y - state.ranking_panel.scroll_y;

--- a/src/scenes/song_select/song_select_ranking_view.h
+++ b/src/scenes/song_select/song_select_ranking_view.h
@@ -10,7 +10,7 @@ struct ranking_panel_result {
     bool source_dropdown_close_requested = false;
 };
 
-ranking_panel_result draw_ranking_panel(const state& state);
+ranking_panel_result draw_ranking_panel(const state& state, bool source_dropdown_interactive = true);
 float ranking_content_height(const state& state);
 
 }  // namespace song_select

--- a/src/scenes/song_select/song_select_state.cpp
+++ b/src/scenes/song_select/song_select_state.cpp
@@ -53,15 +53,21 @@ void reset_for_enter(state& state) {
     state.scrollbar_drag_offset = 0.0f;
     state.context_menu = {};
     state.confirmation_dialog = {};
-    state.status_message.clear();
-    state.status_message_is_error = false;
+    ui::clear_notices(state.notices);
     state.recent_result_offset.reset();
     state.ranking_panel = {};
+    state.login_dialog = {};
 }
 
 void tick_animations(state& state, float dt) {
     state.song_change_anim_t = std::max(0.0f, state.song_change_anim_t - dt * 4.0f);
     state.chart_change_anim_t = std::max(0.0f, state.chart_change_anim_t - dt * 5.0f);
+    if (state.login_dialog.open) {
+        state.login_dialog.open_anim = std::min(1.0f, state.login_dialog.open_anim + dt * 8.0f);
+    } else {
+        state.login_dialog.open_anim = 0.0f;
+    }
+    ui::tick_notices(state.notices, dt);
     state.scene_fade_in.update(dt);
 }
 
@@ -170,8 +176,8 @@ void close_context_menu(state& state) {
 }
 
 void queue_status_message(state& state, std::string message, bool is_error) {
-    state.status_message = std::move(message);
-    state.status_message_is_error = is_error;
+    ui::push_notice(state.notices, std::move(message),
+                    is_error ? ui::notice_tone::error : ui::notice_tone::success);
 }
 
 float expanded_row_height(const state& state, int song_index) {

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -8,6 +8,8 @@
 #include "ranking_service.h"
 #include "raylib.h"
 #include "shared/scene_fade.h"
+#include "ui_notice.h"
+#include "ui_text_input.h"
 
 namespace song_select {
 
@@ -88,6 +90,21 @@ struct ranking_panel_state {
     float scrollbar_drag_offset = 0.0f;
 };
 
+struct auth_state {
+    bool logged_in = false;
+    std::string email;
+    std::string display_name;
+};
+
+struct login_dialog_state {
+    bool open = false;
+    float open_anim = 0.0f;
+    std::string status_message;
+    bool status_message_is_error = false;
+    ui::text_input_state email_input;
+    ui::text_input_state password_input;
+};
+
 struct state {
     std::vector<song_entry> songs;
     std::vector<std::string> load_errors;
@@ -102,10 +119,11 @@ struct state {
     float scrollbar_drag_offset = 0.0f;
     context_menu_state context_menu;
     confirmation_dialog_state confirmation_dialog;
-    std::string status_message;
-    bool status_message_is_error = false;
+    ui::notice_queue notices;
     std::optional<recent_result_offset> recent_result_offset;
     ranking_panel_state ranking_panel;
+    auth_state auth;
+    login_dialog_state login_dialog;
 };
 
 const song_entry* selected_song(const state& state);

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -94,6 +94,7 @@ struct auth_state {
     bool logged_in = false;
     std::string email;
     std::string display_name;
+    bool email_verified = false;
 };
 
 struct login_dialog_state {

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -669,6 +669,12 @@ void song_select_scene::update(float dt) {
         return;
     }
 
+    if (ui::is_clicked(song_select::layout::kLoginButtonRect, song_select::layout::kSceneLayer)) {
+        song_select::close_context_menu(state_);
+        song_select::queue_status_message(state_, "Login is not available yet.", false);
+        return;
+    }
+
     if (ui::is_clicked(song_select::layout::local_offset_double_left_rect(), song_select::layout::kSceneLayer)) {
         adjust_selected_song_local_offset(-5);
         return;

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -7,6 +7,8 @@
 #include <utility>
 
 #include "core/app_paths.h"
+#include "core/window_dialog_support.h"
+#include "network/auth_client.h"
 #include "file_dialog.h"
 #include "mv/mv_storage.h"
 #include "path_utils.h"
@@ -17,6 +19,7 @@
 #include "song_select/song_select_confirmation_dialog.h"
 #include "song_select/song_select_layout.h"
 #include "song_select/song_select_last_played.h"
+#include "song_select/song_select_login_dialog.h"
 #include "song_select/song_select_list_view.h"
 #include "song_select/song_select_navigation.h"
 #include "song_select/song_select_ranking_view.h"
@@ -28,6 +31,10 @@ namespace {
 
 std::string format_offset_label(int offset_ms) {
     return (offset_ms > 0 ? "+" : "") + std::to_string(offset_ms) + "ms";
+}
+
+std::string register_web_url() {
+    return auth::normalize_server_url(auth::kDefaultServerUrl) + "/register";
 }
 
 }  // namespace
@@ -49,12 +56,17 @@ void song_select_scene::on_enter() {
     }
     song_select::reset_for_enter(state_);
     state_.recent_result_offset = recent_result_offset_;
+    refresh_auth_state();
+    if (state_.auth.logged_in) {
+        start_auth_restore();
+    }
     reload_song_library(preferred_song_id_, preferred_chart_id_);
 }
 
 void song_select_scene::on_exit() {
     song_select::close_context_menu(state_);
     state_.confirmation_dialog = {};
+    state_.login_dialog.open = false;
     if (pending_song_import_request_.has_value()) {
         song_select::cleanup_song_import_request(*pending_song_import_request_);
         pending_song_import_request_.reset();
@@ -86,6 +98,13 @@ void song_select_scene::reload_selected_chart_ranking() {
     state_.ranking_panel.scrollbar_drag_offset = 0.0f;
 }
 
+void song_select_scene::refresh_auth_state() {
+    const auth::session_summary summary = auth::load_session_summary();
+    state_.auth.logged_in = summary.logged_in;
+    state_.auth.email = summary.email;
+    state_.auth.display_name = summary.display_name;
+}
+
 void song_select_scene::apply_delete_result(const song_select::delete_result& result) {
     state_.confirmation_dialog = {};
     if (!result.success) {
@@ -111,6 +130,102 @@ void song_select_scene::apply_transfer_result(const song_select::transfer_result
         reload_song_library(result.preferred_song_id, result.preferred_chart_id);
     }
     song_select::queue_status_message(state_, result.message, false);
+}
+
+void song_select_scene::start_auth_restore() {
+    auth_restore_active_ = true;
+    auth_restore_ = std::async(std::launch::async, []() {
+        return auth::restore_saved_session();
+    });
+}
+
+void song_select_scene::poll_auth_restore() {
+    if (!auth_restore_active_) {
+        return;
+    }
+
+    if (auth_restore_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    auth_restore_active_ = false;
+    const auth::operation_result result = auth_restore_.get();
+    refresh_auth_state();
+    if (!result.success) {
+        if (state_.login_dialog.open) {
+            state_.login_dialog.status_message = result.message;
+            state_.login_dialog.status_message_is_error = true;
+        } else {
+            song_select::queue_status_message(state_, result.message, true);
+        }
+    }
+}
+
+void song_select_scene::start_login_request(song_select::login_dialog_command command) {
+    if (auth_request_active_) {
+        return;
+    }
+
+    if (command == song_select::login_dialog_command::open_register_web) {
+        const bool opened = window_dialog_support::open_url(register_web_url());
+        state_.login_dialog.status_message = opened
+            ? "Opened the account page in your browser."
+            : "Failed to open the account page.";
+        state_.login_dialog.status_message_is_error = !opened;
+        return;
+    }
+
+    auth_request_active_ = true;
+    state_.login_dialog.status_message_is_error = false;
+    const std::string server_url = auth::kDefaultServerUrl;
+    const std::string email = state_.login_dialog.email_input.value;
+    const std::string password = state_.login_dialog.password_input.value;
+
+    switch (command) {
+    case song_select::login_dialog_command::request_restore:
+        state_.login_dialog.status_message = "Restoring session...";
+        auth_request_ = std::async(std::launch::async, []() {
+            return auth::restore_saved_session();
+        });
+        break;
+    case song_select::login_dialog_command::request_login:
+        state_.login_dialog.status_message = "Connecting to raythm-Server...";
+        auth_request_ = std::async(std::launch::async, [server_url, email, password]() {
+            return auth::login_user(server_url, email, password);
+        });
+        break;
+    case song_select::login_dialog_command::request_logout:
+        state_.login_dialog.status_message = "Logging out...";
+        auth_request_ = std::async(std::launch::async, []() {
+            return auth::logout_saved_session();
+        });
+        break;
+    case song_select::login_dialog_command::open_register_web:
+    case song_select::login_dialog_command::none:
+    case song_select::login_dialog_command::close:
+        auth_request_active_ = false;
+        break;
+    }
+}
+
+void song_select_scene::poll_login_request() {
+    if (!auth_request_active_) {
+        return;
+    }
+
+    if (auth_request_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    auth_request_active_ = false;
+    const auth::operation_result result = auth_request_.get();
+    refresh_auth_state();
+    state_.login_dialog.password_input.value.clear();
+    state_.login_dialog.status_message = result.message;
+    state_.login_dialog.status_message_is_error = !result.success;
+
+    const auth::session_summary summary = auth::load_session_summary();
+    state_.login_dialog.email_input.value = summary.email;
 }
 
 void song_select_scene::poll_song_import_prepare() {
@@ -602,18 +717,28 @@ void song_select_scene::apply_confirmation_command(song_select::confirmation_com
 
 void song_select_scene::update(float dt) {
     ui::begin_hit_regions();
+    const bool modal_ui_active = state_.confirmation_dialog.open || state_.login_dialog.open ||
+                                 background_song_import_prepare_active_ || background_transfer_active_;
+    if (modal_ui_active) {
+        state_.ranking_panel.source_dropdown_open = false;
+    }
     if (state_.context_menu.open) {
         ui::register_hit_region(state_.context_menu.rect, song_select::layout::kContextMenuLayer);
     }
-    if (state_.ranking_panel.source_dropdown_open) {
+    if (state_.ranking_panel.source_dropdown_open && !modal_ui_active) {
         ui::register_hit_region(song_select::layout::ranking_source_dropdown_menu_rect(), ui::draw_layer::overlay);
     }
     if (state_.confirmation_dialog.open) {
         ui::register_hit_region(song_select::layout::kConfirmDialogRect, song_select::layout::kModalLayer);
     }
+    if (state_.login_dialog.open) {
+        ui::register_hit_region(song_select::login_dialog_rect(state_), song_select::layout::kModalLayer);
+    }
 
     preview_controller_.update(dt, song_select::selected_song(state_));
     song_select::tick_animations(state_, dt);
+    poll_auth_restore();
+    poll_login_request();
     poll_song_import_prepare();
     poll_background_transfer();
 
@@ -624,6 +749,20 @@ void song_select_scene::update(float dt) {
     }
 
     if (background_song_import_prepare_active_ || background_transfer_active_) {
+        return;
+    }
+
+    if (state_.login_dialog.open) {
+        const Vector2 mouse = virtual_screen::get_virtual_mouse();
+        if (!auth_request_active_ &&
+            IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+            !CheckCollisionPointRec(mouse, song_select::login_dialog_rect(state_))) {
+            state_.login_dialog.open = false;
+            return;
+        }
+        if (IsKeyPressed(KEY_ESCAPE) && !auth_request_active_) {
+            state_.login_dialog.open = false;
+        }
         return;
     }
 
@@ -671,7 +810,7 @@ void song_select_scene::update(float dt) {
 
     if (ui::is_clicked(song_select::layout::kLoginButtonRect, song_select::layout::kSceneLayer)) {
         song_select::close_context_menu(state_);
-        song_select::queue_status_message(state_, "Login is not available yet.", false);
+        song_select::open_login_dialog(state_, auth::load_session_summary());
         return;
     }
 
@@ -821,7 +960,7 @@ void song_select_scene::draw() {
     ClearBackground(theme.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, theme.bg, theme.bg_alt);
     ui::begin_draw_queue();
-    song_select::draw_frame();
+    song_select::draw_frame(state_);
     song_select::draw_song_list(state_);
 
     if (state_.songs.empty()) {
@@ -831,6 +970,13 @@ void song_select_scene::draw() {
             song_select::draw_busy_overlay(background_transfer_label_);
         }
         apply_context_menu_command(song_select::draw_context_menu(state_));
+        const song_select::login_dialog_command login_command =
+            song_select::draw_login_dialog(state_, auth_request_active_);
+        if (login_command == song_select::login_dialog_command::close) {
+            state_.login_dialog.open = false;
+        } else if (login_command != song_select::login_dialog_command::none) {
+            start_login_request(login_command);
+        }
         ui::flush_draw_queue();
         virtual_screen::end();
         ClearBackground(BLACK);
@@ -839,13 +985,26 @@ void song_select_scene::draw() {
     }
 
     song_select::draw_song_details(state_, preview_controller_);
-    const song_select::ranking_panel_result ranking_result = song_select::draw_ranking_panel(state_);
+    const bool ranking_source_dropdown_interactive =
+        !state_.confirmation_dialog.open &&
+        !state_.login_dialog.open &&
+        !background_song_import_prepare_active_ &&
+        !background_transfer_active_;
+    const song_select::ranking_panel_result ranking_result =
+        song_select::draw_ranking_panel(state_, ranking_source_dropdown_interactive);
     song_select::draw_status_message(state_);
     if (background_song_import_prepare_active_ || background_transfer_active_) {
         song_select::draw_busy_overlay(background_transfer_label_);
     }
     apply_context_menu_command(song_select::draw_context_menu(state_));
     apply_confirmation_command(song_select::draw_confirmation_dialog(state_));
+    const song_select::login_dialog_command login_command =
+        song_select::draw_login_dialog(state_, auth_request_active_);
+    if (login_command == song_select::login_dialog_command::close) {
+        state_.login_dialog.open = false;
+    } else if (login_command != song_select::login_dialog_command::none) {
+        start_login_request(login_command);
+    }
     if (ranking_result.source_dropdown_toggled) {
         state_.ranking_panel.source_dropdown_open = !state_.ranking_panel.source_dropdown_open;
     }

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -103,6 +103,7 @@ void song_select_scene::refresh_auth_state() {
     state_.auth.logged_in = summary.logged_in;
     state_.auth.email = summary.email;
     state_.auth.display_name = summary.display_name;
+    state_.auth.email_verified = summary.email_verified;
 }
 
 void song_select_scene::apply_delete_result(const song_select::delete_result& result) {

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -4,11 +4,13 @@
 #include <optional>
 #include <string>
 
+#include "network/auth_client.h"
 #include "raylib.h"
 #include "scene.h"
 #include "song_select/song_import_export_service.h"
 #include "song_select/song_catalog_service.h"
 #include "song_select/song_select_confirmation_dialog.h"
+#include "song_select/song_select_login_dialog.h"
 #include "song_select/song_preview_controller.h"
 #include "song_select/song_select_overlay_view.h"
 #include "song_select/song_select_state.h"
@@ -30,6 +32,10 @@ private:
     void sync_selected_song_media();
     void apply_delete_result(const song_select::delete_result& result);
     void apply_transfer_result(const song_select::transfer_result& result);
+    void start_auth_restore();
+    void poll_auth_restore();
+    void start_login_request(song_select::login_dialog_command command);
+    void poll_login_request();
     void poll_song_import_prepare();
     void poll_background_transfer();
     void start_song_import_prepare(std::string source_path);
@@ -40,6 +46,7 @@ private:
     bool adjust_selected_song_local_offset(int delta_ms);
     bool apply_recent_result_offset();
     void reload_selected_chart_ranking();
+    void refresh_auth_state();
     bool handle_song_list_pointer(Vector2 mouse, bool left_pressed, bool right_pressed);
     void apply_context_menu_command(song_select::context_menu_command command);
     void apply_confirmation_command(song_select::confirmation_command command);
@@ -51,8 +58,12 @@ private:
     std::optional<song_select::recent_result_offset> recent_result_offset_;
     std::future<song_select::transfer_result> background_transfer_;
     std::future<song_select::song_import_prepare_result> background_song_import_prepare_;
+    std::future<auth::operation_result> auth_restore_;
+    std::future<auth::operation_result> auth_request_;
     bool background_transfer_active_ = false;
     bool background_song_import_prepare_active_ = false;
+    bool auth_restore_active_ = false;
+    bool auth_request_active_ = false;
     std::string background_transfer_label_;
     std::optional<song_select::song_import_request> pending_song_import_request_;
     std::optional<song_select::chart_import_request> pending_chart_import_request_;

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -58,7 +58,7 @@ int main() {
     const ranking_service::listing online_listing =
         ranking_service::load_chart_ranking(chart.chart_id, ranking_service::source::online, 50);
     if (online_listing.available || online_listing.message.empty()) {
-        std::cerr << "Online placeholder listing failed\n";
+        std::cerr << "Online unavailable listing failed\n";
         return EXIT_FAILURE;
     }
 

--- a/src/tests/song_select_state_smoke.cpp
+++ b/src/tests/song_select_state_smoke.cpp
@@ -44,8 +44,13 @@ int main() {
     assert(state.difficulty_index == 1);
     assert(state.scroll_y == 0.0f);
     assert(state.scroll_y_target == 0.0f);
+    assert(std::fabs(song_select::layout::kLoginButtonRect.y - song_select::layout::kSettingsButtonRect.y) < 0.01f);
+    assert(std::fabs(song_select::layout::kLoginButtonRect.x + song_select::layout::kLoginButtonRect.width + 10.0f -
+                     song_select::layout::kSettingsButtonRect.x) < 0.01f);
 
-    const float expected_height = song_select::layout::kRowHeight + 14.0f + 2.0f * 30.0f + song_select::layout::kRowHeight;
+    const float expected_height = song_select::layout::kSongListTopPadding +
+                                  song_select::layout::kRowHeight + 14.0f + 2.0f * 30.0f +
+                                  song_select::layout::kRowHeight;
     assert(std::fabs(song_select::content_height(state) - expected_height) < 0.01f);
 
     const bool changed = song_select::apply_song_selection(state, 1, 3);

--- a/src/tests/song_select_state_smoke.cpp
+++ b/src/tests/song_select_state_smoke.cpp
@@ -53,6 +53,17 @@ int main() {
                                   song_select::layout::kRowHeight;
     assert(std::fabs(song_select::content_height(state) - expected_height) < 0.01f);
 
+    song_select::queue_status_message(state, "First notice", true);
+    song_select::queue_status_message(state, "Second notice", false);
+    assert(state.notices.items.size() == 2);
+    assert(state.notices.items.front().message == "First notice");
+    assert(state.notices.items.back().message == "Second notice");
+
+    song_select::tick_animations(state, 1.0f);
+    assert(state.notices.items.size() == 2);
+    song_select::tick_animations(state, 1.0f);
+    assert(state.notices.items.empty());
+
     const bool changed = song_select::apply_song_selection(state, 1, 3);
     assert(changed);
     assert(state.selected_song_index == 1);

--- a/src/ui/ui_notice.h
+++ b/src/ui/ui_notice.h
@@ -1,0 +1,123 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "raylib.h"
+#include "theme.h"
+#include "ui_font.h"
+#include "ui_layout.h"
+#include "ui_text.h"
+
+namespace ui {
+
+enum class notice_tone {
+    info,
+    success,
+    error,
+};
+
+struct notice_entry {
+    std::string message;
+    notice_tone tone = notice_tone::info;
+    float remaining_seconds = 0.0f;
+    float lifetime_seconds = 0.0f;
+};
+
+struct notice_queue {
+    std::vector<notice_entry> items;
+};
+
+inline void clear_notices(notice_queue& queue) {
+    queue.items.clear();
+}
+
+inline void push_notice(notice_queue& queue, std::string message, notice_tone tone, float lifetime_seconds = 2.0f) {
+    if (message.empty()) {
+        return;
+    }
+    queue.items.push_back({
+        .message = std::move(message),
+        .tone = tone,
+        .remaining_seconds = lifetime_seconds,
+        .lifetime_seconds = lifetime_seconds,
+    });
+}
+
+inline void tick_notices(notice_queue& queue, float dt) {
+    for (notice_entry& notice : queue.items) {
+        notice.remaining_seconds = std::max(0.0f, notice.remaining_seconds - dt);
+    }
+    std::erase_if(queue.items, [](const notice_entry& notice) {
+        return notice.remaining_seconds <= 0.0f;
+    });
+}
+
+inline Color notice_color(notice_tone tone) {
+    switch (tone) {
+    case notice_tone::success:
+        return g_theme->success;
+    case notice_tone::error:
+        return g_theme->error;
+    case notice_tone::info:
+    default:
+        return g_theme->accent;
+    }
+}
+
+inline unsigned char notice_alpha(const notice_entry& notice) {
+    if (notice.lifetime_seconds <= 0.0f) {
+        return 255;
+    }
+
+    constexpr float kFadeWindowSeconds = 0.18f;
+    const float fade_in = std::min(1.0f, (notice.lifetime_seconds - notice.remaining_seconds) / kFadeWindowSeconds);
+    const float fade_out = std::min(1.0f, notice.remaining_seconds / kFadeWindowSeconds);
+    const float alpha = std::clamp(std::min(fade_in, fade_out), 0.0f, 1.0f);
+    return static_cast<unsigned char>(160.0f + 95.0f * alpha);
+}
+
+inline void draw_notice_queue_bottom_right(const notice_queue& queue, Rectangle bounds,
+                                           float right_margin = 24.0f, float bottom_margin = 16.0f,
+                                           float max_width = 460.0f, float min_width = 140.0f,
+                                           float vertical_gap = 10.0f) {
+    if (queue.items.empty()) {
+        return;
+    }
+
+    constexpr float kHorizontalPadding = 12.0f;
+    constexpr float kVerticalPadding = 6.0f;
+    constexpr int kFontSize = 18;
+    float bottom_y = bounds.y + bounds.height - bottom_margin;
+
+    for (auto it = queue.items.rbegin(); it != queue.items.rend(); ++it) {
+        const notice_entry& notice = *it;
+        const Color tone = notice_color(notice.tone);
+        const unsigned char alpha = notice_alpha(notice);
+        const Vector2 measured = measure_text_size(notice.message, static_cast<float>(kFontSize));
+        const float width = std::clamp(measured.x + kHorizontalPadding * 2.0f, min_width, max_width);
+        const float height = std::max(30.0f, measured.y + kVerticalPadding * 2.0f);
+        const Rectangle rect = {
+            bounds.x + bounds.width - right_margin - width,
+            bottom_y - height,
+            width,
+            height
+        };
+
+        const Color background = with_alpha(lerp_color(g_theme->panel, tone, 0.12f), alpha);
+        const Color border = with_alpha(lerp_color(g_theme->border, tone, 0.45f), alpha);
+        const Color text_color = with_alpha(tone, alpha);
+
+        DrawRectangleRec(rect, background);
+        DrawRectangleLinesEx(rect, 2.0f, border);
+        draw_text_in_rect(notice.message.c_str(), kFontSize,
+                          inset(rect, edge_insets::symmetric(kVerticalPadding, kHorizontalPadding)),
+                          text_color, text_align::right);
+
+        bottom_y = rect.y - vertical_gap;
+    }
+}
+
+}  // namespace ui

--- a/src/ui/ui_text_input.h
+++ b/src/ui/ui_text_input.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <algorithm>
 #include <cstddef>
 #include <cmath>
 #include <string>
+#include <string_view>
 
 #include "raylib.h"
 #include "ui_draw.h"
@@ -14,6 +16,11 @@ using text_input_filter = bool (*)(int codepoint, const std::string& current_val
 struct text_input_state {
     std::string value;
     bool active = false;
+    size_t cursor = 0;
+    bool has_selection = false;
+    size_t selection_anchor = 0;
+    bool mouse_selecting = false;
+    float scroll_x = 0.0f;
 };
 
 struct text_input_result {
@@ -48,6 +55,31 @@ inline size_t utf8_codepoint_count(const std::string& value) {
     return count;
 }
 
+inline size_t utf8_codepoint_to_byte_index(const std::string& value, size_t codepoint_index) {
+    if (codepoint_index == 0) {
+        return 0;
+    }
+
+    size_t count = 0;
+    for (size_t i = 0; i < value.size(); ++i) {
+        const unsigned char c = static_cast<unsigned char>(value[i]);
+        if ((c & 0xC0u) != 0x80u) {
+            if (count == codepoint_index) {
+                return i;
+            }
+            ++count;
+        }
+    }
+    return value.size();
+}
+
+inline std::string utf8_substr_codepoints(const std::string& value, size_t start_codepoint,
+                                          size_t end_codepoint) {
+    const size_t start = utf8_codepoint_to_byte_index(value, start_codepoint);
+    const size_t end = utf8_codepoint_to_byte_index(value, end_codepoint);
+    return value.substr(start, end - start);
+}
+
 inline void pop_last_utf8_codepoint(std::string& value) {
     if (value.empty()) {
         return;
@@ -61,6 +93,197 @@ inline void pop_last_utf8_codepoint(std::string& value) {
     value.resize(next_size);
 }
 
+inline bool decode_next_utf8_codepoint(std::string_view text, size_t offset,
+                                       int& codepoint, size_t& next_offset) {
+    if (offset >= text.size()) {
+        return false;
+    }
+
+    const unsigned char c0 = static_cast<unsigned char>(text[offset]);
+    if (c0 < 0x80u) {
+        codepoint = c0;
+        next_offset = offset + 1;
+        return true;
+    }
+
+    if ((c0 & 0xE0u) == 0xC0u && offset + 1 < text.size()) {
+        const unsigned char c1 = static_cast<unsigned char>(text[offset + 1]);
+        codepoint = ((c0 & 0x1Fu) << 6) | (c1 & 0x3Fu);
+        next_offset = offset + 2;
+        return true;
+    }
+
+    if ((c0 & 0xF0u) == 0xE0u && offset + 2 < text.size()) {
+        const unsigned char c1 = static_cast<unsigned char>(text[offset + 1]);
+        const unsigned char c2 = static_cast<unsigned char>(text[offset + 2]);
+        codepoint = ((c0 & 0x0Fu) << 12) | ((c1 & 0x3Fu) << 6) | (c2 & 0x3Fu);
+        next_offset = offset + 3;
+        return true;
+    }
+
+    if ((c0 & 0xF8u) == 0xF0u && offset + 3 < text.size()) {
+        const unsigned char c1 = static_cast<unsigned char>(text[offset + 1]);
+        const unsigned char c2 = static_cast<unsigned char>(text[offset + 2]);
+        const unsigned char c3 = static_cast<unsigned char>(text[offset + 3]);
+        codepoint = ((c0 & 0x07u) << 18) | ((c1 & 0x3Fu) << 12) |
+                    ((c2 & 0x3Fu) << 6) | (c3 & 0x3Fu);
+        next_offset = offset + 4;
+        return true;
+    }
+
+    codepoint = c0;
+    next_offset = offset + 1;
+    return false;
+}
+
+inline void clamp_text_input_state(text_input_state& state) {
+    const size_t codepoint_count = utf8_codepoint_count(state.value);
+    state.cursor = std::min(state.cursor, codepoint_count);
+    state.selection_anchor = std::min(state.selection_anchor, codepoint_count);
+    if (!state.has_selection || state.selection_anchor == state.cursor) {
+        state.has_selection = false;
+        state.selection_anchor = state.cursor;
+    }
+    if (!state.active) {
+        state.mouse_selecting = false;
+    }
+    state.scroll_x = std::max(0.0f, state.scroll_x);
+}
+
+inline std::pair<size_t, size_t> text_input_selection_range(const text_input_state& state) {
+    return {
+        std::min(state.selection_anchor, state.cursor),
+        std::max(state.selection_anchor, state.cursor)
+    };
+}
+
+inline void clear_text_input_selection(text_input_state& state) {
+    state.has_selection = false;
+    state.selection_anchor = state.cursor;
+}
+
+inline bool delete_text_input_selection(text_input_state& state) {
+    if (!state.has_selection) {
+        return false;
+    }
+
+    const auto [start, end] = text_input_selection_range(state);
+    const size_t start_byte = utf8_codepoint_to_byte_index(state.value, start);
+    const size_t end_byte = utf8_codepoint_to_byte_index(state.value, end);
+    state.value.erase(start_byte, end_byte - start_byte);
+    state.cursor = start;
+    clear_text_input_selection(state);
+    return true;
+}
+
+inline std::string selected_text_input_text(const text_input_state& state) {
+    if (!state.has_selection) {
+        return {};
+    }
+    const auto [start, end] = text_input_selection_range(state);
+    return utf8_substr_codepoints(state.value, start, end);
+}
+
+inline bool insert_codepoint_at_cursor(text_input_state& state, int codepoint) {
+    int codepoint_size = 0;
+    const char* encoded = CodepointToUTF8(codepoint, &codepoint_size);
+    if (encoded == nullptr || codepoint_size <= 0) {
+        return false;
+    }
+
+    const size_t byte_index = utf8_codepoint_to_byte_index(state.value, state.cursor);
+    state.value.insert(byte_index, encoded, static_cast<size_t>(codepoint_size));
+    ++state.cursor;
+    clear_text_input_selection(state);
+    return true;
+}
+
+inline bool paste_text_input_at_cursor(text_input_state& state, std::string_view text,
+                                       size_t max_length, text_input_filter filter) {
+    bool changed = delete_text_input_selection(state);
+    size_t offset = 0;
+    while (offset < text.size() && utf8_codepoint_count(state.value) < max_length) {
+        int codepoint = 0;
+        size_t next_offset = offset + 1;
+        decode_next_utf8_codepoint(text, offset, codepoint, next_offset);
+        offset = next_offset;
+        if (filter != nullptr && !filter(codepoint, state.value)) {
+            continue;
+        }
+        changed = insert_codepoint_at_cursor(state, codepoint) || changed;
+    }
+    return changed;
+}
+
+inline float text_input_prefix_width(const std::string& value, size_t codepoint_index, int font_size) {
+    const size_t byte_index = utf8_codepoint_to_byte_index(value, codepoint_index);
+    return measure_text_size(value.substr(0, byte_index), static_cast<float>(font_size)).x;
+}
+
+inline size_t text_input_cursor_from_mouse(const std::string& value, float local_x, int font_size) {
+    const size_t codepoint_count = utf8_codepoint_count(value);
+    if (local_x <= 0.0f || codepoint_count == 0) {
+        return 0;
+    }
+
+    float previous_width = 0.0f;
+    for (size_t codepoint_index = 1; codepoint_index <= codepoint_count; ++codepoint_index) {
+        const float width = text_input_prefix_width(value, codepoint_index, font_size);
+        if (local_x <= width) {
+            return (local_x - previous_width) <= (width - local_x)
+                       ? codepoint_index - 1
+                       : codepoint_index;
+        }
+        previous_width = width;
+    }
+
+    return codepoint_count;
+}
+
+inline void update_text_input_scroll(text_input_state& state, float viewport_width, int font_size) {
+    if (!state.active) {
+        state.scroll_x = 0.0f;
+        return;
+    }
+
+    const float cursor_x = text_input_prefix_width(state.value, state.cursor, font_size);
+    const float padding = 8.0f;
+    const float max_scroll = std::max(0.0f,
+                                      measure_text_size(state.value, static_cast<float>(font_size)).x -
+                                          viewport_width + padding);
+
+    if (cursor_x - state.scroll_x < padding) {
+        state.scroll_x = std::max(0.0f, cursor_x - padding);
+    } else if (cursor_x - state.scroll_x > viewport_width - padding) {
+        state.scroll_x = cursor_x - viewport_width + padding;
+    }
+
+    state.scroll_x = std::clamp(state.scroll_x, 0.0f, max_scroll);
+}
+
+inline void move_text_input_cursor(text_input_state& state, size_t next_cursor, bool selecting) {
+    const size_t codepoint_count = utf8_codepoint_count(state.value);
+    const size_t clamped_cursor = std::min(next_cursor, codepoint_count);
+    if (selecting) {
+        if (!state.has_selection) {
+            state.has_selection = true;
+            state.selection_anchor = state.cursor;
+        }
+        state.cursor = clamped_cursor;
+        if (state.cursor == state.selection_anchor) {
+            clear_text_input_selection(state);
+        }
+        return;
+    }
+
+    state.cursor = clamped_cursor;
+    clear_text_input_selection(state);
+}
+
+inline bool text_input_key_action(int key) {
+    return IsKeyPressed(key) || IsKeyPressedRepeat(key);
+}
+
 inline text_input_result draw_text_input(Rectangle rect, text_input_state& state,
                                          const char* label, const char* placeholder,
                                          const char* default_value = nullptr,
@@ -69,10 +292,14 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
                                          text_input_filter filter = default_text_input_filter,
                                          float label_width = 84.0f) {
     text_input_result result;
+    clamp_text_input_state(state);
 
     const auto apply_default_if_empty = [&]() {
         if (default_value != nullptr && state.value.empty()) {
             state.value = default_value;
+            state.cursor = utf8_codepoint_count(state.value);
+            clear_text_input_selection(state);
+            state.scroll_x = 0.0f;
             result.changed = true;
             result.defaulted = true;
         }
@@ -88,42 +315,6 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
                             state.active ? g_theme->border_active : g_theme->border,
                             1.5f);
 
-    if (clicked) {
-        result.clicked = true;
-        if (!state.active) {
-            result.activated = true;
-        }
-        state.active = true;
-    } else if (state.active && IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && !hovered) {
-        apply_default_if_empty();
-        state.active = false;
-        result.deactivated = true;
-    }
-
-    if (state.active) {
-        int codepoint = GetCharPressed();
-        while (codepoint > 0) {
-            if (utf8_codepoint_count(state.value) < max_length &&
-                (filter == nullptr || filter(codepoint, state.value))) {
-                append_codepoint_utf8(state.value, codepoint);
-                result.changed = true;
-            }
-            codepoint = GetCharPressed();
-        }
-
-        if (IsKeyPressed(KEY_BACKSPACE) && !state.value.empty()) {
-            pop_last_utf8_codepoint(state.value);
-            result.changed = true;
-        }
-
-        if (IsKeyPressed(KEY_ENTER)) {
-            apply_default_if_empty();
-            result.submitted = true;
-            state.active = false;
-            result.deactivated = true;
-        }
-    }
-
     const Rectangle content_rect = inset(visual, edge_insets::symmetric(0.0f, 12.0f));
     const Rectangle label_rect = {content_rect.x, content_rect.y, label_width, content_rect.height};
     const Rectangle input_rect = {
@@ -132,6 +323,146 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
         content_rect.width - label_width,
         content_rect.height - 8.0f
     };
+    const Rectangle text_rect = {
+        input_rect.x + 10.0f,
+        input_rect.y,
+        std::max(0.0f, input_rect.width - 20.0f),
+        input_rect.height
+    };
+
+    if (clicked) {
+        result.clicked = true;
+        if (!state.active) {
+            result.activated = true;
+        }
+        state.active = true;
+
+        if (CheckCollisionPointRec(GetMousePosition(), input_rect)) {
+            const float local_x = GetMousePosition().x - text_rect.x + state.scroll_x;
+            state.cursor = text_input_cursor_from_mouse(state.value, local_x, font_size);
+            clear_text_input_selection(state);
+            state.mouse_selecting = true;
+        } else {
+            state.cursor = utf8_codepoint_count(state.value);
+            clear_text_input_selection(state);
+        }
+    } else if (state.active && IsMouseButtonPressed(MOUSE_BUTTON_LEFT) && !hovered) {
+        apply_default_if_empty();
+        state.active = false;
+        state.mouse_selecting = false;
+        clear_text_input_selection(state);
+        result.deactivated = true;
+    }
+
+    if (state.active && state.mouse_selecting && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        const Vector2 mouse = GetMousePosition();
+        const float local_x = mouse.x - text_rect.x + state.scroll_x;
+        const size_t mouse_cursor = text_input_cursor_from_mouse(state.value, local_x, font_size);
+        state.cursor = mouse_cursor;
+        state.has_selection = state.cursor != state.selection_anchor;
+    }
+
+    if (state.mouse_selecting && IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        state.mouse_selecting = false;
+    }
+
+    if (state.active) {
+        const bool ctrl = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
+        const bool shift = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
+
+        if (ctrl && IsKeyPressed(KEY_A)) {
+            state.selection_anchor = 0;
+            state.cursor = utf8_codepoint_count(state.value);
+            state.has_selection = state.cursor > 0;
+        }
+
+        if (ctrl && IsKeyPressed(KEY_C) && state.has_selection) {
+            SetClipboardText(selected_text_input_text(state).c_str());
+        }
+
+        if (ctrl && IsKeyPressed(KEY_X) && state.has_selection) {
+            SetClipboardText(selected_text_input_text(state).c_str());
+            result.changed = delete_text_input_selection(state) || result.changed;
+        }
+
+        if (ctrl && IsKeyPressed(KEY_V)) {
+            const char* clipboard = GetClipboardText();
+            if (clipboard != nullptr) {
+                result.changed = paste_text_input_at_cursor(state, clipboard, max_length, filter) || result.changed;
+            }
+        }
+
+        int codepoint = GetCharPressed();
+        while (codepoint > 0) {
+            if (state.has_selection) {
+                result.changed = delete_text_input_selection(state) || result.changed;
+            }
+            if (utf8_codepoint_count(state.value) < max_length &&
+                (filter == nullptr || filter(codepoint, state.value))) {
+                result.changed = insert_codepoint_at_cursor(state, codepoint) || result.changed;
+            }
+            codepoint = GetCharPressed();
+        }
+
+        if (text_input_key_action(KEY_BACKSPACE)) {
+            if (state.has_selection) {
+                result.changed = delete_text_input_selection(state) || result.changed;
+            } else if (state.cursor > 0) {
+                const size_t end_byte = utf8_codepoint_to_byte_index(state.value, state.cursor);
+                const size_t start_byte = utf8_codepoint_to_byte_index(state.value, state.cursor - 1);
+                state.value.erase(start_byte, end_byte - start_byte);
+                --state.cursor;
+                clear_text_input_selection(state);
+                result.changed = true;
+            }
+        }
+
+        if (text_input_key_action(KEY_DELETE)) {
+            if (state.has_selection) {
+                result.changed = delete_text_input_selection(state) || result.changed;
+            } else if (state.cursor < utf8_codepoint_count(state.value)) {
+                const size_t start_byte = utf8_codepoint_to_byte_index(state.value, state.cursor);
+                const size_t end_byte = utf8_codepoint_to_byte_index(state.value, state.cursor + 1);
+                state.value.erase(start_byte, end_byte - start_byte);
+                result.changed = true;
+            }
+        }
+
+        if (text_input_key_action(KEY_LEFT)) {
+            if (state.has_selection && !shift) {
+                move_text_input_cursor(state, text_input_selection_range(state).first, false);
+            } else if (state.cursor > 0) {
+                move_text_input_cursor(state, state.cursor - 1, shift);
+            }
+        }
+
+        if (text_input_key_action(KEY_RIGHT)) {
+            if (state.has_selection && !shift) {
+                move_text_input_cursor(state, text_input_selection_range(state).second, false);
+            } else if (state.cursor < utf8_codepoint_count(state.value)) {
+                move_text_input_cursor(state, state.cursor + 1, shift);
+            }
+        }
+
+        if (text_input_key_action(KEY_HOME)) {
+            move_text_input_cursor(state, 0, shift);
+        }
+
+        if (text_input_key_action(KEY_END)) {
+            move_text_input_cursor(state, utf8_codepoint_count(state.value), shift);
+        }
+
+        if (IsKeyPressed(KEY_ENTER)) {
+            apply_default_if_empty();
+            result.submitted = true;
+            state.active = false;
+            state.mouse_selecting = false;
+            clear_text_input_selection(state);
+            result.deactivated = true;
+        }
+    }
+
+    update_text_input_scroll(state, text_rect.width, font_size);
 
     DrawRectangleRec(input_rect, state.active ? with_alpha(g_theme->panel, 255) : with_alpha(g_theme->section, 255));
     DrawRectangleLinesEx(input_rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
@@ -142,24 +473,45 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
     if (display_value.empty() && !state.active && placeholder != nullptr) {
         display_value = placeholder;
     }
-    if (state.active && (GetTime() * 2.0 - std::floor(GetTime() * 2.0)) < 0.5) {
-        display_value += "_";
-    }
 
-    const Rectangle text_rect = {
-        input_rect.x + 10.0f,
-        input_rect.y,
-        std::max(0.0f, input_rect.width - 20.0f + 4.0f),
-        input_rect.height
-    };
-    const Rectangle shifted_text_rect = {text_rect.x, text_rect.y + 1.5f, text_rect.width, text_rect.height};
     const Color text_color = state.value.empty() && !state.active ? g_theme->text_hint : g_theme->text;
+    const float text_y = text_rect.y + (text_rect.height - static_cast<float>(font_size)) * 0.5f + 1.5f;
+
     if (!state.active && !state.value.empty()) {
-        const float marquee_y = shifted_text_rect.y + (shifted_text_rect.height - static_cast<float>(font_size)) * 0.5f;
-        draw_marquee_text(display_value.c_str(), shifted_text_rect.x, marquee_y, font_size, text_color,
-                          shifted_text_rect.width, GetTime());
+        draw_marquee_text(display_value.c_str(), text_rect.x, text_y, font_size, text_color,
+                          text_rect.width, GetTime());
+    } else if (!state.active) {
+        draw_text_in_rect(display_value.c_str(), font_size,
+                          {text_rect.x, text_rect.y + 1.5f, text_rect.width, text_rect.height},
+                          text_color, text_align::left);
     } else {
-        draw_text_in_rect(display_value.c_str(), font_size, shifted_text_rect, text_color, text_align::left);
+        begin_scissor_rect(input_rect);
+
+        if (state.has_selection) {
+            const auto [selection_start, selection_end] = text_input_selection_range(state);
+            const float selection_x = text_rect.x +
+                                      text_input_prefix_width(state.value, selection_start, font_size) -
+                                      state.scroll_x;
+            const float selection_end_x = text_rect.x +
+                                          text_input_prefix_width(state.value, selection_end, font_size) -
+                                          state.scroll_x;
+            draw_rect_span({selection_x, input_rect.y + 5.0f,
+                            selection_end_x - selection_x, input_rect.height - 10.0f},
+                           with_alpha(g_theme->row_selected, 255));
+        }
+
+        draw_text_f(state.value.c_str(), text_rect.x - state.scroll_x, text_y, font_size, g_theme->text);
+
+        const double blink = GetTime() * 1.6;
+        if (std::fmod(blink, 1.0) < 0.6) {
+            const float cursor_x = text_rect.x +
+                                   text_input_prefix_width(state.value, state.cursor, font_size) -
+                                   state.scroll_x;
+            draw_rect_span({cursor_x, input_rect.y + 5.0f, 1.5f, input_rect.height - 10.0f},
+                           g_theme->text);
+        }
+
+        EndScissorMode();
     }
 
     return result;


### PR DESCRIPTION
## 概要
- `raythm-Server` の `GET /charts/:chartId/rankings` を使って ONLINE ランキングを取得できるようにする
- 既存のランキング UI をそのまま使いながら `source::online` を本実装へ差し替える

## 変更内容
- `src/network/ranking_client.*` を追加
  - ランキング取得用の HTTP クライアントを実装
  - server レスポンスを `ranking_service::entry` 相当へ変換
- `ranking_service::load_chart_ranking(..., source::online, ...)` を実装
- 保存済みセッションがある場合は access token 付きで ONLINE ランキングを取得
- 401 の場合は `refresh` を試して再取得
- 未ログイン時は `Sign in to view online rankings.` を返す
- Official 対象外など server 側の `available=false` / `message` をそのまま UI へ流せるようにした
- `ranking_service_smoke` を新挙動へ更新

## 確認
- `cmake --build C:/Users/rento/CLionProjects/raythm/cmake-build-codex --target raythm -j 4`
- `cmake --build C:/Users/rento/CLionProjects/raythm/cmake-build-codex --target ranking_service_smoke -j 4`
- `C:/Users/rento/CLionProjects/raythm/cmake-build-codex/ranking_service_smoke.exe`

## 補足
- この変更は `#221` の認証基盤 commit に依存しているため、PR diff にはその土台も含まれる
- 実サーバーへの live 疎通は、ローカルに保存済みセッションが無かったため今回の作業では未確認

Closes #222
Refs #221