### PR TITLE
自己ベスト更新時のオンラインランキング送信を実装する

### DIFF
--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -213,6 +213,10 @@ bool ranking_entry_better(const ranking_service::entry& left, const ranking_serv
     return left.recorded_at < right.recorded_at;
 }
 
+bool chart_obviously_eligible_for_online_ranking(const chart_meta& chart) {
+    return !chart.chart_id.empty() && chart.is_public;
+}
+
 #ifdef _WIN32
 bool crypt_protect_utf8(const std::string& plaintext, std::vector<std::byte>& ciphertext) {
     DATA_BLOB input_blob{};
@@ -387,13 +391,16 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
     return result;
 }
 
-bool submit_local_result(const chart_meta& chart, const result_data& result) {
+local_submit_result submit_local_result_detailed(const chart_meta& chart, const result_data& result) {
+    local_submit_result submission;
     if (chart.chart_id.empty() || result.failed) {
-        return false;
+        return submission;
     }
 
     std::vector<entry> entries = load_local_entries(chart.chart_id);
-    entries.push_back({
+    std::sort(entries.begin(), entries.end(), ranking_entry_better);
+
+    entry new_entry{
         .placement = 0,
         .player_display_name = current_local_player_display_name(),
         .accuracy = result.accuracy,
@@ -402,14 +409,87 @@ bool submit_local_result(const chart_meta& chart, const result_data& result) {
         .score = result.score,
         .recorded_at = current_timestamp_utc(),
         .verified = false,
-    });
+    };
 
+    submission.best_updated =
+        entries.empty() || ranking_entry_better(new_entry, entries.front());
+
+    entries.push_back(new_entry);
     std::sort(entries.begin(), entries.end(), ranking_entry_better);
     if (entries.size() > 50) {
         entries.resize(50);
     }
 
-    return save_local_entries(chart.chart_id, entries);
+    submission.success = save_local_entries(chart.chart_id, entries);
+    if (submission.success) {
+        submission.submitted_entry = std::move(new_entry);
+    }
+    return submission;
+}
+
+bool submit_local_result(const chart_meta& chart, const result_data& result) {
+    return submit_local_result_detailed(chart, result).success;
+}
+
+online_submit_result submit_online_result(const chart_meta& chart, const entry& submitted_entry) {
+    online_submit_result submission;
+    if (!chart_obviously_eligible_for_online_ranking(chart)) {
+        return submission;
+    }
+
+    const auth::session_summary summary = auth::load_session_summary();
+    if (!summary.logged_in) {
+        return submission;
+    }
+
+    if (!summary.email_verified) {
+        submission.message = "Verify your email on the Web to submit online rankings.";
+        return submission;
+    }
+
+    const std::optional<auth::session> stored = auth::load_saved_session();
+    if (!stored.has_value()) {
+        submission.message = "Sign in to submit online rankings.";
+        return submission;
+    }
+
+    submission.attempted = true;
+
+    ranking_client::submit_operation_result request =
+        ranking_client::submit_chart_ranking(
+            stored->server_url,
+            stored->access_token,
+            chart.chart_id,
+            submitted_entry);
+
+    if (request.unauthorized) {
+        const auth::operation_result restored = auth::restore_saved_session();
+        if (!restored.success || !restored.session_data.has_value()) {
+            submission.success = false;
+            submission.message = restored.message.empty()
+                ? "Sign in to submit online rankings."
+                : restored.message;
+            return submission;
+        }
+
+        request = ranking_client::submit_chart_ranking(
+            restored.session_data->server_url,
+            restored.session_data->access_token,
+            chart.chart_id,
+            submitted_entry);
+    }
+
+    submission.success = request.success;
+    submission.message = request.message;
+    if (request.submission.has_value()) {
+        submission.updated = request.submission->updated;
+        submission.entry = request.submission->entry;
+        if (submission.message.empty()) {
+            submission.message = request.submission->message;
+        }
+    }
+
+    return submission;
 }
 
 }  // namespace ranking_service

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,23 @@ struct listing {
     bool available = true;
 };
 
+struct local_submit_result {
+    bool success = false;
+    bool best_updated = false;
+    std::optional<entry> submitted_entry;
+};
+
+struct online_submit_result {
+    bool attempted = false;
+    bool success = false;
+    bool updated = false;
+    std::string message;
+    std::optional<entry> entry;
+};
+
 listing load_chart_ranking(const std::string& chart_id, source ranking_source, int limit = 50);
+local_submit_result submit_local_result_detailed(const chart_meta& chart, const result_data& result);
 bool submit_local_result(const chart_meta& chart, const result_data& result);
+online_submit_result submit_online_result(const chart_meta& chart, const entry& entry);
 
 }  // namespace ranking_service

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -48,6 +48,22 @@ std::string trim(std::string_view value) {
     return std::string(value.substr(start, end - start));
 }
 
+std::string escape_json_string(const std::string& value) {
+    std::string result;
+    result.reserve(value.size() + 8);
+    for (const char ch : value) {
+        switch (ch) {
+            case '\\': result += "\\\\"; break;
+            case '"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default: result += ch; break;
+        }
+    }
+    return result;
+}
+
 std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
     const std::string token = "\"" + key + "\"";
     const size_t key_pos = content.find(token);
@@ -375,7 +391,8 @@ std::optional<http_url_parts> parse_url_parts(const std::string& url) {
 
 http_response send_request(const std::string& method,
                            const std::string& url,
-                           const std::vector<std::pair<std::string, std::string>>& headers) {
+                           const std::vector<std::pair<std::string, std::string>>& headers,
+                           const std::string& body = {}) {
     http_response response;
 
     const std::optional<http_url_parts> parts = parse_url_parts(url);
@@ -429,9 +446,9 @@ http_response send_request(const std::string& method,
     const BOOL sent = WinHttpSendRequest(request,
                                          header_block.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : header_block.c_str(),
                                          header_block.empty() ? 0 : static_cast<DWORD>(-1L),
-                                         WINHTTP_NO_REQUEST_DATA,
-                                         0,
-                                         0,
+                                         body.empty() ? WINHTTP_NO_REQUEST_DATA : reinterpret_cast<LPVOID>(const_cast<char*>(body.data())),
+                                         static_cast<DWORD>(body.size()),
+                                         static_cast<DWORD>(body.size()),
                                          0);
     if (sent == FALSE || WinHttpReceiveResponse(request, nullptr) == FALSE) {
         response.error_message = describe_winhttp_error(GetLastError());
@@ -483,7 +500,8 @@ http_response send_request(const std::string& method,
 #else
 http_response send_request(const std::string&,
                            const std::string&,
-                           const std::vector<std::pair<std::string, std::string>>&) {
+                           const std::vector<std::pair<std::string, std::string>>&,
+                           const std::string&) {
     return {
         .status_code = 0,
         .body = {},
@@ -553,6 +571,33 @@ std::optional<ranking_client::listing_response> parse_listing_response(const std
 std::string build_ranking_url(const std::string& server_url, const std::string& chart_id, int limit) {
     const int clamped_limit = std::max(1, limit);
     return server_url + "/charts/" + chart_id + "/rankings?page=1&pageSize=" + std::to_string(clamped_limit);
+}
+
+std::string build_submit_ranking_url(const std::string& server_url, const std::string& chart_id) {
+    return server_url + "/charts/" + chart_id + "/rankings";
+}
+
+std::string build_submit_payload(const ranking_service::entry& entry) {
+    return "{"
+        "\"score\":" + std::to_string(entry.score) + ","
+        "\"accuracy\":" + std::to_string(entry.accuracy) + ","
+        "\"is_full_combo\":" + std::string(entry.is_full_combo ? "true" : "false") + ","
+        "\"max_combo\":" + std::to_string(entry.max_combo) + ","
+        "\"recorded_at\":\"" + escape_json_string(entry.recorded_at) + "\""
+        "}";
+}
+
+std::optional<ranking_client::submit_response> parse_submit_response(const std::string& body) {
+    ranking_client::submit_response response;
+    response.available = extract_json_bool(body, "available").value_or(true);
+    response.updated = extract_json_bool(body, "updated").value_or(false);
+    response.message = extract_json_string(body, "message").value_or("");
+
+    if (const auto entry_object = extract_json_object(body, "entry"); entry_object.has_value()) {
+        response.entry = parse_ranking_entry(*entry_object);
+    }
+
+    return response;
 }
 
 }  // namespace
@@ -632,6 +677,84 @@ operation_result fetch_chart_ranking(const std::string& server_url,
         .unauthorized = false,
         .message = listing->message,
         .listing = listing,
+    };
+}
+
+submit_operation_result submit_chart_ranking(const std::string& server_url,
+                                             const std::string& access_token,
+                                             const std::string& chart_id,
+                                             const ranking_service::entry& entry) {
+    if (server_url.empty()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = "No server URL is configured.",
+            .submission = std::nullopt,
+        };
+    }
+
+    if (access_token.empty()) {
+        return {
+            .success = false,
+            .unauthorized = true,
+            .message = "Sign in to submit online rankings.",
+            .submission = std::nullopt,
+        };
+    }
+
+    const http_response response = send_request(
+        "POST",
+        build_submit_ranking_url(server_url, chart_id),
+        {
+            {"Accept", "application/json"},
+            {"Authorization", "Bearer " + access_token},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        },
+        build_submit_payload(entry));
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = response.error_message,
+            .submission = std::nullopt,
+        };
+    }
+
+    if (response.status_code == 401) {
+        return {
+            .success = false,
+            .unauthorized = true,
+            .message = "Sign in to submit online rankings.",
+            .submission = std::nullopt,
+        };
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = extract_json_string(response.body, "message").value_or("Failed to submit online ranking."),
+            .submission = std::nullopt,
+        };
+    }
+
+    const std::optional<submit_response> submission = parse_submit_response(response.body);
+    if (!submission.has_value()) {
+        return {
+            .success = false,
+            .unauthorized = false,
+            .message = "Server returned an unexpected ranking response.",
+            .submission = std::nullopt,
+        };
+    }
+
+    return {
+        .success = true,
+        .unauthorized = false,
+        .message = submission->message,
+        .submission = submission,
     };
 }
 

--- a/src/network/ranking_client.h
+++ b/src/network/ranking_client.h
@@ -21,9 +21,28 @@ struct operation_result {
     std::optional<listing_response> listing;
 };
 
+struct submit_response {
+    bool available = true;
+    bool updated = false;
+    std::string message;
+    std::optional<ranking_service::entry> entry;
+};
+
+struct submit_operation_result {
+    bool success = false;
+    bool unauthorized = false;
+    std::string message;
+    std::optional<submit_response> submission;
+};
+
 operation_result fetch_chart_ranking(const std::string& server_url,
                                      const std::string& access_token,
                                      const std::string& chart_id,
                                      int limit = 50);
+
+submit_operation_result submit_chart_ranking(const std::string& server_url,
+                                             const std::string& access_token,
+                                             const std::string& chart_id,
+                                             const ranking_service::entry& entry);
 
 }  // namespace ranking_client

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <thread>
 
 #include "play_scene.h"
 #include "raylib.h"
@@ -38,7 +39,13 @@ constexpr Rectangle kJudgeRowsRect = ui::inset(kJudgeRect, 16.0f);
 constexpr Rectangle kStatsRowsRect = ui::inset(kStatsRect, ui::edge_insets{24.0f, 24.0f, 68.0f, 24.0f});
 constexpr Rectangle kStatsHintRect = {
     kStatsRect.x + 24.0f,
-    kStatsRect.y + kStatsRect.height - 46.0f,
+    kStatsRect.y + kStatsRect.height - 64.0f,
+    kStatsRect.width - 48.0f,
+    24.0f
+};
+constexpr Rectangle kOnlineStatusRect = {
+    kStatsRect.x + 24.0f,
+    kStatsRect.y + kStatsRect.height - 36.0f,
     kStatsRect.width - 48.0f,
     24.0f
 };
@@ -83,7 +90,27 @@ result_scene::result_scene(scene_manager& manager, result_data result, bool rank
 
 void result_scene::on_enter() {
     if (ranking_enabled_) {
-        ranking_service::submit_local_result(chart_, result_);
+        const ranking_service::local_submit_result local_result =
+            ranking_service::submit_local_result_detailed(chart_, result_);
+
+        if (local_result.success && local_result.best_updated && local_result.submitted_entry.has_value()) {
+            online_submit_status_message_ = "Submitting online ranking...";
+            online_submit_status_is_error_ = false;
+
+            online_submit_task_ = std::make_shared<online_submit_task_state>();
+            std::shared_ptr<online_submit_task_state> task = online_submit_task_;
+            const chart_meta chart = chart_;
+            const ranking_service::entry entry = *local_result.submitted_entry;
+            std::thread([task, chart, entry]() {
+                ranking_service::online_submit_result result =
+                    ranking_service::submit_online_result(chart, entry);
+                {
+                    std::scoped_lock lock(task->mutex);
+                    task->result = std::move(result);
+                }
+                task->done.store(true);
+            }).detach();
+        }
     }
 }
 
@@ -97,6 +124,7 @@ void result_scene::return_to_song_select() const {
 
 void result_scene::update(float dt) {
     fade_in_.update(dt);
+    poll_online_submit();
 
     if (IsKeyPressed(KEY_ENTER)) {
         return_to_song_select();
@@ -104,6 +132,33 @@ void result_scene::update(float dt) {
         return_to_song_select();
     } else if (IsKeyPressed(KEY_R)) {
         manager_.change_scene(std::make_unique<play_scene>(manager_, song_, chart_path_, key_count_));
+    }
+}
+
+void result_scene::poll_online_submit() {
+    if (!online_submit_task_ || online_submit_consumed_ || !online_submit_task_->done.load()) {
+        return;
+    }
+
+    online_submit_consumed_ = true;
+    ranking_service::online_submit_result result;
+    {
+        std::scoped_lock lock(online_submit_task_->mutex);
+        result = online_submit_task_->result;
+    }
+
+    if (!result.message.empty()) {
+        online_submit_status_message_ = result.message;
+        online_submit_status_is_error_ = !result.success;
+    } else if (result.success && result.updated) {
+        online_submit_status_message_ = "Online ranking updated.";
+        online_submit_status_is_error_ = false;
+    } else if (result.success) {
+        online_submit_status_message_ = "Submitted score did not beat your online best.";
+        online_submit_status_is_error_ = false;
+    } else {
+        online_submit_status_message_.clear();
+        online_submit_status_is_error_ = false;
     }
 }
 
@@ -214,6 +269,12 @@ void result_scene::draw() {
         ui::draw_label_value(stat_rows[3], "Slow", TextFormat("%d", result_.slow_count), 24, t.text_dim, t.slow);
         ui::draw_text_in_rect("ENTER: Song Select    R: Retry    Use AUTO APPLY there", 20,
                               kStatsHintRect, t.text_hint, ui::text_align::left);
+        if (!online_submit_status_message_.empty()) {
+            ui::draw_text_in_rect(online_submit_status_message_.c_str(), 18,
+                                  kOnlineStatusRect,
+                                  online_submit_status_is_error_ ? t.error : t.text_secondary,
+                                  ui::text_align::left);
+        }
     }
 
     // フェードイン（暗い状態から明るくなる）

--- a/src/scenes/result_scene.h
+++ b/src/scenes/result_scene.h
@@ -1,8 +1,12 @@
 #pragma once
 
+#include <atomic>
+#include <memory>
+#include <mutex>
 #include <string>
 
 #include "data_models.h"
+#include "ranking_service.h"
 #include "scene.h"
 #include "score_system.h"
 #include "shared/scene_fade.h"
@@ -18,7 +22,14 @@ public:
     void draw() override;
 
 private:
+    struct online_submit_task_state {
+        std::atomic<bool> done = false;
+        std::mutex mutex;
+        ranking_service::online_submit_result result;
+    };
+
     void return_to_song_select() const;
+    void poll_online_submit();
 
     result_data result_;
     bool ranking_enabled_ = true;
@@ -26,5 +37,9 @@ private:
     std::string chart_path_;
     chart_meta chart_;
     int key_count_ = 4;
+    std::shared_ptr<online_submit_task_state> online_submit_task_;
+    bool online_submit_consumed_ = false;
+    std::string online_submit_status_message_;
+    bool online_submit_status_is_error_ = false;
     scene_fade fade_in_{scene_fade::direction::in, 1.0f, 0.65f};
 };

--- a/src/scenes/song_select/song_select_ranking_view.cpp
+++ b/src/scenes/song_select/song_select_ranking_view.cpp
@@ -1,9 +1,8 @@
 #include "song_select/song_select_ranking_view.h"
 
 #include <chrono>
+#include <cstdio>
 #include <ctime>
-#include <iomanip>
-#include <sstream>
 #include <string>
 
 #include "song_select/song_select_layout.h"
@@ -76,11 +75,29 @@ std::optional<std::chrono::system_clock::time_point> parse_recorded_at_utc(const
     }
 
     std::tm utc_tm{};
-    std::istringstream input(value);
-    input >> std::get_time(&utc_tm, "%Y-%m-%dT%H:%M:%SZ");
-    if (input.fail()) {
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+    if (std::sscanf(value.c_str(),
+                    "%d-%d-%dT%d:%d:%dZ",
+                    &year,
+                    &month,
+                    &day,
+                    &hour,
+                    &minute,
+                    &second) != 6) {
         return std::nullopt;
     }
+
+    utc_tm.tm_year = year - 1900;
+    utc_tm.tm_mon = month - 1;
+    utc_tm.tm_mday = day;
+    utc_tm.tm_hour = hour;
+    utc_tm.tm_min = minute;
+    utc_tm.tm_sec = second;
 
 #ifdef _WIN32
     const std::time_t raw_time = _mkgmtime(&utc_tm);

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -38,19 +38,35 @@ int main() {
     higher_result.max_combo = 654;
     higher_result.score = 765432;
 
-    if (!ranking_service::submit_local_result(chart, lower_result) ||
-        !ranking_service::submit_local_result(chart, higher_result)) {
+    const ranking_service::local_submit_result lower_submission =
+        ranking_service::submit_local_result_detailed(chart, lower_result);
+    const ranking_service::local_submit_result higher_submission =
+        ranking_service::submit_local_result_detailed(chart, higher_result);
+    const ranking_service::local_submit_result duplicate_lower_submission =
+        ranking_service::submit_local_result_detailed(chart, lower_result);
+
+    if (!lower_submission.success ||
+        !higher_submission.success ||
+        !duplicate_lower_submission.success) {
         std::cerr << "Failed to save encrypted local ranking\n";
+        return EXIT_FAILURE;
+    }
+
+    if (!lower_submission.best_updated ||
+        !higher_submission.best_updated ||
+        duplicate_lower_submission.best_updated) {
+        std::cerr << "Local best update detection failed\n";
         return EXIT_FAILURE;
     }
 
     const ranking_service::listing local_listing =
         ranking_service::load_chart_ranking(chart.chart_id, ranking_service::source::local, 50);
-    if (local_listing.entries.size() != 2 ||
+    if (local_listing.entries.size() != 3 ||
         local_listing.entries[0].score != higher_result.score ||
         local_listing.entries[0].max_combo != higher_result.max_combo ||
         local_listing.entries[0].placement != 1 ||
-        local_listing.entries[1].placement != 2) {
+        local_listing.entries[1].placement != 2 ||
+        local_listing.entries[2].placement != 3) {
         std::cerr << "Local ranking ordering failed\n";
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
## 概要
- プレイ終了時に、ローカル自己ベスト更新時のみ `raythm-Server` へオンラインランキングを送信する
- 未ログインや対象外譜面では送信をスキップし、通信失敗してもローカル保存は成立させる
- リザルト画面にオンライン送信状況を小さく表示する

## 変更内容
- `src/network/ranking_client.*`
  - `POST /charts/:chartId/rankings` 用のクライアントを追加
  - `updated` / `message` / `entry` を読めるようにした
- `src/gameplay/ranking_service.*`
  - ローカル保存時に `best_updated` を返す詳細結果を追加
  - ローカル保存で使った `recorded_at` をそのままオンライン送信へ流す
  - 認証済みセッションがある場合のみ、自己ベスト更新時にオンライン送信する処理を追加
  - 401 時は `refresh` 後に再送を試みる
- `src/scenes/result_scene.*`
  - リザルト画面開始時にローカル保存を行い、必要時だけ非同期送信するように変更
  - 送信中 / 成功 / エラーのメッセージを画面下部に表示
- `src/tests/ranking_service_smoke.cpp`
  - ローカル自己ベスト更新判定の確認を追加

## 挙動
- Official/public 譜面のうち、クライアントから見て明らかに対象外でない譜面のみ送信候補にする
- 未ログイン時は送信しない
- 未確認メール状態では送信せず、Web で確認が必要な旨を表示する
- ローカル保存は常に先に完了し、オンライン送信失敗では巻き戻らない

## 確認
- `cmake --build C:/Users/rento/CLionProjects/raythm/cmake-build-codex --target raythm -j 4`
- `cmake --build C:/Users/rento/CLionProjects/raythm/cmake-build-codex --target ranking_service_smoke -j 4`
- `C:/Users/rento/CLionProjects/raythm/cmake-build-codex/ranking_service_smoke.exe`

## 補足
- ローカル `raythm-Server` に対する手動 API 疎通は確認途中で、クライアント経由の live 検証は未実施です

Closes #223
Refs #222
Refs #221