### PR TITLE
オンライン譜面ランキング取得を実装する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,6 +132,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/timing_engine.h
         src/network/auth_client.cpp
         src/network/auth_client.h
+        src/network/ranking_client.cpp
+        src/network/ranking_client.h
         src/core/app_paths.cpp
         src/core/app_paths.h
         src/core/file_dialog.cpp
@@ -438,6 +440,10 @@ add_executable(ranking_service_smoke
         src/models/data_models.h
         src/gameplay/ranking_service.cpp
         src/gameplay/ranking_service.h
+        src/network/auth_client.cpp
+        src/network/auth_client.h
+        src/network/ranking_client.cpp
+        src/network/ranking_client.h
         src/tests/ranking_service_smoke.cpp)
 
 add_executable(play_note_draw_queue_smoke
@@ -665,7 +671,7 @@ target_link_libraries(song_select_state_smoke PRIVATE raylib)
 target_link_libraries(settings_io_smoke PRIVATE raylib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
 target_link_libraries(judge_system_smoke PRIVATE raylib)
-target_link_libraries(ranking_service_smoke PRIVATE crypt32)
+target_link_libraries(ranking_service_smoke PRIVATE crypt32 winhttp)
 target_link_libraries(play_flow_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_timeline_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_panel_controller_smoke PRIVATE raylib)

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -27,6 +27,7 @@ namespace {
 constexpr std::string_view kFileHeaderV1 = "RAYTHM_LOCAL_RANKING_V1";
 constexpr std::string_view kFileHeaderV2 = "RAYTHM_LOCAL_RANKING_V2";
 constexpr std::string_view kFileHeaderV3 = "RAYTHM_LOCAL_RANKING_V3";
+constexpr std::string_view kFileHeaderV4 = "RAYTHM_LOCAL_RANKING_V4";
 constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
 
 std::string trim(std::string_view value) {
@@ -58,20 +59,48 @@ std::string current_timestamp_utc() {
     return out.str();
 }
 
+std::string sanitize_player_display_name(std::string_view value) {
+    std::string sanitized;
+    sanitized.reserve(value.size());
+    for (const char ch : value) {
+        switch (ch) {
+            case '\t':
+            case '\r':
+            case '\n':
+                sanitized += ' ';
+                break;
+            default:
+                sanitized += ch;
+                break;
+        }
+    }
+    const std::string trimmed = trim(sanitized);
+    return trimmed.empty() ? "Guest" : trimmed;
+}
+
+std::string current_local_player_display_name() {
+    const auth::session_summary summary = auth::load_session_summary();
+    if (summary.logged_in && !summary.display_name.empty()) {
+        return sanitize_player_display_name(summary.display_name);
+    }
+    return "Guest";
+}
+
 std::string serialize_entries(const std::vector<ranking_service::entry>& entries) {
     std::ostringstream out;
-    out << kFileHeaderV3 << '\n';
+    out << kFileHeaderV4 << '\n';
     for (const ranking_service::entry& entry : entries) {
         out << std::fixed << std::setprecision(4) << entry.accuracy << '\t'
             << (entry.is_full_combo ? 1 : 0) << '\t'
             << entry.max_combo << '\t'
             << entry.score << '\t'
-            << entry.recorded_at << '\n';
+            << entry.recorded_at << '\t'
+            << sanitize_player_display_name(entry.player_display_name) << '\n';
     }
     return out.str();
 }
 
-enum class file_version { v1, v2, v3 };
+enum class file_version { v1, v2, v3, v4 };
 
 std::vector<ranking_service::entry> parse_entries(const std::string& content) {
     std::vector<ranking_service::entry> entries;
@@ -82,7 +111,9 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
     }
     const std::string header = trim(line);
     file_version version;
-    if (header == kFileHeaderV3) {
+    if (header == kFileHeaderV4) {
+        version = file_version::v4;
+    } else if (header == kFileHeaderV3) {
         version = file_version::v3;
     } else if (header == kFileHeaderV2) {
         version = file_version::v2;
@@ -102,21 +133,35 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
         try {
             ranking_service::entry entry;
 
-            if (version == file_version::v3) {
+            if (version == file_version::v4 || version == file_version::v3) {
                 // V3: accuracy \t is_full_combo \t max_combo \t score \t timestamp
-                std::string accuracy_token, fc_token, combo_token, score_token, timestamp_token;
+                // V4: accuracy \t is_full_combo \t max_combo \t score \t timestamp \t player_display_name
+                std::string accuracy_token, fc_token, combo_token, score_token, timestamp_token, player_token;
                 if (!std::getline(row, accuracy_token, '\t') ||
                     !std::getline(row, fc_token, '\t') ||
                     !std::getline(row, combo_token, '\t') ||
-                    !std::getline(row, score_token, '\t') ||
-                    !std::getline(row, timestamp_token)) {
+                    !std::getline(row, score_token, '\t')) {
                     continue;
+                }
+                if (version == file_version::v4) {
+                    if (!std::getline(row, timestamp_token, '\t')) {
+                        continue;
+                    }
+                } else {
+                    if (!std::getline(row, timestamp_token)) {
+                        continue;
+                    }
                 }
                 entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
                 entry.is_full_combo = trim(fc_token) == "1";
                 entry.max_combo = std::clamp(std::stoi(trim(combo_token)), 0, 999999);
                 entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
                 entry.recorded_at = trim(timestamp_token);
+                if (version == file_version::v4 && std::getline(row, player_token)) {
+                    entry.player_display_name = sanitize_player_display_name(player_token);
+                } else {
+                    entry.player_display_name = "Guest";
+                }
             } else {
                 // V1/V2: rank \t accuracy \t [max_combo \t] score \t timestamp
                 std::string rank_token, accuracy_token, combo_token, score_token, timestamp_token;
@@ -145,6 +190,7 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
                 // V1/V2 にはフルコンボ情報がないので、保存された rank が SS/S ならフルコンボとみなす。
                 const int stored_rank = std::clamp(std::stoi(trim(rank_token)), 0, 6);
                 entry.is_full_combo = (stored_rank == static_cast<int>(rank::ss) || stored_rank == static_cast<int>(rank::s));
+                entry.player_display_name = "Guest";
             }
 
             entry.verified = false;
@@ -349,6 +395,7 @@ bool submit_local_result(const chart_meta& chart, const result_data& result) {
     std::vector<entry> entries = load_local_entries(chart.chart_id);
     entries.push_back({
         .placement = 0,
+        .player_display_name = current_local_player_display_name(),
         .accuracy = result.accuracy,
         .is_full_combo = result.is_full_combo,
         .max_combo = result.max_combo,

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -14,6 +14,8 @@
 #include <vector>
 
 #include "app_paths.h"
+#include "network/auth_client.h"
+#include "network/ranking_client.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -280,8 +282,44 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
     }
 
     if (ranking_source == source::online) {
-        result.available = false;
-        result.message = "Online ranking coming soon.";
+        const std::optional<auth::session> stored = auth::load_saved_session();
+        if (!stored.has_value()) {
+            result.available = false;
+            result.message = "Sign in to view online rankings.";
+            return result;
+        }
+
+        ranking_client::operation_result online_result =
+            ranking_client::fetch_chart_ranking(stored->server_url, stored->access_token, chart_id, limit);
+
+        if (online_result.unauthorized) {
+            const auth::operation_result restored = auth::restore_saved_session();
+            if (!restored.success || !restored.session_data.has_value()) {
+                result.available = false;
+                result.message = restored.message.empty()
+                    ? "Sign in to view online rankings."
+                    : restored.message;
+                return result;
+            }
+
+            online_result = ranking_client::fetch_chart_ranking(
+                restored.session_data->server_url,
+                restored.session_data->access_token,
+                chart_id,
+                limit);
+        }
+
+        if (!online_result.success || !online_result.listing.has_value()) {
+            result.available = false;
+            result.message = online_result.message.empty()
+                ? "Failed to load online rankings."
+                : online_result.message;
+            return result;
+        }
+
+        result.available = online_result.listing->available;
+        result.entries = std::move(online_result.listing->entries);
+        result.message = online_result.listing->message;
         return result;
     }
 

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -14,6 +14,7 @@ enum class source {
 
 struct entry {
     int placement = 0;
+    std::string player_display_name;
     float accuracy = 0.0f;
     bool is_full_combo = false;
     int max_combo = 0;

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -116,6 +116,48 @@ std::optional<std::string> extract_json_string(const std::string& content, const
     return std::nullopt;
 }
 
+std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '{') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            ++depth;
+        } else if (ch == '}') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
 std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
     const auto start_opt = find_value_start(content, key);
     if (!start_opt.has_value()) {
@@ -451,6 +493,11 @@ http_response send_request(const std::string&,
 #endif
 
 std::optional<ranking_service::entry> parse_ranking_entry(const std::string& content) {
+    std::string player_display_name;
+    if (const auto player_object = extract_json_object(content, "player"); player_object.has_value()) {
+        player_display_name = extract_json_string(*player_object, "display_name").value_or("");
+    }
+
     const auto placement = extract_json_int(content, "placement");
     const auto accuracy = extract_json_float(content, "accuracy");
     const auto is_full_combo = extract_json_bool(content, "is_full_combo");
@@ -470,6 +517,7 @@ std::optional<ranking_service::entry> parse_ranking_entry(const std::string& con
 
     return ranking_service::entry{
         .placement = *placement,
+        .player_display_name = player_display_name,
         .accuracy = *accuracy,
         .is_full_combo = *is_full_combo,
         .max_combo = *max_combo,

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -1,0 +1,590 @@
+#include "network/ranking_client.h"
+
+#include <cctype>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
+namespace {
+
+struct http_response {
+    int status_code = 0;
+    std::string body;
+    std::string error_message;
+};
+
+#ifdef _WIN32
+struct http_url_parts {
+    std::wstring host;
+    std::wstring path_and_query;
+    INTERNET_PORT port = INTERNET_DEFAULT_HTTP_PORT;
+    bool secure = false;
+};
+
+constexpr int kResolveTimeoutMs = 5000;
+constexpr int kConnectTimeoutMs = 5000;
+constexpr int kSendTimeoutMs = 5000;
+constexpr int kReceiveTimeoutMs = 5000;
+#endif
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+    return key_pos + token.size();
+}
+
+std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
+    const auto key_end = find_json_key(content, key);
+    if (!key_end.has_value()) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', *key_end);
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
+        ++start;
+    }
+
+    if (start >= content.size()) {
+        return std::nullopt;
+    }
+
+    return start;
+}
+
+std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '"') {
+        return std::nullopt;
+    }
+
+    std::string result;
+    bool escaping = false;
+    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (escaping) {
+            switch (ch) {
+                case 'n': result += '\n'; break;
+                case 'r': result += '\r'; break;
+                case 't': result += '\t'; break;
+                default: result += ch; break;
+            }
+            escaping = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            return result;
+        }
+
+        result += ch;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    if (content.compare(*start_opt, 4, "true") == 0) {
+        return true;
+    }
+
+    if (content.compare(*start_opt, 5, "false") == 0) {
+        return false;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<int> extract_json_int(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t end = *start_opt;
+    if (content[end] == '-') {
+        ++end;
+    }
+    while (end < content.size() && std::isdigit(static_cast<unsigned char>(content[end]))) {
+        ++end;
+    }
+    if (end == *start_opt) {
+        return std::nullopt;
+    }
+
+    try {
+        return std::stoi(content.substr(*start_opt, end - *start_opt));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> extract_json_float(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t end = *start_opt;
+    if (content[end] == '-') {
+        ++end;
+    }
+    while (end < content.size()) {
+        const char ch = content[end];
+        if (!(std::isdigit(static_cast<unsigned char>(ch)) || ch == '.')) {
+            break;
+        }
+        ++end;
+    }
+    if (end == *start_opt) {
+        return std::nullopt;
+    }
+
+    try {
+        return std::stof(content.substr(*start_opt, end - *start_opt));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<std::string> extract_json_array(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '[') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '[') {
+            ++depth;
+        } else if (ch == ']') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::vector<std::string> extract_json_objects_from_array(const std::string& content) {
+    std::vector<std::string> objects;
+    bool in_string = false;
+    bool escaping = false;
+    size_t object_start = std::string::npos;
+    size_t depth = 0;
+
+    for (size_t index = 0; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            if (depth == 0) {
+                object_start = index;
+            }
+            ++depth;
+        } else if (ch == '}') {
+            if (depth == 0) {
+                continue;
+            }
+            --depth;
+            if (depth == 0 && object_start != std::string::npos) {
+                objects.push_back(content.substr(object_start, index - object_start + 1));
+                object_start = std::string::npos;
+            }
+        }
+    }
+
+    return objects;
+}
+
+#ifdef _WIN32
+std::wstring to_wstring(std::string_view value) {
+    return std::wstring(value.begin(), value.end());
+}
+
+std::string describe_winhttp_error(DWORD error_code) {
+    switch (error_code) {
+        case ERROR_WINHTTP_TIMEOUT:
+            return "The connection to raythm-Server timed out.";
+        case ERROR_WINHTTP_CANNOT_CONNECT:
+            return "Could not connect to raythm-Server.";
+        case ERROR_WINHTTP_CONNECTION_ERROR:
+            return "The connection to raythm-Server was interrupted.";
+        case ERROR_WINHTTP_NAME_NOT_RESOLVED:
+            return "The server name could not be resolved.";
+        case ERROR_WINHTTP_INVALID_URL:
+            return "The server URL is invalid.";
+        case ERROR_WINHTTP_UNRECOGNIZED_SCHEME:
+            return "The server URL scheme is not supported.";
+        case ERROR_WINHTTP_SECURE_FAILURE:
+            return "A secure connection to raythm-Server could not be established.";
+        default:
+            return "Failed to communicate with raythm-Server.";
+    }
+}
+
+std::optional<http_url_parts> parse_url_parts(const std::string& url) {
+    std::wstring wide_url = to_wstring(url);
+
+    URL_COMPONENTSW components{};
+    components.dwStructSize = sizeof(components);
+
+    wchar_t host_buffer[256];
+    wchar_t path_buffer[2048];
+    wchar_t extra_buffer[2048];
+    components.lpszHostName = host_buffer;
+    components.dwHostNameLength = sizeof(host_buffer) / sizeof(wchar_t);
+    components.lpszUrlPath = path_buffer;
+    components.dwUrlPathLength = sizeof(path_buffer) / sizeof(wchar_t);
+    components.lpszExtraInfo = extra_buffer;
+    components.dwExtraInfoLength = sizeof(extra_buffer) / sizeof(wchar_t);
+
+    if (WinHttpCrackUrl(wide_url.c_str(), static_cast<DWORD>(wide_url.size()), 0, &components) == FALSE) {
+        return std::nullopt;
+    }
+
+    http_url_parts parts;
+    parts.host.assign(components.lpszHostName, components.dwHostNameLength);
+    parts.path_and_query.assign(components.lpszUrlPath, components.dwUrlPathLength);
+    if (components.dwExtraInfoLength > 0) {
+        parts.path_and_query.append(components.lpszExtraInfo, components.dwExtraInfoLength);
+    }
+    parts.port = components.nPort;
+    parts.secure = components.nScheme == INTERNET_SCHEME_HTTPS;
+    return parts;
+}
+
+http_response send_request(const std::string& method,
+                           const std::string& url,
+                           const std::vector<std::pair<std::string, std::string>>& headers) {
+    http_response response;
+
+    const std::optional<http_url_parts> parts = parse_url_parts(url);
+    if (!parts.has_value()) {
+        response.error_message = "Invalid server URL.";
+        return response;
+    }
+
+    HINTERNET session = WinHttpOpen(L"raythm/0.1",
+                                    WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                    WINHTTP_NO_PROXY_NAME,
+                                    WINHTTP_NO_PROXY_BYPASS,
+                                    0);
+    if (session == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        return response;
+    }
+
+    WinHttpSetTimeouts(session, kResolveTimeoutMs, kConnectTimeoutMs, kSendTimeoutMs, kReceiveTimeoutMs);
+
+    HINTERNET connection = WinHttpConnect(session, parts->host.c_str(), parts->port, 0);
+    if (connection == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    const DWORD request_flags = parts->secure ? WINHTTP_FLAG_SECURE : 0;
+    HINTERNET request = WinHttpOpenRequest(connection,
+                                           to_wstring(method).c_str(),
+                                           parts->path_and_query.c_str(),
+                                           nullptr,
+                                           WINHTTP_NO_REFERER,
+                                           WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                           request_flags);
+    if (request == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    std::wstring header_block;
+    for (const auto& [name, value] : headers) {
+        header_block += to_wstring(name);
+        header_block += L": ";
+        header_block += to_wstring(value);
+        header_block += L"\r\n";
+    }
+
+    const BOOL sent = WinHttpSendRequest(request,
+                                         header_block.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : header_block.c_str(),
+                                         header_block.empty() ? 0 : static_cast<DWORD>(-1L),
+                                         WINHTTP_NO_REQUEST_DATA,
+                                         0,
+                                         0,
+                                         0);
+    if (sent == FALSE || WinHttpReceiveResponse(request, nullptr) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    DWORD status_code = 0;
+    DWORD status_code_size = sizeof(status_code);
+    if (WinHttpQueryHeaders(request,
+                            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX,
+                            &status_code,
+                            &status_code_size,
+                            WINHTTP_NO_HEADER_INDEX) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    response.status_code = static_cast<int>(status_code);
+
+    DWORD available_size = 0;
+    while (WinHttpQueryDataAvailable(request, &available_size) == TRUE && available_size > 0) {
+        std::string chunk(available_size, '\0');
+        DWORD bytes_read = 0;
+        if (WinHttpReadData(request, chunk.data(), available_size, &bytes_read) == FALSE) {
+            response.error_message = describe_winhttp_error(GetLastError());
+            WinHttpCloseHandle(request);
+            WinHttpCloseHandle(connection);
+            WinHttpCloseHandle(session);
+            return response;
+        }
+
+        chunk.resize(bytes_read);
+        response.body += chunk;
+        available_size = 0;
+    }
+
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connection);
+    WinHttpCloseHandle(session);
+    return response;
+}
+#else
+http_response send_request(const std::string&,
+                           const std::string&,
+                           const std::vector<std::pair<std::string, std::string>>&) {
+    return {
+        .status_code = 0,
+        .body = {},
+        .error_message = "Networking is only supported on Windows in the current build.",
+    };
+}
+#endif
+
+std::optional<ranking_service::entry> parse_ranking_entry(const std::string& content) {
+    const auto placement = extract_json_int(content, "placement");
+    const auto accuracy = extract_json_float(content, "accuracy");
+    const auto is_full_combo = extract_json_bool(content, "is_full_combo");
+    const auto max_combo = extract_json_int(content, "max_combo");
+    const auto score = extract_json_int(content, "score");
+    const auto recorded_at = extract_json_string(content, "recorded_at");
+    const auto verified = extract_json_bool(content, "verified");
+    if (!placement.has_value() ||
+        !accuracy.has_value() ||
+        !is_full_combo.has_value() ||
+        !max_combo.has_value() ||
+        !score.has_value() ||
+        !recorded_at.has_value() ||
+        !verified.has_value()) {
+        return std::nullopt;
+    }
+
+    return ranking_service::entry{
+        .placement = *placement,
+        .accuracy = *accuracy,
+        .is_full_combo = *is_full_combo,
+        .max_combo = *max_combo,
+        .score = *score,
+        .recorded_at = *recorded_at,
+        .verified = *verified,
+    };
+}
+
+std::optional<ranking_client::listing_response> parse_listing_response(const std::string& body) {
+    const bool available = extract_json_bool(body, "available").value_or(false);
+    const std::string message = extract_json_string(body, "message").value_or("");
+
+    ranking_client::listing_response listing;
+    listing.available = available;
+    listing.message = message;
+
+    const std::optional<std::string> entries_array = extract_json_array(body, "entries");
+    if (!entries_array.has_value()) {
+        return listing;
+    }
+
+    for (const std::string& object : extract_json_objects_from_array(*entries_array)) {
+        const auto entry = parse_ranking_entry(object);
+        if (entry.has_value()) {
+            listing.entries.push_back(*entry);
+        }
+    }
+
+    return listing;
+}
+
+std::string build_ranking_url(const std::string& server_url, const std::string& chart_id, int limit) {
+    const int clamped_limit = std::max(1, limit);
+    return server_url + "/charts/" + chart_id + "/rankings?page=1&pageSize=" + std::to_string(clamped_limit);
+}
+
+}  // namespace
+
+namespace ranking_client {
+
+operation_result fetch_chart_ranking(const std::string& server_url,
+                                     const std::string& access_token,
+                                     const std::string& chart_id,
+                                     int limit) {
+    if (server_url.empty()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = "No server URL is configured.",
+            .listing = std::nullopt,
+        };
+    }
+
+    if (access_token.empty()) {
+        return {
+            .success = false,
+            .unauthorized = true,
+            .message = "Sign in to view online rankings.",
+            .listing = std::nullopt,
+        };
+    }
+
+    const http_response response = send_request(
+        "GET",
+        build_ranking_url(server_url, chart_id, limit),
+        {
+            {"Accept", "application/json"},
+            {"Authorization", "Bearer " + access_token},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = response.error_message,
+            .listing = std::nullopt,
+        };
+    }
+
+    if (response.status_code == 401) {
+        return {
+            .success = false,
+            .unauthorized = true,
+            .message = "Sign in to view online rankings.",
+            .listing = std::nullopt,
+        };
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = extract_json_string(response.body, "message").value_or("Failed to load online rankings."),
+            .listing = std::nullopt,
+        };
+    }
+
+    const std::optional<listing_response> listing = parse_listing_response(response.body);
+    if (!listing.has_value()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = "Server returned an unexpected ranking response.",
+            .listing = std::nullopt,
+        };
+    }
+
+    return {
+        .success = true,
+        .unauthorized = false,
+        .message = listing->message,
+        .listing = listing,
+    };
+}
+
+}  // namespace ranking_client

--- a/src/network/ranking_client.h
+++ b/src/network/ranking_client.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "ranking_service.h"
+
+namespace ranking_client {
+
+struct listing_response {
+    bool available = true;
+    std::vector<ranking_service::entry> entries;
+    std::string message;
+};
+
+struct operation_result {
+    bool success = false;
+    bool unauthorized = false;
+    std::string message;
+    std::optional<listing_response> listing;
+};
+
+operation_result fetch_chart_ranking(const std::string& server_url,
+                                     const std::string& access_token,
+                                     const std::string& chart_id,
+                                     int limit = 50);
+
+}  // namespace ranking_client

--- a/src/scenes/song_select/song_select_layout.h
+++ b/src/scenes/song_select/song_select_layout.h
@@ -45,7 +45,7 @@ inline constexpr Rectangle kRankingListRect = ui::scroll_view(kRankingPanelRect,
 inline constexpr Rectangle kRankingScrollbarTrackRect = ui::place(kRankingListRect, 6.0f, kRankingListRect.height,
                                                                   ui::anchor::top_right, ui::anchor::top_right,
                                                                   {-8.0f, 0.0f});
-inline constexpr float kRankingRowHeight = 42.0f;
+inline constexpr float kRankingRowHeight = 54.0f;
 inline constexpr float kDetailColumnX = kJacketRect.x + kJacketRect.width + 20.0f;
 inline constexpr float kDetailColumnWidth = kLeftPanelRect.x + kLeftPanelRect.width - kDetailColumnX - 16.0f;
 inline constexpr Rectangle kLocalOffsetLabelRect = {kDetailColumnX, kJacketRect.y + 236.0f, kDetailColumnWidth, 22.0f};

--- a/src/scenes/song_select/song_select_ranking_view.cpp
+++ b/src/scenes/song_select/song_select_ranking_view.cpp
@@ -168,18 +168,24 @@ void draw_ranking_row(const ranking_service::entry& entry, float y, float offset
 
     const Rectangle placement_rect = {content.x, content.y, 36.0f, content.height};
     const Rectangle rank_rect = {content.x + 52.0f, content.y, 48.0f, content.height};
-    const Rectangle accuracy_rect = {content.x + 124.0f, content.y, 108.0f, content.height};
-    const Rectangle combo_rect = {content.x + 254.0f, content.y, 104.0f, content.height};
-    const Rectangle recorded_at_rect = {content.x + 378.0f, content.y, 90.0f, content.height};
-    const Rectangle score_rect = {content.x + 476.0f, content.y, content.width - 476.0f, content.height};
+    const Rectangle name_rect = {content.x + 124.0f, content.y, 248.0f, 18.0f};
+    const Rectangle accuracy_rect = {content.x + 124.0f, content.y + 20.0f, 108.0f, 16.0f};
+    const Rectangle combo_rect = {content.x + 236.0f, content.y + 20.0f, 110.0f, 16.0f};
+    const Rectangle recorded_at_rect = {content.x + 350.0f, content.y + 20.0f, 92.0f, 16.0f};
+    const Rectangle score_rect = {content.x + 446.0f, content.y, content.width - 446.0f, content.height};
 
     DrawRectangleRec(rank_rect, with_alpha(theme.section, alpha));
     DrawRectangleLinesEx(rank_rect, 1.5f, with_alpha(theme.border_light, alpha));
 
     ui::draw_text_in_rect(TextFormat("%02d", entry.placement), 18, placement_rect, with_alpha(theme.text, alpha), ui::text_align::center);
     ui::draw_text_in_rect(rank_label(entry.clear_rank()), 17, rank_rect, with_alpha(rank_color(entry.clear_rank()), alpha), ui::text_align::center);
-    ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), 17, accuracy_rect, with_alpha(theme.text_secondary, alpha), ui::text_align::left);
-    ui::draw_text_in_rect(TextFormat("%d Combo", entry.max_combo), 14, combo_rect, with_alpha(theme.text_muted, alpha), ui::text_align::left);
+    ui::draw_text_in_rect(entry.player_display_name.empty() ? "Unknown Player" : entry.player_display_name.c_str(),
+                          15,
+                          name_rect,
+                          with_alpha(theme.text, alpha),
+                          ui::text_align::left);
+    ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), 14, accuracy_rect, with_alpha(theme.text_secondary, alpha), ui::text_align::left);
+    ui::draw_text_in_rect(TextFormat("%d Combo", entry.max_combo), 13, combo_rect, with_alpha(theme.text_muted, alpha), ui::text_align::left);
     ui::draw_text_in_rect(format_relative_recorded_at(entry.recorded_at).c_str(), 14, recorded_at_rect,
                           with_alpha(theme.text_muted, alpha), ui::text_align::left);
     const std::string score_label = format_score(entry.score);

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -58,7 +58,7 @@ int main() {
     const ranking_service::listing online_listing =
         ranking_service::load_chart_ranking(chart.chart_id, ranking_service::source::online, 50);
     if (online_listing.available || online_listing.message.empty()) {
-        std::cerr << "Online placeholder listing failed\n";
+        std::cerr << "Online unavailable listing failed\n";
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
## 概要
- `raythm-Server` の `GET /charts/:chartId/rankings` を使って ONLINE ランキングを取得できるようにする
- 既存のランキング UI をそのまま使いながら `source::online` を本実装へ差し替える
- ランキング行にプレイヤー名を表示し、LOCAL 記録は保存時点の名前を保持する

## 変更内容
- `src/network/ranking_client.*` を追加
  - ランキング取得用の HTTP クライアントを実装
  - server レスポンスを `ranking_service::entry` 相当へ変換
- `ranking_service::load_chart_ranking(..., source::online, ...)` を実装
- 保存済みセッションがある場合は access token 付きで ONLINE ランキングを取得
- 401 の場合は `refresh` を試して再取得
- 未ログイン時は `Sign in to view online rankings.` を返す
- Official 対象外など server 側の `available=false` / `message` をそのまま UI へ流せるようにした
- ONLINE ランキング行にプレイヤー名を表示
- LOCAL ランキング保存形式を拡張し、記録ごとのプレイヤー名を保存・表示
  - 旧形式の既存記録は `Guest` として後方互換で表示
- `ranking_service_smoke` を新挙動へ更新

## 確認
- `cmake --build C:/Users/rento/CLionProjects/raythm/cmake-build-codex --target raythm -j 4`
- `cmake --build C:/Users/rento/CLionProjects/raythm/cmake-build-codex --target ranking_service_smoke -j 4`
- `C:/Users/rento/CLionProjects/raythm/cmake-build-codex/ranking_service_smoke.exe`
- ローカル `raythm-Server` に対して ONLINE ランキング表示を確認

## 補足
- この変更は `#221` の認証基盤 commit に依存しているため、PR diff にはその土台も含まれる

Closes #222
Refs #221