### PR TITLE
オンライン送信条件をローカル自己ベストから切り離す

### DIFF
--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -575,6 +575,10 @@ bool submit_local_result(const chart_meta& chart, const result_data& result) {
     return submit_local_result_detailed(chart, result).success;
 }
 
+bool should_attempt_online_submit(const local_submit_result& local_result) {
+    return local_result.success && local_result.submitted_entry.has_value();
+}
+
 online_submit_result submit_online_result(const song_data& song,
                                           const std::string& chart_path,
                                           const chart_meta& chart,

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -50,6 +50,7 @@ struct online_submit_result {
 listing load_chart_ranking(const std::string& chart_id, source ranking_source, int limit = 50);
 local_submit_result submit_local_result_detailed(const chart_meta& chart, const result_data& result);
 bool submit_local_result(const chart_meta& chart, const result_data& result);
+bool should_attempt_online_submit(const local_submit_result& local_result);
 online_submit_result submit_online_result(const song_data& song,
                                           const std::string& chart_path,
                                           const chart_meta& chart,

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -93,7 +93,7 @@ void result_scene::on_enter() {
         const ranking_service::local_submit_result local_result =
             ranking_service::submit_local_result_detailed(chart_, result_);
 
-        if (local_result.success && local_result.best_updated && local_result.submitted_entry.has_value()) {
+        if (ranking_service::should_attempt_online_submit(local_result)) {
             online_submit_status_message_ = "Submitting online ranking...";
             online_submit_status_is_error_ = false;
 

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -59,6 +59,13 @@ int main() {
         return EXIT_FAILURE;
     }
 
+    if (!ranking_service::should_attempt_online_submit(lower_submission) ||
+        !ranking_service::should_attempt_online_submit(higher_submission) ||
+        !ranking_service::should_attempt_online_submit(duplicate_lower_submission)) {
+        std::cerr << "Online submit eligibility should not depend on local best updates\n";
+        return EXIT_FAILURE;
+    }
+
     const ranking_service::listing local_listing =
         ranking_service::load_chart_ranking(chart.chart_id, ranking_service::source::local, 50);
     if (local_listing.entries.size() != 3 ||


### PR DESCRIPTION
## 概要
- オンラインランキング送信条件をローカル自己ベスト更新から切り離します
- ローカル保存が成功して送信対象エントリが作れた場合は、毎回オンライン送信を試みます
- 更新可否はサーバー側の `updated` 判定に委ねます

## 変更内容
- `result_scene` での送信条件から `best_updated` を除去
- `ranking_service::should_attempt_online_submit(...)` を追加
- smoke test で「ローカル best ではなくても送信候補になる」ことを確認

## 確認
- `cmake --build cmake-build-codex --target raythm ranking_service_smoke -j 4`
- `ranking_service_smoke.exe`

※サーバー上には１つの譜面に対して１人が２つ以上の結果を残さないようになっているそうだ。

Closes #238