### PR TITLE
Official譜面ランキング送信前にハッシュ照合を行う

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -134,6 +134,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/network/auth_client.h
         src/network/ranking_client.cpp
         src/network/ranking_client.h
+        src/updater/update_verify.cpp
+        src/updater/update_verify.h
         src/core/app_paths.cpp
         src/core/app_paths.h
         src/core/file_dialog.cpp
@@ -444,6 +446,8 @@ add_executable(ranking_service_smoke
         src/network/auth_client.h
         src/network/ranking_client.cpp
         src/network/ranking_client.h
+        src/updater/update_verify.cpp
+        src/updater/update_verify.h
         src/tests/ranking_service_smoke.cpp)
 
 add_executable(play_note_draw_queue_smoke

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -16,6 +16,8 @@
 #include "app_paths.h"
 #include "network/auth_client.h"
 #include "network/ranking_client.h"
+#include "path_utils.h"
+#include "updater/update_verify.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -215,6 +217,148 @@ bool ranking_entry_better(const ranking_service::entry& left, const ranking_serv
 
 bool chart_obviously_eligible_for_online_ranking(const chart_meta& chart) {
     return !chart.chart_id.empty() && chart.is_public;
+}
+
+std::string lowercase(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+struct local_official_hashes {
+    std::string song_json_sha256;
+    std::string audio_sha256;
+    std::string jacket_sha256;
+    std::string chart_sha256;
+};
+
+struct verification_result {
+    bool success = false;
+    std::string message;
+};
+
+verification_result compare_hash(const std::string& label,
+                                 const std::string& local_hash,
+                                 const std::string& server_hash) {
+    if (local_hash.empty() || server_hash.empty()) {
+        return {
+            .success = false,
+            .message = "Official chart verification is missing required hash data.",
+        };
+    }
+
+    if (lowercase(local_hash) != lowercase(server_hash)) {
+        return {
+            .success = false,
+            .message = "Official chart verification failed for " + label + ".",
+        };
+    }
+
+    return {
+        .success = true,
+        .message = {},
+    };
+}
+
+std::optional<local_official_hashes> compute_local_official_hashes(const song_data& song,
+                                                                   const std::string& chart_path,
+                                                                   std::string& error_message) {
+    const std::filesystem::path song_dir = path_utils::from_utf8(song.directory);
+    const std::filesystem::path song_json_path = song_dir / "song.json";
+    const std::filesystem::path audio_path = song_dir / path_utils::from_utf8(song.meta.audio_file);
+    const std::filesystem::path jacket_path = song_dir / path_utils::from_utf8(song.meta.jacket_file);
+    const std::filesystem::path local_chart_path = path_utils::from_utf8(chart_path);
+
+    const std::optional<std::string> song_json_sha256 = updater::compute_sha256_hex(song_json_path);
+    if (!song_json_sha256.has_value()) {
+        error_message = "Failed to hash local song.json for Official verification.";
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> audio_sha256 = updater::compute_sha256_hex(audio_path);
+    if (!audio_sha256.has_value()) {
+        error_message = "Failed to hash local audio for Official verification.";
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> jacket_sha256 = updater::compute_sha256_hex(jacket_path);
+    if (!jacket_sha256.has_value()) {
+        error_message = "Failed to hash local jacket for Official verification.";
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> chart_sha256 = updater::compute_sha256_hex(local_chart_path);
+    if (!chart_sha256.has_value()) {
+        error_message = "Failed to hash local chart for Official verification.";
+        return std::nullopt;
+    }
+
+    return local_official_hashes{
+        .song_json_sha256 = *song_json_sha256,
+        .audio_sha256 = *audio_sha256,
+        .jacket_sha256 = *jacket_sha256,
+        .chart_sha256 = *chart_sha256,
+    };
+}
+
+verification_result verify_official_manifest(const song_data& song,
+                                             const std::string& chart_path,
+                                             const chart_meta& chart,
+                                             const std::string& server_url) {
+    const ranking_client::manifest_operation_result manifest_result =
+        ranking_client::fetch_official_chart_manifest(server_url, chart.chart_id);
+    if (!manifest_result.success || !manifest_result.manifest.has_value()) {
+        return {
+            .success = false,
+            .message = manifest_result.message.empty()
+                ? "Failed to fetch Official verification manifest."
+                : manifest_result.message,
+        };
+    }
+
+    const ranking_client::official_manifest& manifest = *manifest_result.manifest;
+    if (!manifest.available) {
+        return {
+            .success = false,
+            .message = manifest.message.empty()
+                ? "This chart is not eligible for Official ranking verification."
+                : manifest.message,
+        };
+    }
+
+    if (manifest.chart_id != chart.chart_id || manifest.song_id != song.meta.song_id) {
+        return {
+            .success = false,
+            .message = "Official chart verification failed because the manifest IDs do not match local content.",
+        };
+    }
+
+    std::string hash_error;
+    const std::optional<local_official_hashes> local_hashes =
+        compute_local_official_hashes(song, chart_path, hash_error);
+    if (!local_hashes.has_value()) {
+        return {
+            .success = false,
+            .message = hash_error,
+        };
+    }
+
+    for (const verification_result& result : {
+             compare_hash("song.json", local_hashes->song_json_sha256, manifest.song_json_sha256),
+             compare_hash("audio", local_hashes->audio_sha256, manifest.audio_sha256),
+             compare_hash("jacket", local_hashes->jacket_sha256, manifest.jacket_sha256),
+             compare_hash("chart", local_hashes->chart_sha256, manifest.chart_sha256),
+         }) {
+        if (!result.success) {
+            return result;
+        }
+    }
+
+    return {
+        .success = true,
+        .message = {},
+    };
 }
 
 #ifdef _WIN32
@@ -431,7 +575,10 @@ bool submit_local_result(const chart_meta& chart, const result_data& result) {
     return submit_local_result_detailed(chart, result).success;
 }
 
-online_submit_result submit_online_result(const chart_meta& chart, const entry& submitted_entry) {
+online_submit_result submit_online_result(const song_data& song,
+                                          const std::string& chart_path,
+                                          const chart_meta& chart,
+                                          const entry& submitted_entry) {
     online_submit_result submission;
     if (!chart_obviously_eligible_for_online_ranking(chart)) {
         return submission;
@@ -450,6 +597,13 @@ online_submit_result submit_online_result(const chart_meta& chart, const entry& 
     const std::optional<auth::session> stored = auth::load_saved_session();
     if (!stored.has_value()) {
         submission.message = "Sign in to submit online rankings.";
+        return submission;
+    }
+
+    const verification_result verification =
+        verify_official_manifest(song, chart_path, chart, stored->server_url);
+    if (!verification.success) {
+        submission.message = verification.message;
         return submission;
     }
 

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -50,6 +50,9 @@ struct online_submit_result {
 listing load_chart_ranking(const std::string& chart_id, source ranking_source, int limit = 50);
 local_submit_result submit_local_result_detailed(const chart_meta& chart, const result_data& result);
 bool submit_local_result(const chart_meta& chart, const result_data& result);
-online_submit_result submit_online_result(const chart_meta& chart, const entry& entry);
+online_submit_result submit_online_result(const song_data& song,
+                                          const std::string& chart_path,
+                                          const chart_meta& chart,
+                                          const entry& entry);
 
 }  // namespace ranking_service

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -577,6 +577,10 @@ std::string build_submit_ranking_url(const std::string& server_url, const std::s
     return server_url + "/charts/" + chart_id + "/rankings";
 }
 
+std::string build_manifest_url(const std::string& server_url, const std::string& chart_id) {
+    return server_url + "/charts/" + chart_id + "/official-manifest";
+}
+
 std::string build_submit_payload(const ranking_service::entry& entry) {
     return "{"
         "\"score\":" + std::to_string(entry.score) + ","
@@ -598,6 +602,26 @@ std::optional<ranking_client::submit_response> parse_submit_response(const std::
     }
 
     return response;
+}
+
+std::optional<ranking_client::official_manifest> parse_official_manifest_response(const std::string& body) {
+    const auto available = extract_json_bool(body, "available");
+    const auto chart_id = extract_json_string(body, "chart_id");
+    const auto song_id = extract_json_string(body, "song_id");
+    if (!available.has_value() || !chart_id.has_value() || !song_id.has_value()) {
+        return std::nullopt;
+    }
+
+    return ranking_client::official_manifest{
+        .available = *available,
+        .message = extract_json_string(body, "message").value_or(""),
+        .chart_id = *chart_id,
+        .song_id = *song_id,
+        .song_json_sha256 = extract_json_string(body, "song_json_sha256").value_or(""),
+        .audio_sha256 = extract_json_string(body, "audio_sha256").value_or(""),
+        .jacket_sha256 = extract_json_string(body, "jacket_sha256").value_or(""),
+        .chart_sha256 = extract_json_string(body, "chart_sha256").value_or(""),
+    };
 }
 
 }  // namespace
@@ -755,6 +779,56 @@ submit_operation_result submit_chart_ranking(const std::string& server_url,
         .unauthorized = false,
         .message = submission->message,
         .submission = submission,
+    };
+}
+
+manifest_operation_result fetch_official_chart_manifest(const std::string& server_url,
+                                                        const std::string& chart_id) {
+    if (server_url.empty()) {
+        return {
+            .success = false,
+            .message = "No server URL is configured.",
+            .manifest = std::nullopt,
+        };
+    }
+
+    const http_response response = send_request(
+        "GET",
+        build_manifest_url(server_url, chart_id),
+        {
+            {"Accept", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .manifest = std::nullopt,
+        };
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .message = extract_json_string(response.body, "message").value_or("Failed to fetch official manifest."),
+            .manifest = std::nullopt,
+        };
+    }
+
+    const std::optional<official_manifest> manifest = parse_official_manifest_response(response.body);
+    if (!manifest.has_value()) {
+        return {
+            .success = false,
+            .message = "Server returned an unexpected official manifest response.",
+            .manifest = std::nullopt,
+        };
+    }
+
+    return {
+        .success = true,
+        .message = manifest->message,
+        .manifest = manifest,
     };
 }
 

--- a/src/network/ranking_client.h
+++ b/src/network/ranking_client.h
@@ -35,6 +35,23 @@ struct submit_operation_result {
     std::optional<submit_response> submission;
 };
 
+struct official_manifest {
+    bool available = false;
+    std::string message;
+    std::string chart_id;
+    std::string song_id;
+    std::string song_json_sha256;
+    std::string audio_sha256;
+    std::string jacket_sha256;
+    std::string chart_sha256;
+};
+
+struct manifest_operation_result {
+    bool success = false;
+    std::string message;
+    std::optional<official_manifest> manifest;
+};
+
 operation_result fetch_chart_ranking(const std::string& server_url,
                                      const std::string& access_token,
                                      const std::string& chart_id,
@@ -44,5 +61,8 @@ submit_operation_result submit_chart_ranking(const std::string& server_url,
                                              const std::string& access_token,
                                              const std::string& chart_id,
                                              const ranking_service::entry& entry);
+
+manifest_operation_result fetch_official_chart_manifest(const std::string& server_url,
+                                                        const std::string& chart_id);
 
 }  // namespace ranking_client

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -99,11 +99,13 @@ void result_scene::on_enter() {
 
             online_submit_task_ = std::make_shared<online_submit_task_state>();
             std::shared_ptr<online_submit_task_state> task = online_submit_task_;
+            const song_data song = song_;
+            const std::string chart_path = chart_path_;
             const chart_meta chart = chart_;
             const ranking_service::entry entry = *local_result.submitted_entry;
-            std::thread([task, chart, entry]() {
+            std::thread([task, song, chart_path, chart, entry]() {
                 ranking_service::online_submit_result result =
-                    ranking_service::submit_online_result(chart, entry);
+                    ranking_service::submit_online_result(song, chart_path, chart, entry);
                 {
                     std::scoped_lock lock(task->mutex);
                     task->result = std::move(result);


### PR DESCRIPTION
## 概要
- Official 譜面のオンラインランキング送信前に server manifest を取得
- `song.json`, 音源, ジャケット, 譜面の SHA-256 をローカルで計算して照合
- manifest が一致したときだけランキング送信するように変更
- 未確認メールや非対象譜面は従来どおり送信しない

## 確認
- `cmake --build cmake-build-codex --target raythm ranking_service_smoke -j 4`
- `ranking_service_smoke.exe`
- local `raythm-Server` の official manifest 取得
- local verified user でランキング更新 API の疎通確認

## メモ
- server 側の manifest API は Rofutok112/raythm-server#25 にあります

Closes #236