### PR TITLE
タイトル画面のHOME導線とアカウントオーバーレイを再設計する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/settings_io.h
         src/scenes/scene_common.cpp
         src/scenes/scene_common.h
+        src/scenes/shared/auth_overlay_controller.cpp
+        src/scenes/shared/auth_overlay_controller.h
         src/scenes/title_scene.cpp
         src/scenes/title_scene.h
         src/scenes/title/title_bgm_controller.cpp

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -1,0 +1,135 @@
+#include "shared/auth_overlay_controller.h"
+
+#include <chrono>
+
+#include "core/window_dialog_support.h"
+
+namespace {
+
+std::string register_web_url() {
+    return auth::normalize_server_url(auth::kDefaultServerUrl) + "/register";
+}
+
+}  // namespace
+
+namespace auth_overlay {
+
+void refresh_auth_state(song_select::auth_state& auth_state) {
+    const auth::session_summary summary = auth::load_session_summary();
+    auth_state.logged_in = summary.logged_in;
+    auth_state.email = summary.email;
+    auth_state.display_name = summary.display_name;
+    auth_state.email_verified = summary.email_verified;
+}
+
+void start_restore(controller& controller_state, song_select::login_dialog_state&) {
+    controller_state.restore_active = true;
+    controller_state.restore_future = std::async(std::launch::async, []() {
+        return auth::restore_saved_session();
+    });
+}
+
+void start_request(controller& controller_state,
+                   song_select::login_dialog_state& dialog_state,
+                   song_select::login_dialog_command command) {
+    if (controller_state.request_active) {
+        return;
+    }
+
+    if (command == song_select::login_dialog_command::open_register_web) {
+        const bool opened = window_dialog_support::open_url(register_web_url());
+        dialog_state.status_message = opened
+            ? "Opened the account page in your browser."
+            : "Failed to open the account page.";
+        dialog_state.status_message_is_error = !opened;
+        return;
+    }
+
+    controller_state.request_active = true;
+    dialog_state.status_message_is_error = false;
+    const std::string server_url = auth::kDefaultServerUrl;
+    const std::string email = dialog_state.email_input.value;
+    const std::string password = dialog_state.password_input.value;
+
+    switch (command) {
+    case song_select::login_dialog_command::request_restore:
+        dialog_state.status_message = "Restoring session...";
+        controller_state.request_future = std::async(std::launch::async, []() {
+            return auth::restore_saved_session();
+        });
+        break;
+    case song_select::login_dialog_command::request_login:
+        dialog_state.status_message = "Connecting to raythm-Server...";
+        controller_state.request_future = std::async(std::launch::async, [server_url, email, password]() {
+            return auth::login_user(server_url, email, password);
+        });
+        break;
+    case song_select::login_dialog_command::request_logout:
+        dialog_state.status_message = "Logging out...";
+        controller_state.request_future = std::async(std::launch::async, []() {
+            return auth::logout_saved_session();
+        });
+        break;
+    case song_select::login_dialog_command::open_register_web:
+    case song_select::login_dialog_command::none:
+    case song_select::login_dialog_command::close:
+        controller_state.request_active = false;
+        break;
+    }
+}
+
+poll_result poll_restore(controller& controller_state,
+                         song_select::auth_state& auth_state,
+                         song_select::login_dialog_state& dialog_state) {
+    if (!controller_state.restore_active) {
+        return {};
+    }
+
+    if (controller_state.restore_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return {};
+    }
+
+    controller_state.restore_active = false;
+    const auth::operation_result result = controller_state.restore_future.get();
+    refresh_auth_state(auth_state);
+
+    if (!result.success) {
+        if (dialog_state.open) {
+            dialog_state.status_message = result.message;
+            dialog_state.status_message_is_error = true;
+        } else {
+            return {
+                true,
+                true,
+                result.message,
+            };
+        }
+    }
+
+    return {};
+}
+
+poll_result poll_request(controller& controller_state,
+                         song_select::auth_state& auth_state,
+                         song_select::login_dialog_state& dialog_state) {
+    if (!controller_state.request_active) {
+        return {};
+    }
+
+    if (controller_state.request_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return {};
+    }
+
+    controller_state.request_active = false;
+    const auth::operation_result result = controller_state.request_future.get();
+    refresh_auth_state(auth_state);
+    dialog_state.password_input.value.clear();
+    dialog_state.status_message = result.message;
+    dialog_state.status_message_is_error = !result.success;
+
+    const auth::session_summary summary = auth::load_session_summary();
+    dialog_state.email_input.value = summary.email;
+    return {};
+}
+
+}  // namespace auth_overlay

--- a/src/scenes/shared/auth_overlay_controller.h
+++ b/src/scenes/shared/auth_overlay_controller.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <future>
+#include <string>
+
+#include "network/auth_client.h"
+#include "song_select/song_select_login_dialog.h"
+#include "song_select/song_select_state.h"
+
+namespace auth_overlay {
+
+struct controller {
+    std::future<auth::operation_result> restore_future;
+    std::future<auth::operation_result> request_future;
+    bool restore_active = false;
+    bool request_active = false;
+};
+
+struct poll_result {
+    bool should_show_notice = false;
+    bool notice_is_error = false;
+    std::string notice_message;
+};
+
+void refresh_auth_state(song_select::auth_state& auth_state);
+void start_restore(controller& controller_state, song_select::login_dialog_state& dialog_state);
+void start_request(controller& controller_state,
+                   song_select::login_dialog_state& dialog_state,
+                   song_select::login_dialog_command command);
+poll_result poll_restore(controller& controller_state,
+                         song_select::auth_state& auth_state,
+                         song_select::login_dialog_state& dialog_state);
+poll_result poll_request(controller& controller_state,
+                         song_select::auth_state& auth_state,
+                         song_select::login_dialog_state& dialog_state);
+
+}  // namespace auth_overlay

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -6,7 +6,6 @@
 
 namespace {
 
-constexpr ui::draw_layer kModalLayer = song_select::layout::kModalLayer;
 constexpr float kDialogWidth = 360.0f;
 constexpr float kLoginDialogHeight = 308.0f;
 constexpr float kAccountDialogHeight = 258.0f;
@@ -48,6 +47,26 @@ Rectangle dialog_rect_for(const song_select::state& state) {
     return rect;
 }
 
+Rectangle dialog_rect_for(const song_select::auth_state& auth_state,
+                          const song_select::login_dialog_state& dialog_state,
+                          Rectangle anchor_rect,
+                          Rectangle screen_rect) {
+    const float dialog_height = auth_state.logged_in
+        ? kAccountDialogHeight
+        : kLoginDialogHeight;
+    Rectangle rect = {
+        anchor_rect.x + anchor_rect.width - kDialogWidth,
+        anchor_rect.y + anchor_rect.height + kDialogOffsetY,
+        kDialogWidth,
+        dialog_height
+    };
+    rect.x = std::clamp(rect.x, 12.0f, screen_rect.width - rect.width - 12.0f);
+    rect.y = std::clamp(rect.y, 12.0f, screen_rect.height - rect.height - 12.0f);
+    const float anim_t = ease_out_cubic(dialog_state.open_anim);
+    rect.y -= (1.0f - anim_t) * 18.0f;
+    return rect;
+}
+
 Rectangle make_row(const Rectangle& dialog_rect, int index) {
     return {
         dialog_rect.x + kDialogPaddingX,
@@ -65,26 +84,29 @@ bool printable_filter(int codepoint, const std::string&) {
 
 namespace song_select {
 
-void open_login_dialog(state& state, const auth::session_summary& summary) {
-    state.login_dialog.open = true;
-    state.login_dialog.open_anim = 0.0f;
-    state.login_dialog.status_message.clear();
-    state.login_dialog.status_message_is_error = false;
-    state.login_dialog.email_input.value = summary.email;
-    state.login_dialog.password_input.value.clear();
+void open_login_dialog(login_dialog_state& dialog_state, const auth::session_summary& summary) {
+    dialog_state.open = true;
+    dialog_state.open_anim = 0.0f;
+    dialog_state.status_message.clear();
+    dialog_state.status_message_is_error = false;
+    dialog_state.email_input.value = summary.email;
+    dialog_state.password_input.value.clear();
 }
 
-Rectangle login_dialog_rect(const state& state) {
-    return dialog_rect_for(state);
+Rectangle login_dialog_rect(const auth_state& auth_state, const login_dialog_state& dialog_state,
+                            Rectangle anchor_rect, Rectangle screen_rect) {
+    return dialog_rect_for(auth_state, dialog_state, anchor_rect, screen_rect);
 }
 
-login_dialog_command draw_login_dialog(state& state, bool request_active) {
-    if (!state.login_dialog.open) {
+login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialog_state& dialog_state,
+                                       Rectangle anchor_rect, Rectangle screen_rect,
+                                       bool request_active, ui::draw_layer layer) {
+    if (!dialog_state.open) {
         return login_dialog_command::none;
     }
 
     const auto& theme = *g_theme;
-    const Rectangle dialog_rect = dialog_rect_for(state);
+    const Rectangle dialog_rect = dialog_rect_for(auth_state, dialog_state, anchor_rect, screen_rect);
     const float form_x = dialog_rect.x + kDialogPaddingX;
     const float form_width = dialog_rect.width - kDialogPaddingX * 2.0f;
     const float footer_y = dialog_rect.y + dialog_rect.height - 18.0f - kButtonHeight;
@@ -99,7 +121,7 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
                            dialog_rect.width - kDialogPaddingX * 2.0f, kSubtitleHeight},
                           theme.text_secondary, ui::text_align::left);
 
-    if (state.auth.logged_in) {
+    if (auth_state.logged_in) {
         const Rectangle signed_in_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 22.0f};
         const Rectangle display_name_rect = {form_x, dialog_rect.y + kBodyTop + 28.0f, form_width, 20.0f};
         const Rectangle email_rect = {form_x, dialog_rect.y + kBodyTop + 52.0f, form_width, 16.0f};
@@ -110,35 +132,35 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
         const Rectangle refresh_rect = {logout_rect.x - kButtonWidth - kButtonGap, button_row.y, kButtonWidth, kButtonHeight};
 
         ui::draw_text_in_rect("Signed in", 20, signed_in_rect, theme.success, ui::text_align::left);
-        ui::draw_text_in_rect(state.auth.display_name.empty() ? state.auth.email.c_str() : state.auth.display_name.c_str(),
+        ui::draw_text_in_rect(auth_state.display_name.empty() ? auth_state.email.c_str() : auth_state.display_name.c_str(),
                               18,
                               display_name_rect,
                               theme.text_secondary,
                               ui::text_align::left);
-        ui::draw_text_in_rect(state.auth.email.c_str(),
+        ui::draw_text_in_rect(auth_state.email.c_str(),
                               14,
                               email_rect,
                               theme.text_muted,
                               ui::text_align::left);
-        ui::draw_text_in_rect(state.auth.email_verified
+        ui::draw_text_in_rect(auth_state.email_verified
                                   ? "Email verified"
                                   : "Verify on the Web to submit online scores.",
                               13,
                               verify_rect,
-                              state.auth.email_verified ? theme.success : theme.error,
+                              auth_state.email_verified ? theme.success : theme.error,
                               ui::text_align::left);
 
-        if (!state.login_dialog.status_message.empty()) {
-            ui::draw_text_in_rect(state.login_dialog.status_message.c_str(), 13,
+        if (!dialog_state.status_message.empty()) {
+            ui::draw_text_in_rect(dialog_state.status_message.c_str(), 13,
                                   {form_x, footer_y - 28.0f, form_width, 20.0f},
-                                  state.login_dialog.status_message_is_error ? theme.error : theme.success,
+                                  dialog_state.status_message_is_error ? theme.error : theme.success,
                                   ui::text_align::left);
         }
 
-        if (ui::enqueue_button(refresh_rect, "REFRESH", 14, kModalLayer, 1.5f).clicked && !request_active) {
+        if (ui::enqueue_button(refresh_rect, "REFRESH", 14, layer, 1.5f).clicked && !request_active) {
             return login_dialog_command::request_restore;
         }
-        if (ui::enqueue_button(logout_rect, "LOGOUT", 14, kModalLayer, 1.5f).clicked && !request_active) {
+        if (ui::enqueue_button(logout_rect, "LOGOUT", 14, layer, 1.5f).clicked && !request_active) {
             return login_dialog_command::request_logout;
         }
         return login_dialog_command::none;
@@ -146,12 +168,12 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
 
     int row = 0;
     const ui::text_input_result email_result = ui::draw_text_input(
-        make_row(dialog_rect, row++), state.login_dialog.email_input, "Email", "name@example.com",
-        nullptr, kModalLayer, 15, 64, printable_filter, 90.0f);
+        make_row(dialog_rect, row++), dialog_state.email_input, "Email", "name@example.com",
+        nullptr, layer, 15, 64, printable_filter, 90.0f);
 
     const ui::text_input_result password_result = ui::draw_text_input(
-        make_row(dialog_rect, row++), state.login_dialog.password_input, "Pass", "At least 8 characters",
-        nullptr, kModalLayer, 15, 64, printable_filter, 90.0f);
+        make_row(dialog_rect, row++), dialog_state.password_input, "Pass", "At least 8 characters",
+        nullptr, layer, 15, 64, printable_filter, 90.0f);
 
     const float action_top = dialog_rect.y + 166.0f;
     const Rectangle message_rect = {form_x, action_top, form_width, 18.0f};
@@ -165,22 +187,40 @@ login_dialog_command draw_login_dialog(state& state, bool request_active) {
 
     const bool submitted = email_result.submitted || password_result.submitted;
 
-    if (!state.login_dialog.status_message.empty()) {
-        ui::draw_text_in_rect(state.login_dialog.status_message.c_str(), 16, message_rect,
-                              state.login_dialog.status_message_is_error ? theme.error : theme.success,
+    if (!dialog_state.status_message.empty()) {
+        ui::draw_text_in_rect(dialog_state.status_message.c_str(), 16, message_rect,
+                              dialog_state.status_message_is_error ? theme.error : theme.success,
                               ui::text_align::left);
     }
 
     ui::enqueue_text_in_rect("New to raythm? Register on the Web.", 14, helper_rect,
-                             theme.text_muted, ui::text_align::center, kModalLayer);
-    if (ui::enqueue_button(web_button_rect, "Create", 15, kModalLayer, 1.5f).clicked && !request_active) {
+                             theme.text_muted, ui::text_align::center, layer);
+    if (ui::enqueue_button(web_button_rect, "Create", 15, layer, 1.5f).clicked && !request_active) {
         return login_dialog_command::open_register_web;
     }
-    if ((ui::enqueue_button(primary_rect, "LOGIN", 16, kModalLayer, 1.5f).clicked || submitted) && !request_active) {
+    if ((ui::enqueue_button(primary_rect, "LOGIN", 16, layer, 1.5f).clicked || submitted) && !request_active) {
         return login_dialog_command::request_login;
     }
 
     return login_dialog_command::none;
+}
+
+void open_login_dialog(state& state, const auth::session_summary& summary) {
+    open_login_dialog(state.login_dialog, summary);
+}
+
+Rectangle login_dialog_rect(const state& state) {
+    return login_dialog_rect(state.auth, state.login_dialog,
+                             song_select::layout::kLoginButtonRect,
+                             song_select::layout::kScreenRect);
+}
+
+login_dialog_command draw_login_dialog(state& state, bool request_active) {
+    return draw_login_dialog(state.auth, state.login_dialog,
+                             song_select::layout::kLoginButtonRect,
+                             song_select::layout::kScreenRect,
+                             request_active,
+                             song_select::layout::kModalLayer);
 }
 
 }  // namespace song_select

--- a/src/scenes/song_select/song_select_login_dialog.h
+++ b/src/scenes/song_select/song_select_login_dialog.h
@@ -14,6 +14,14 @@ enum class login_dialog_command {
     request_logout,
 };
 
+void open_login_dialog(login_dialog_state& dialog_state, const auth::session_summary& summary);
+Rectangle login_dialog_rect(const auth_state& auth_state, const login_dialog_state& dialog_state,
+                            Rectangle anchor_rect, Rectangle screen_rect);
+login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialog_state& dialog_state,
+                                       Rectangle anchor_rect, Rectangle screen_rect,
+                                       bool request_active,
+                                       ui::draw_layer layer = ui::draw_layer::modal);
+
 void open_login_dialog(state& state, const auth::session_summary& summary);
 Rectangle login_dialog_rect(const state& state);
 login_dialog_command draw_login_dialog(state& state, bool request_active);

--- a/src/scenes/song_select/song_select_navigation.cpp
+++ b/src/scenes/song_select/song_select_navigation.cpp
@@ -13,8 +13,8 @@
 
 namespace song_select {
 
-std::unique_ptr<scene> make_title_scene(scene_manager& manager) {
-    return std::make_unique<title_scene>(manager);
+std::unique_ptr<scene> make_title_scene(scene_manager& manager, bool start_with_home_open) {
+    return std::make_unique<title_scene>(manager, start_with_home_open, !start_with_home_open);
 }
 
 std::unique_ptr<scene> make_settings_scene(scene_manager& manager) {

--- a/src/scenes/song_select/song_select_navigation.h
+++ b/src/scenes/song_select/song_select_navigation.h
@@ -9,7 +9,7 @@ class scene_manager;
 
 namespace song_select {
 
-std::unique_ptr<scene> make_title_scene(scene_manager& manager);
+std::unique_ptr<scene> make_title_scene(scene_manager& manager, bool start_with_home_open = false);
 std::unique_ptr<scene> make_settings_scene(scene_manager& manager);
 std::unique_ptr<scene> make_song_create_scene(scene_manager& manager);
 std::unique_ptr<scene> make_edit_song_scene(scene_manager& manager, const song_entry& song);

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -1,14 +1,11 @@
 #include "song_select_scene.h"
 
 #include <algorithm>
-#include <chrono>
 #include <cmath>
 #include <filesystem>
 #include <utility>
 
 #include "core/app_paths.h"
-#include "core/window_dialog_support.h"
-#include "network/auth_client.h"
 #include "file_dialog.h"
 #include "mv/mv_storage.h"
 #include "path_utils.h"
@@ -31,10 +28,6 @@ namespace {
 
 std::string format_offset_label(int offset_ms) {
     return (offset_ms > 0 ? "+" : "") + std::to_string(offset_ms) + "ms";
-}
-
-std::string register_web_url() {
-    return auth::normalize_server_url(auth::kDefaultServerUrl) + "/register";
 }
 
 }  // namespace
@@ -63,7 +56,7 @@ void song_select_scene::on_enter() {
         song_select::open_login_dialog(state_, auth::load_session_summary());
     }
     if (state_.auth.logged_in) {
-        start_auth_restore();
+        auth_overlay::start_restore(auth_controller_, state_.login_dialog);
     }
     reload_song_library(preferred_song_id_, preferred_chart_id_);
 }
@@ -104,11 +97,7 @@ void song_select_scene::reload_selected_chart_ranking() {
 }
 
 void song_select_scene::refresh_auth_state() {
-    const auth::session_summary summary = auth::load_session_summary();
-    state_.auth.logged_in = summary.logged_in;
-    state_.auth.email = summary.email;
-    state_.auth.display_name = summary.display_name;
-    state_.auth.email_verified = summary.email_verified;
+    auth_overlay::refresh_auth_state(state_.auth);
 }
 
 void song_select_scene::apply_delete_result(const song_select::delete_result& result) {
@@ -136,102 +125,6 @@ void song_select_scene::apply_transfer_result(const song_select::transfer_result
         reload_song_library(result.preferred_song_id, result.preferred_chart_id);
     }
     song_select::queue_status_message(state_, result.message, false);
-}
-
-void song_select_scene::start_auth_restore() {
-    auth_restore_active_ = true;
-    auth_restore_ = std::async(std::launch::async, []() {
-        return auth::restore_saved_session();
-    });
-}
-
-void song_select_scene::poll_auth_restore() {
-    if (!auth_restore_active_) {
-        return;
-    }
-
-    if (auth_restore_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
-        return;
-    }
-
-    auth_restore_active_ = false;
-    const auth::operation_result result = auth_restore_.get();
-    refresh_auth_state();
-    if (!result.success) {
-        if (state_.login_dialog.open) {
-            state_.login_dialog.status_message = result.message;
-            state_.login_dialog.status_message_is_error = true;
-        } else {
-            song_select::queue_status_message(state_, result.message, true);
-        }
-    }
-}
-
-void song_select_scene::start_login_request(song_select::login_dialog_command command) {
-    if (auth_request_active_) {
-        return;
-    }
-
-    if (command == song_select::login_dialog_command::open_register_web) {
-        const bool opened = window_dialog_support::open_url(register_web_url());
-        state_.login_dialog.status_message = opened
-            ? "Opened the account page in your browser."
-            : "Failed to open the account page.";
-        state_.login_dialog.status_message_is_error = !opened;
-        return;
-    }
-
-    auth_request_active_ = true;
-    state_.login_dialog.status_message_is_error = false;
-    const std::string server_url = auth::kDefaultServerUrl;
-    const std::string email = state_.login_dialog.email_input.value;
-    const std::string password = state_.login_dialog.password_input.value;
-
-    switch (command) {
-    case song_select::login_dialog_command::request_restore:
-        state_.login_dialog.status_message = "Restoring session...";
-        auth_request_ = std::async(std::launch::async, []() {
-            return auth::restore_saved_session();
-        });
-        break;
-    case song_select::login_dialog_command::request_login:
-        state_.login_dialog.status_message = "Connecting to raythm-Server...";
-        auth_request_ = std::async(std::launch::async, [server_url, email, password]() {
-            return auth::login_user(server_url, email, password);
-        });
-        break;
-    case song_select::login_dialog_command::request_logout:
-        state_.login_dialog.status_message = "Logging out...";
-        auth_request_ = std::async(std::launch::async, []() {
-            return auth::logout_saved_session();
-        });
-        break;
-    case song_select::login_dialog_command::open_register_web:
-    case song_select::login_dialog_command::none:
-    case song_select::login_dialog_command::close:
-        auth_request_active_ = false;
-        break;
-    }
-}
-
-void song_select_scene::poll_login_request() {
-    if (!auth_request_active_) {
-        return;
-    }
-
-    if (auth_request_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
-        return;
-    }
-
-    auth_request_active_ = false;
-    const auth::operation_result result = auth_request_.get();
-    refresh_auth_state();
-    state_.login_dialog.password_input.value.clear();
-    state_.login_dialog.status_message = result.message;
-    state_.login_dialog.status_message_is_error = !result.success;
-
-    const auth::session_summary summary = auth::load_session_summary();
-    state_.login_dialog.email_input.value = summary.email;
 }
 
 void song_select_scene::poll_song_import_prepare() {
@@ -731,8 +624,11 @@ void song_select_scene::update(float dt) {
 
     preview_controller_.update(dt, song_select::selected_song(state_));
     song_select::tick_animations(state_, dt);
-    poll_auth_restore();
-    poll_login_request();
+    if (const auto restore_result = auth_overlay::poll_restore(auth_controller_, state_.auth, state_.login_dialog);
+        restore_result.should_show_notice) {
+        song_select::queue_status_message(state_, restore_result.notice_message, restore_result.notice_is_error);
+    }
+    auth_overlay::poll_request(auth_controller_, state_.auth, state_.login_dialog);
     poll_song_import_prepare();
     poll_background_transfer();
 
@@ -748,13 +644,13 @@ void song_select_scene::update(float dt) {
 
     if (state_.login_dialog.open) {
         const Vector2 mouse = virtual_screen::get_virtual_mouse();
-        if (!auth_request_active_ &&
+        if (!auth_controller_.request_active &&
             IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
             !CheckCollisionPointRec(mouse, song_select::login_dialog_rect(state_))) {
             state_.login_dialog.open = false;
             return;
         }
-        if (IsKeyPressed(KEY_ESCAPE) && !auth_request_active_) {
+        if (IsKeyPressed(KEY_ESCAPE) && !auth_controller_.request_active) {
             state_.login_dialog.open = false;
         }
         return;
@@ -965,11 +861,11 @@ void song_select_scene::draw() {
         }
         apply_context_menu_command(song_select::draw_context_menu(state_));
         const song_select::login_dialog_command login_command =
-            song_select::draw_login_dialog(state_, auth_request_active_);
+            song_select::draw_login_dialog(state_, auth_controller_.request_active);
         if (login_command == song_select::login_dialog_command::close) {
             state_.login_dialog.open = false;
         } else if (login_command != song_select::login_dialog_command::none) {
-            start_login_request(login_command);
+            auth_overlay::start_request(auth_controller_, state_.login_dialog, login_command);
         }
         ui::flush_draw_queue();
         virtual_screen::end();
@@ -993,11 +889,11 @@ void song_select_scene::draw() {
     apply_context_menu_command(song_select::draw_context_menu(state_));
     apply_confirmation_command(song_select::draw_confirmation_dialog(state_));
     const song_select::login_dialog_command login_command =
-        song_select::draw_login_dialog(state_, auth_request_active_);
+        song_select::draw_login_dialog(state_, auth_controller_.request_active);
     if (login_command == song_select::login_dialog_command::close) {
         state_.login_dialog.open = false;
     } else if (login_command != song_select::login_dialog_command::none) {
-        start_login_request(login_command);
+        auth_overlay::start_request(auth_controller_, state_.login_dialog, login_command);
     }
     if (ranking_result.source_dropdown_toggled) {
         state_.ranking_panel.source_dropdown_open = !state_.ranking_panel.source_dropdown_open;

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -41,11 +41,13 @@ std::string register_web_url() {
 
 song_select_scene::song_select_scene(scene_manager& manager, std::string preferred_song_id,
                                      std::string preferred_chart_id,
-                                     std::optional<song_select::recent_result_offset> recent_result_offset)
+                                     std::optional<song_select::recent_result_offset> recent_result_offset,
+                                     bool open_login_dialog_on_enter)
     : scene(manager),
       preferred_song_id_(std::move(preferred_song_id)),
       preferred_chart_id_(std::move(preferred_chart_id)),
-      recent_result_offset_(std::move(recent_result_offset)) {
+      recent_result_offset_(std::move(recent_result_offset)),
+      open_login_dialog_on_enter_(open_login_dialog_on_enter) {
 }
 
 void song_select_scene::on_enter() {
@@ -57,6 +59,9 @@ void song_select_scene::on_enter() {
     song_select::reset_for_enter(state_);
     state_.recent_result_offset = recent_result_offset_;
     refresh_auth_state();
+    if (open_login_dialog_on_enter_) {
+        song_select::open_login_dialog(state_, auth::load_session_summary());
+    }
     if (state_.auth.logged_in) {
         start_auth_restore();
     }

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -665,7 +665,7 @@ void song_select_scene::update(float dt) {
             song_select::close_context_menu(state_);
             return;
         }
-        manager_.change_scene(song_select::make_title_scene(manager_));
+        manager_.change_scene(song_select::make_title_scene(manager_, true));
         return;
     }
 

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -1,12 +1,11 @@
 #pragma once
 
-#include <future>
 #include <optional>
 #include <string>
 
-#include "network/auth_client.h"
 #include "raylib.h"
 #include "scene.h"
+#include "shared/auth_overlay_controller.h"
 #include "song_select/song_import_export_service.h"
 #include "song_select/song_catalog_service.h"
 #include "song_select/song_select_confirmation_dialog.h"
@@ -33,10 +32,6 @@ private:
     void sync_selected_song_media();
     void apply_delete_result(const song_select::delete_result& result);
     void apply_transfer_result(const song_select::transfer_result& result);
-    void start_auth_restore();
-    void poll_auth_restore();
-    void start_login_request(song_select::login_dialog_command command);
-    void poll_login_request();
     void poll_song_import_prepare();
     void poll_background_transfer();
     void start_song_import_prepare(std::string source_path);
@@ -60,12 +55,9 @@ private:
     bool open_login_dialog_on_enter_ = false;
     std::future<song_select::transfer_result> background_transfer_;
     std::future<song_select::song_import_prepare_result> background_song_import_prepare_;
-    std::future<auth::operation_result> auth_restore_;
-    std::future<auth::operation_result> auth_request_;
     bool background_transfer_active_ = false;
     bool background_song_import_prepare_active_ = false;
-    bool auth_restore_active_ = false;
-    bool auth_request_active_ = false;
+    auth_overlay::controller auth_controller_;
     std::string background_transfer_label_;
     std::optional<song_select::song_import_request> pending_song_import_request_;
     std::optional<song_select::chart_import_request> pending_chart_import_request_;

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -19,7 +19,8 @@ class song_select_scene final : public scene {
 public:
     explicit song_select_scene(scene_manager& manager, std::string preferred_song_id = "",
                                std::string preferred_chart_id = "",
-                               std::optional<song_select::recent_result_offset> recent_result_offset = std::nullopt);
+                               std::optional<song_select::recent_result_offset> recent_result_offset = std::nullopt,
+                               bool open_login_dialog_on_enter = false);
 
     void on_enter() override;
     void on_exit() override;
@@ -56,6 +57,7 @@ private:
     std::string preferred_song_id_;
     std::string preferred_chart_id_;
     std::optional<song_select::recent_result_offset> recent_result_offset_;
+    bool open_login_dialog_on_enter_ = false;
     std::future<song_select::transfer_result> background_transfer_;
     std::future<song_select::song_import_prepare_result> background_song_import_prepare_;
     std::future<auth::operation_result> auth_restore_;

--- a/src/scenes/title/title_spectrum_visualizer.cpp
+++ b/src/scenes/title/title_spectrum_visualizer.cpp
@@ -65,18 +65,18 @@ void title_spectrum_visualizer::update() {
     }
 
     if (frame_peak > dynamic_peak_) {
-        dynamic_peak_ += (frame_peak - dynamic_peak_) * 0.18f;
+        dynamic_peak_ += (frame_peak - dynamic_peak_) * 0.14f;
     } else {
-        dynamic_peak_ += (frame_peak - dynamic_peak_) * 0.04f;
+        dynamic_peak_ += (frame_peak - dynamic_peak_) * 0.035f;
     }
     dynamic_peak_ = std::max(0.12f, dynamic_peak_);
 
     for (int i = 0; i < kBarCount; ++i) {
         const float target = std::clamp(targets[static_cast<size_t>(i)] / dynamic_peak_, 0.0f, 1.0f);
         if (target > bars_[static_cast<size_t>(i)]) {
-            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.38f;
+            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.36f;
         } else {
-            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.15f;
+            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.045f;
         }
 
         const float bar_height = bars_[static_cast<size_t>(i)];
@@ -106,7 +106,7 @@ void title_spectrum_visualizer::draw(const Rectangle& rect) const {
     const float bar_width =
         (rect.width - gap * static_cast<float>(kBarCount - 1)) / static_cast<float>(kBarCount);
     const float baseline = rect.y + rect.height;
-    const float max_height = rect.height * 0.55f;
+    const float max_height = rect.height;// * 0.55f;
     const Color base_low = {107, 33, 168, 128};
     const Color base_top = {216, 180, 254, 230};
     const Color peak_glow = {216, 180, 254, 110};

--- a/src/scenes/title/title_spectrum_visualizer.cpp
+++ b/src/scenes/title/title_spectrum_visualizer.cpp
@@ -9,12 +9,12 @@
 
 namespace {
 
-constexpr std::array kSpectrumRanges = {
-    1, 2, 3, 4, 5, 6, 7, 8, 10, 12, 14, 17, 20, 24, 29, 35, 42,
-    50, 58, 66, 74, 82, 90, 98, 104, 109, 113, 117, 120, 123, 125, 127, 128
-};
+Color with_alpha_scale(Color color, float alpha_scale) {
+    color.a = static_cast<unsigned char>(std::clamp(alpha_scale, 0.0f, 1.0f) * 255.0f);
+    return color;
+}
 
-float average_band_energy(const std::array<float, 128>& spectrum, int begin, int end) {
+float average_bucket_energy(const std::array<float, 128>& spectrum, int begin, int end) {
     if (begin >= end) {
         return 0.0f;
     }
@@ -26,28 +26,13 @@ float average_band_energy(const std::array<float, 128>& spectrum, int begin, int
     return sum / static_cast<float>(end - begin);
 }
 
-Color with_alpha_scale(Color color, float alpha_scale) {
-    color.a = static_cast<unsigned char>(std::clamp(alpha_scale, 0.0f, 1.0f) * 255.0f);
-    return color;
-}
-
-Color fade_spectrum_color(Color base, float alpha_scale) {
-    return with_alpha_scale(base, alpha_scale);
-}
-
-float band_visual_weight(int band_index, int band_count) {
-    if (band_count <= 1) {
-        return 1.0f;
-    }
-
-    const float normalized_index = static_cast<float>(band_index) / static_cast<float>(band_count - 1);
-    return 0.34f + normalized_index * 0.92f;
-}
-
 }  // namespace
 
 void title_spectrum_visualizer::reset() {
     bars_.fill(0.0f);
+    peaks_.fill(0.0f);
+    peak_velocities_.fill(0.0f);
+    peak_hold_timers_.fill(0.0f);
     dynamic_peak_ = 0.12f;
 }
 
@@ -56,13 +41,24 @@ void title_spectrum_visualizer::update() {
     const bool has_audio = audio_manager::instance().get_bgm_fft256(spectrum);
     std::array<float, kBarCount> targets = {};
     float frame_peak = 0.0f;
+    constexpr float kFrequencyCurve = 1.55f;
 
     for (int i = 0; i < kBarCount; ++i) {
         float target = 0.0f;
         if (has_audio) {
-            const float band = average_band_energy(spectrum, kSpectrumRanges[static_cast<size_t>(i)],
-                                                   kSpectrumRanges[static_cast<size_t>(i + 1)]);
-            target = std::sqrt(std::max(0.0f, band)) * 7.5f * band_visual_weight(i, kBarCount);
+            const float start_t = static_cast<float>(i) / static_cast<float>(kBarCount);
+            const float end_t = static_cast<float>(i + 1) / static_cast<float>(kBarCount);
+            int begin = static_cast<int>(std::floor(std::pow(start_t, kFrequencyCurve) * static_cast<float>(spectrum.size())));
+            int end = static_cast<int>(std::floor(std::pow(end_t, kFrequencyCurve) * static_cast<float>(spectrum.size())));
+            begin = std::clamp(begin, 0, static_cast<int>(spectrum.size()) - 1);
+            end = std::clamp(end, begin + 1, static_cast<int>(spectrum.size()));
+
+            const float averaged = average_bucket_energy(spectrum, begin, end);
+            const float normalized = std::clamp(averaged, 0.0f, 1.0f);
+            const float band_t = static_cast<float>(i) / static_cast<float>(kBarCount - 1);
+            const float low_cut = 0.24f + band_t * 0.98f;
+            const float detail_boost = 0.82f + std::sqrt(band_t) * 0.36f;
+            target = std::pow(normalized, 0.82f) * low_cut * detail_boost;
         }
         targets[static_cast<size_t>(i)] = target;
         frame_peak = std::max(frame_peak, target);
@@ -78,9 +74,25 @@ void title_spectrum_visualizer::update() {
     for (int i = 0; i < kBarCount; ++i) {
         const float target = std::clamp(targets[static_cast<size_t>(i)] / dynamic_peak_, 0.0f, 1.0f);
         if (target > bars_[static_cast<size_t>(i)]) {
-            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.45f;
+            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.38f;
         } else {
-            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.12f;
+            bars_[static_cast<size_t>(i)] += (target - bars_[static_cast<size_t>(i)]) * 0.15f;
+        }
+
+        const float bar_height = bars_[static_cast<size_t>(i)];
+        if (bar_height > peaks_[static_cast<size_t>(i)]) {
+            peaks_[static_cast<size_t>(i)] +=
+                (bar_height - peaks_[static_cast<size_t>(i)]) * 0.24f;
+            peak_velocities_[static_cast<size_t>(i)] = 0.0f;
+            peak_hold_timers_[static_cast<size_t>(i)] = 7.0f;
+        } else {
+            if (peak_hold_timers_[static_cast<size_t>(i)] > 0.0f) {
+                peak_hold_timers_[static_cast<size_t>(i)] -= 1.0f;
+            } else {
+                peak_velocities_[static_cast<size_t>(i)] += 0.0035f;
+                peaks_[static_cast<size_t>(i)] =
+                    std::max(0.0f, peaks_[static_cast<size_t>(i)] - peak_velocities_[static_cast<size_t>(i)]);
+            }
         }
     }
 }
@@ -90,22 +102,33 @@ void title_spectrum_visualizer::draw(const Rectangle& rect) const {
         return;
     }
 
-    const auto& t = *g_theme;
-    const float gap = 4.0f;
+    const float gap = 3.0f;
     const float bar_width =
         (rect.width - gap * static_cast<float>(kBarCount - 1)) / static_cast<float>(kBarCount);
     const float baseline = rect.y + rect.height;
-    const Color base_color = t.accent;
+    const float max_height = rect.height * 0.55f;
+    const Color base_low = {107, 33, 168, 128};
+    const Color base_top = {216, 180, 254, 230};
+    const Color peak_glow = {216, 180, 254, 110};
+    const Color peak_color = {242, 230, 255, 220};
 
     for (int i = 0; i < kBarCount; ++i) {
         const float value = std::clamp(bars_[static_cast<size_t>(i)], 0.0f, 1.0f);
-        const float shaped_value = std::pow(value, 0.82f);
-        const float min_height = rect.height * 0.012f;
-        const float height = min_height + (rect.height - min_height) * shaped_value;
+        const float height = value * max_height;
         const float x = rect.x + static_cast<float>(i) * (bar_width + gap);
-        const Rectangle bar_rect = {x, baseline - height, bar_width, height};
-        const float color_t = static_cast<float>(i) / static_cast<float>(kBarCount - 1);
-        const float alpha_scale = 0.42f - color_t * 0.24f;
-        DrawRectangleRec(bar_rect, fade_spectrum_color(base_color, alpha_scale));
+        if (height > 0.5f) {
+            const float y = baseline - height;
+            DrawRectangleGradientV(
+                static_cast<int>(x),
+                static_cast<int>(y),
+                static_cast<int>(bar_width),
+                static_cast<int>(height),
+                base_top,
+                base_low);
+        }
+
+        const float peak_y = baseline - std::clamp(peaks_[static_cast<size_t>(i)], 0.0f, 1.0f) * max_height - 3.0f;
+        DrawRectangleRec({x, peak_y - 1.0f, bar_width, 4.0f}, peak_glow);
+        DrawRectangleRec({x, peak_y, bar_width, 2.0f}, peak_color);
     }
 }

--- a/src/scenes/title/title_spectrum_visualizer.h
+++ b/src/scenes/title/title_spectrum_visualizer.h
@@ -6,7 +6,7 @@
 
 class title_spectrum_visualizer final {
 public:
-    static constexpr int kBarCount = 64;
+    static constexpr int kBarCount = 48;
 
     void reset();
     void update();

--- a/src/scenes/title/title_spectrum_visualizer.h
+++ b/src/scenes/title/title_spectrum_visualizer.h
@@ -6,7 +6,7 @@
 
 class title_spectrum_visualizer final {
 public:
-    static constexpr int kBarCount = 32;
+    static constexpr int kBarCount = 64;
 
     void reset();
     void update();
@@ -14,5 +14,8 @@ public:
 
 private:
     std::array<float, kBarCount> bars_ = {};
+    std::array<float, kBarCount> peaks_ = {};
+    std::array<float, kBarCount> peak_velocities_ = {};
+    std::array<float, kBarCount> peak_hold_timers_ = {};
     float dynamic_peak_ = 0.12f;
 };

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -3,14 +3,13 @@
 #include <array>
 #include <cctype>
 #include <memory>
-#include <optional>
 #include <string>
 
-#include "network/auth_client.h"
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
 #include "song_select_scene.h"
+#include "song_select/song_select_layout.h"
 #include "song_select/song_select_navigation.h"
 #include "theme.h"
 #include "ui_draw.h"
@@ -39,6 +38,7 @@ constexpr float kHomeButtonGap = 18.0f;
 constexpr float kHomeAnimSpeed = 6.5f;
 constexpr float kHomeButtonRowY = 376.0f;
 constexpr float kHomeButtonIntroOffsetY = 24.0f;
+constexpr ui::draw_layer kTitleModalLayer = ui::draw_layer::modal;
 
 struct home_entry {
     const char* label;
@@ -81,14 +81,15 @@ std::string make_avatar_label(const auth::session_summary& summary) {
     return result.empty() ? "A" : result;
 }
 
-Rectangle lerp_rect(Rectangle from, Rectangle to, float t) {
-    const float clamped = std::clamp(t, 0.0f, 1.0f);
-    return {
-        from.x + (to.x - from.x) * clamped,
-        from.y + (to.y - from.y) * clamped,
-        from.width + (to.width - from.width) * clamped,
-        from.height + (to.height - from.height) * clamped,
+std::string make_avatar_label(const song_select::auth_state& auth_state) {
+    const auth::session_summary summary = {
+        auth_state.logged_in,
+        {},
+        auth_state.email,
+        auth_state.display_name,
+        auth_state.email_verified,
     };
+    return make_avatar_label(summary);
 }
 
 Vector2 lerp_vec2(Vector2 from, Vector2 to, float t) {
@@ -99,8 +100,18 @@ Vector2 lerp_vec2(Vector2 from, Vector2 to, float t) {
     };
 }
 
-Rectangle title_header_rect(float anim_t) {
-    return lerp_rect(kTitleClosedHeaderRect, kTitleOpenHeaderRect, ease_out_cubic(anim_t));
+const char* account_name_for(const song_select::auth_state& auth_state) {
+    if (!auth_state.logged_in) {
+        return "ACCOUNT";
+    }
+    return auth_state.display_name.empty() ? auth_state.email.c_str() : auth_state.display_name.c_str();
+}
+
+const char* account_status_for(const song_select::auth_state& auth_state) {
+    if (!auth_state.logged_in) {
+        return "Manage account";
+    }
+    return auth_state.email_verified ? "Verified profile" : "Manage account";
 }
 
 Rectangle home_button_rect(int index, float anim_t) {
@@ -132,24 +143,25 @@ void title_scene::start_transition(transition_target target) {
     transition_fade_.restart(scene_fade::direction::out, 0.3f, 0.65f);
 }
 
-void title_scene::refresh_auth_summary() {
-    auth_summary_ = auth::load_session_summary();
-}
-
 void title_scene::on_enter() {
     bgm_controller_.configure(kTitleIntroPath, kTitleLoopPath);
     spectrum_visualizer_.reset();
     bgm_controller_.on_enter();
-    refresh_auth_summary();
+    auth_overlay::refresh_auth_state(auth_state_);
     home_menu_open_ = false;
     home_menu_anim_ = 0.0f;
     home_menu_selected_index_ = 0;
     home_status_message_.clear();
+    login_dialog_.open = false;
+    if (auth_state_.logged_in) {
+        auth_overlay::start_restore(auth_controller_, login_dialog_);
+    }
 }
 
 void title_scene::on_exit() {
     bgm_controller_.on_exit();
     spectrum_visualizer_.reset();
+    login_dialog_.open = false;
 }
 
 // Title 上で Home 展開、Play/Create への遷移、Account 導線を扱う。
@@ -157,6 +169,13 @@ void title_scene::update(float dt) {
     ui::begin_hit_regions();
     bgm_controller_.update();
     spectrum_visualizer_.update();
+    auth_overlay::poll_restore(auth_controller_, auth_state_, login_dialog_);
+    auth_overlay::poll_request(auth_controller_, auth_state_, login_dialog_);
+    if (login_dialog_.open) {
+        login_dialog_.open_anim = std::min(1.0f, login_dialog_.open_anim + dt * 8.0f);
+    } else {
+        login_dialog_.open_anim = 0.0f;
+    }
     const float target_anim = home_menu_open_ ? 1.0f : 0.0f;
     home_menu_anim_ = std::clamp(home_menu_anim_ + (target_anim - home_menu_anim_) * std::min(1.0f, dt * kHomeAnimSpeed),
                                  0.0f, 1.0f);
@@ -170,9 +189,6 @@ void title_scene::update(float dt) {
             switch (transition_target_) {
             case transition_target::song_select:
                 manager_.change_scene(std::make_unique<song_select_scene>(manager_));
-                break;
-            case transition_target::song_select_account:
-                manager_.change_scene(std::make_unique<song_select_scene>(manager_, "", "", std::nullopt, true));
                 break;
             case transition_target::song_create:
                 manager_.change_scene(song_select::make_song_create_scene(manager_));
@@ -191,14 +207,33 @@ void title_scene::update(float dt) {
     }
 
     if (ui::is_clicked(kAccountChipRect)) {
-        start_transition(transition_target::song_select_account);
+        if (login_dialog_.open) {
+            login_dialog_.open = false;
+        } else {
+            song_select::open_login_dialog(login_dialog_, auth::load_session_summary());
+            auth_overlay::refresh_auth_state(auth_state_);
+        }
         return;
     }
 
+    if (login_dialog_.open) {
+        if ((IsKeyPressed(KEY_ESCAPE) || IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) &&
+            !auth_controller_.request_active) {
+            login_dialog_.open = false;
+        }
+        return;
+    }
+
+    const bool account_hovered = ui::is_hovered(kAccountChipRect);
+    const bool left_click_for_home =
+        IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+        !account_hovered;
+    const bool right_click_for_home = IsMouseButtonPressed(MOUSE_BUTTON_RIGHT);
+
     if (!home_menu_open_ &&
         (IsKeyPressed(KEY_ENTER) ||
-         IsMouseButtonPressed(MOUSE_BUTTON_LEFT) ||
-         IsMouseButtonPressed(MOUSE_BUTTON_RIGHT))) {
+         left_click_for_home ||
+         right_click_for_home)) {
         home_menu_open_ = true;
         home_status_message_.clear();
         return;
@@ -281,6 +316,7 @@ void title_scene::draw() {
     virtual_screen::begin();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
+    ui::begin_draw_queue();
     spectrum_visualizer_.draw(kSpectrumRect);
     ui::draw_text_f("raythm", title_pos.x, title_pos.y, 124, t.text);
     ui::draw_text_f("trace the line before the beat disappears", subtitle_pos.x, subtitle_pos.y, 30, t.text_dim);
@@ -288,23 +324,18 @@ void title_scene::draw() {
     ui::draw_panel(kAccountChipRect);
     const Rectangle avatar_rect = {kAccountChipRect.x + 12.0f, kAccountChipRect.y + 9.0f, 40.0f, 40.0f};
     const Vector2 avatar_center = {avatar_rect.x + avatar_rect.width * 0.5f, avatar_rect.y + avatar_rect.height * 0.5f};
-    DrawCircleV(avatar_center, 20.0f, auth_summary_.logged_in ? t.accent : t.row_selected);
-    const std::string avatar_label = make_avatar_label(auth_summary_);
+    DrawCircleV(avatar_center, 20.0f, auth_state_.logged_in ? t.accent : t.row_selected);
+    const std::string avatar_label = make_avatar_label(auth_state_);
     ui::draw_text_in_rect(avatar_label.c_str(), 18, avatar_rect,
-                          auth_summary_.logged_in ? t.panel : t.text, ui::text_align::center);
+                          auth_state_.logged_in ? t.panel : t.text, ui::text_align::center);
     const Rectangle account_name_rect = {
         kAccountChipRect.x + 64.0f, kAccountChipRect.y + 8.0f, kAccountChipRect.width - 88.0f, 22.0f
     };
-    const char* account_name = auth_summary_.logged_in
-        ? (auth_summary_.display_name.empty() ? auth_summary_.email.c_str() : auth_summary_.display_name.c_str())
-        : "ACCOUNT";
-    draw_marquee_text(account_name, account_name_rect, 18, t.text, GetTime());
-    ui::draw_text_in_rect(auth_summary_.logged_in
-                              ? (auth_summary_.email_verified ? "Verified profile" : "Manage account")
-                              : "Manage account",
+    draw_marquee_text(account_name_for(auth_state_), account_name_rect, 18, t.text, GetTime());
+    ui::draw_text_in_rect(account_status_for(auth_state_),
                           13,
                           {kAccountChipRect.x + 64.0f, kAccountChipRect.y + 30.0f, kAccountChipRect.width - 88.0f, 16.0f},
-                          auth_summary_.logged_in && !auth_summary_.email_verified ? t.error : t.text_muted,
+                          auth_state_.logged_in && !auth_state_.email_verified ? t.error : t.text_muted,
                           ui::text_align::left);
     ui::draw_text_in_rect(">", 18,
                           {kAccountChipRect.x + kAccountChipRect.width - 24.0f, kAccountChipRect.y + 12.0f, 12.0f, 24.0f},
@@ -343,6 +374,24 @@ void title_scene::draw() {
                                   ui::text_align::center);
         }
     }
+
+    const Rectangle account_dialog_anchor = {
+        kAccountChipRect.x,
+        kAccountChipRect.y + 12.0f,
+        kAccountChipRect.width,
+        kAccountChipRect.height
+    };
+    const song_select::login_dialog_command login_command =
+        song_select::draw_login_dialog(auth_state_, login_dialog_,
+                                       account_dialog_anchor, kScreenRect,
+                                       auth_controller_.request_active, kTitleModalLayer);
+    if (login_command == song_select::login_dialog_command::close) {
+        login_dialog_.open = false;
+    } else if (login_command != song_select::login_dialog_command::none) {
+        auth_overlay::start_request(auth_controller_, login_dialog_, login_command);
+    }
+
+    ui::flush_draw_queue();
 
     if (transitioning_to_song_select_) {
         transition_fade_.draw();

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -1,11 +1,17 @@
 #include "title_scene.h"
 
+#include <array>
+#include <cctype>
 #include <memory>
+#include <optional>
+#include <string>
 
+#include "network/auth_client.h"
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
 #include "song_select_scene.h"
+#include "song_select/song_select_navigation.h"
 #include "theme.h"
 #include "ui_draw.h"
 #include "virtual_screen.h"
@@ -13,38 +19,132 @@
 namespace {
 
 constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-constexpr Rectangle kTitleHeaderRect = ui::place(kScreenRect, 760.0f, 170.0f,
-                                                 ui::anchor::top_left, ui::anchor::top_left,
-                                                 {72.0f, 84.0f});
-constexpr Rectangle kTitleRect = {kTitleHeaderRect.x, kTitleHeaderRect.y, kTitleHeaderRect.width, 124.0f};
-constexpr Rectangle kSubtitleRect = {kTitleHeaderRect.x + 10.0f, kTitleHeaderRect.y + 128.0f,
-                                     kTitleHeaderRect.width - 10.0f, 30.0f};
-constexpr Rectangle kHintAreaRect = ui::place(kScreenRect, 320.0f, 52.0f,
-                                              ui::anchor::bottom_left, ui::anchor::bottom_left,
-                                              {82.0f, -46.0f});
-constexpr Rectangle kSpectrumRect = ui::place(kScreenRect, 760.0f, 150.0f,
-                                              ui::anchor::bottom_right, ui::anchor::bottom_right,
-                                              {-82.0f, -54.0f});
+constexpr Rectangle kTitleClosedHeaderRect = ui::place(kScreenRect, 860.0f, 182.0f,
+                                                       ui::anchor::center, ui::anchor::center,
+                                                       {0.0f, -54.0f});
+constexpr Rectangle kTitleOpenHeaderRect = ui::place(kScreenRect, 760.0f, 170.0f,
+                                                     ui::anchor::top_left, ui::anchor::top_left,
+                                                     {72.0f, 84.0f});
+constexpr Rectangle kSpectrumRect = ui::place(kScreenRect, 1040.0f, 332.0f,
+                                              ui::anchor::bottom_center, ui::anchor::bottom_center,
+                                              {0.0f, -56.0f});
+constexpr Rectangle kAccountChipRect = ui::place(kScreenRect, 264.0f, 58.0f,
+                                                 ui::anchor::top_right, ui::anchor::top_right,
+                                                 {-28.0f, 20.0f});
 constexpr const char* kTitleIntroPath = "assets/audio/title_intro.mp3";
 constexpr const char* kTitleLoopPath = "assets/audio/title_loop.mp3";
+constexpr float kHomeButtonWidth = 232.0f;
+constexpr float kHomeButtonHeight = 78.0f;
+constexpr float kHomeButtonGap = 18.0f;
+constexpr float kHomeAnimSpeed = 6.5f;
+constexpr float kHomeButtonRowY = 376.0f;
+constexpr float kHomeButtonIntroOffsetY = 24.0f;
+
+struct home_entry {
+    const char* label;
+    const char* detail;
+    bool enabled;
+    title_scene::transition_target target;
+};
+
+constexpr std::array<home_entry, 4> kHomeEntries = {{
+    {"PLAY", "Solo song select.", true, title_scene::transition_target::song_select},
+    {"MULTIPLAY", "Room battles soon.", false, title_scene::transition_target::song_select},
+    {"ONLINE", "Browse and download.", false, title_scene::transition_target::song_select},
+    {"CREATE", "Open creation tools.", true, title_scene::transition_target::song_create},
+}};
+
+float ease_out_cubic(float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    const float inv = 1.0f - clamped;
+    return 1.0f - inv * inv * inv;
+}
+
+std::string make_avatar_label(const auth::session_summary& summary) {
+    const std::string source = summary.logged_in
+        ? (summary.display_name.empty() ? summary.email : summary.display_name)
+        : "A";
+    if (source.empty()) {
+        return "A";
+    }
+
+    std::string result;
+    result.reserve(2);
+    for (char ch : source) {
+        if (std::isalnum(static_cast<unsigned char>(ch))) {
+            result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+            if (result.size() == 2) {
+                break;
+            }
+        }
+    }
+    return result.empty() ? "A" : result;
+}
+
+Rectangle lerp_rect(Rectangle from, Rectangle to, float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    return {
+        from.x + (to.x - from.x) * clamped,
+        from.y + (to.y - from.y) * clamped,
+        from.width + (to.width - from.width) * clamped,
+        from.height + (to.height - from.height) * clamped,
+    };
+}
+
+Vector2 lerp_vec2(Vector2 from, Vector2 to, float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    return {
+        from.x + (to.x - from.x) * clamped,
+        from.y + (to.y - from.y) * clamped,
+    };
+}
+
+Rectangle title_header_rect(float anim_t) {
+    return lerp_rect(kTitleClosedHeaderRect, kTitleOpenHeaderRect, ease_out_cubic(anim_t));
+}
+
+Rectangle home_button_rect(int index, float anim_t) {
+    const float eased = ease_out_cubic(anim_t);
+    const float total_width =
+        static_cast<float>(kHomeEntries.size()) * kHomeButtonWidth +
+        static_cast<float>(kHomeEntries.size() - 1) * kHomeButtonGap;
+    Rectangle rect = {
+        (static_cast<float>(kScreenWidth) - total_width) * 0.5f +
+            static_cast<float>(index) * (kHomeButtonWidth + kHomeButtonGap),
+        kHomeButtonRowY + (1.0f - eased) * kHomeButtonIntroOffsetY,
+        kHomeButtonWidth,
+        kHomeButtonHeight
+    };
+    return rect;
+}
 
 }  // namespace
 
 title_scene::title_scene(scene_manager& manager) : scene(manager) {
 }
 
-void title_scene::start_song_select_transition() {
+void title_scene::start_transition(transition_target target) {
     if (transitioning_to_song_select_) {
         return;
     }
+    transition_target_ = target;
     transitioning_to_song_select_ = true;
     transition_fade_.restart(scene_fade::direction::out, 0.3f, 0.65f);
+}
+
+void title_scene::refresh_auth_summary() {
+    auth_summary_ = auth::load_session_summary();
 }
 
 void title_scene::on_enter() {
     bgm_controller_.configure(kTitleIntroPath, kTitleLoopPath);
     spectrum_visualizer_.reset();
     bgm_controller_.on_enter();
+    refresh_auth_summary();
+    home_menu_open_ = false;
+    home_menu_anim_ = 0.0f;
+    home_menu_selected_index_ = 0;
+    home_status_message_.clear();
 }
 
 void title_scene::on_exit() {
@@ -52,16 +152,32 @@ void title_scene::on_exit() {
     spectrum_visualizer_.reset();
 }
 
-// ENTER で曲選択、S で設定画面へ遷移する。
+// Title 上で Home 展開、Play/Create への遷移、Account 導線を扱う。
 void title_scene::update(float dt) {
     ui::begin_hit_regions();
     bgm_controller_.update();
     spectrum_visualizer_.update();
+    const float target_anim = home_menu_open_ ? 1.0f : 0.0f;
+    home_menu_anim_ = std::clamp(home_menu_anim_ + (target_anim - home_menu_anim_) * std::min(1.0f, dt * kHomeAnimSpeed),
+                                 0.0f, 1.0f);
+    if (std::fabs(home_menu_anim_ - target_anim) < 0.002f) {
+        home_menu_anim_ = target_anim;
+    }
 
     if (transitioning_to_song_select_) {
         transition_fade_.update(dt);
         if (transition_fade_.complete()) {
-            manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+            switch (transition_target_) {
+            case transition_target::song_select:
+                manager_.change_scene(std::make_unique<song_select_scene>(manager_));
+                break;
+            case transition_target::song_select_account:
+                manager_.change_scene(std::make_unique<song_select_scene>(manager_, "", "", std::nullopt, true));
+                break;
+            case transition_target::song_create:
+                manager_.change_scene(song_select::make_song_create_scene(manager_));
+                break;
+            }
         }
         return;
     }
@@ -74,12 +190,61 @@ void title_scene::update(float dt) {
         return;
     }
 
-    if (IsKeyPressed(KEY_ENTER) || IsMouseButtonPressed(MOUSE_BUTTON_LEFT)) {
-        start_song_select_transition();
+    if (ui::is_clicked(kAccountChipRect)) {
+        start_transition(transition_target::song_select_account);
         return;
     }
 
-    if (IsKeyDown(KEY_ESCAPE)) {
+    if (!home_menu_open_ &&
+        (IsKeyPressed(KEY_ENTER) ||
+         IsMouseButtonPressed(MOUSE_BUTTON_LEFT) ||
+         IsMouseButtonPressed(MOUSE_BUTTON_RIGHT))) {
+        home_menu_open_ = true;
+        home_status_message_.clear();
+        return;
+    }
+
+    if (home_menu_open_) {
+        if (IsKeyPressed(KEY_ESCAPE) || IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) {
+            home_menu_open_ = false;
+            home_status_message_.clear();
+            return;
+        }
+
+        for (int index = 0; index < static_cast<int>(kHomeEntries.size()); ++index) {
+            const Rectangle rect = home_button_rect(index, home_menu_anim_);
+            if (ui::is_hovered(rect)) {
+                home_menu_selected_index_ = index;
+            }
+            if (ui::is_clicked(rect)) {
+                if (kHomeEntries[static_cast<size_t>(index)].enabled) {
+                    start_transition(kHomeEntries[static_cast<size_t>(index)].target);
+                } else {
+                    home_status_message_ = "This route is still warming up.";
+                }
+                return;
+            }
+        }
+
+        if (IsKeyPressed(KEY_RIGHT) || IsKeyPressed(KEY_D)) {
+            home_menu_selected_index_ = (home_menu_selected_index_ + 1) % static_cast<int>(kHomeEntries.size());
+        }
+        if (IsKeyPressed(KEY_LEFT) || IsKeyPressed(KEY_A)) {
+            home_menu_selected_index_ = (home_menu_selected_index_ - 1 + static_cast<int>(kHomeEntries.size())) %
+                                        static_cast<int>(kHomeEntries.size());
+        }
+        if (IsKeyPressed(KEY_ENTER)) {
+            const home_entry& entry = kHomeEntries[static_cast<size_t>(home_menu_selected_index_)];
+            if (entry.enabled) {
+                start_transition(entry.target);
+            } else {
+                home_status_message_ = "This route is still warming up.";
+            }
+            return;
+        }
+    }
+
+    if (!home_menu_open_ && IsKeyDown(KEY_ESCAPE)) {
         esc_hold_t_ += dt;
         if (esc_hold_t_ >= 0.3f) {
             esc_hold_t_ = 0.0f;
@@ -91,20 +256,94 @@ void title_scene::update(float dt) {
     }
 }
 
-// タイトルロゴと操作案内を描画する。
+// タイトルと、そこから展開する Home 導線を描画する。
 void title_scene::draw() {
     const auto& t = *g_theme;
+    const float menu_t = ease_out_cubic(home_menu_anim_);
+    const Vector2 closed_title_pos = ui::text_position("raythm", 124,
+                                                       {kTitleClosedHeaderRect.x, kTitleClosedHeaderRect.y,
+                                                        kTitleClosedHeaderRect.width, 124.0f},
+                                                       ui::text_align::center);
+    const Vector2 open_title_pos = ui::text_position("raythm", 124,
+                                                     {kTitleOpenHeaderRect.x, kTitleOpenHeaderRect.y,
+                                                      kTitleOpenHeaderRect.width, 124.0f},
+                                                     ui::text_align::left);
+    const Vector2 title_pos = lerp_vec2(closed_title_pos, open_title_pos, menu_t);
+    const Vector2 closed_subtitle_pos = ui::text_position("trace the line before the beat disappears", 30,
+                                                          {kTitleClosedHeaderRect.x + 10.0f, kTitleClosedHeaderRect.y + 128.0f,
+                                                           kTitleClosedHeaderRect.width - 10.0f, 30.0f},
+                                                          ui::text_align::center);
+    const Vector2 open_subtitle_pos = ui::text_position("trace the line before the beat disappears", 30,
+                                                        {kTitleOpenHeaderRect.x + 10.0f, kTitleOpenHeaderRect.y + 128.0f,
+                                                         kTitleOpenHeaderRect.width - 10.0f, 30.0f},
+                                                        ui::text_align::left);
+    const Vector2 subtitle_pos = lerp_vec2(closed_subtitle_pos, open_subtitle_pos, menu_t);
     virtual_screen::begin();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     spectrum_visualizer_.draw(kSpectrumRect);
-    ui::draw_text_in_rect("raythm", 124, kTitleRect, t.text, ui::text_align::left);
-    ui::draw_text_in_rect("trace the line before the beat disappears", 30, kSubtitleRect, t.text_dim, ui::text_align::left);
+    ui::draw_text_f("raythm", title_pos.x, title_pos.y, 124, t.text);
+    ui::draw_text_f("trace the line before the beat disappears", subtitle_pos.x, subtitle_pos.y, 30, t.text_dim);
 
-    Rectangle hint_rows[2];
-    ui::vstack(kHintAreaRect, 22.0f, 8.0f, hint_rows);
-    ui::draw_text_in_rect("LEFT CLICK: Song Select", 22, hint_rows[0], t.text_muted, ui::text_align::left);
-    ui::draw_text_in_rect("ESC: Quit", 22, hint_rows[1], t.text_muted, ui::text_align::left);
+    ui::draw_panel(kAccountChipRect);
+    const Rectangle avatar_rect = {kAccountChipRect.x + 12.0f, kAccountChipRect.y + 9.0f, 40.0f, 40.0f};
+    const Vector2 avatar_center = {avatar_rect.x + avatar_rect.width * 0.5f, avatar_rect.y + avatar_rect.height * 0.5f};
+    DrawCircleV(avatar_center, 20.0f, auth_summary_.logged_in ? t.accent : t.row_selected);
+    const std::string avatar_label = make_avatar_label(auth_summary_);
+    ui::draw_text_in_rect(avatar_label.c_str(), 18, avatar_rect,
+                          auth_summary_.logged_in ? t.panel : t.text, ui::text_align::center);
+    const Rectangle account_name_rect = {
+        kAccountChipRect.x + 64.0f, kAccountChipRect.y + 8.0f, kAccountChipRect.width - 88.0f, 22.0f
+    };
+    const char* account_name = auth_summary_.logged_in
+        ? (auth_summary_.display_name.empty() ? auth_summary_.email.c_str() : auth_summary_.display_name.c_str())
+        : "ACCOUNT";
+    draw_marquee_text(account_name, account_name_rect, 18, t.text, GetTime());
+    ui::draw_text_in_rect(auth_summary_.logged_in
+                              ? (auth_summary_.email_verified ? "Verified profile" : "Manage account")
+                              : "Manage account",
+                          13,
+                          {kAccountChipRect.x + 64.0f, kAccountChipRect.y + 30.0f, kAccountChipRect.width - 88.0f, 16.0f},
+                          auth_summary_.logged_in && !auth_summary_.email_verified ? t.error : t.text_muted,
+                          ui::text_align::left);
+    ui::draw_text_in_rect(">", 18,
+                          {kAccountChipRect.x + kAccountChipRect.width - 24.0f, kAccountChipRect.y + 12.0f, 12.0f, 24.0f},
+                          t.text_muted, ui::text_align::center);
+
+    if (home_menu_anim_ > 0.01f) {
+        for (int index = 0; index < static_cast<int>(kHomeEntries.size()); ++index) {
+            const home_entry& entry = kHomeEntries[static_cast<size_t>(index)];
+            const Rectangle button_rect = home_button_rect(index, home_menu_anim_);
+            const bool selected = index == home_menu_selected_index_;
+            const Color bg = !entry.enabled
+                ? with_alpha(t.row, static_cast<unsigned char>(146.0f * menu_t))
+                : (selected ? with_alpha(t.row_selected, static_cast<unsigned char>(236.0f * menu_t))
+                            : with_alpha(t.row, static_cast<unsigned char>(220.0f * menu_t)));
+            const Color border = !entry.enabled
+                ? with_alpha(t.border_light, static_cast<unsigned char>(180.0f * menu_t))
+                : (selected ? with_alpha(t.border_active, static_cast<unsigned char>(255.0f * menu_t))
+                            : with_alpha(t.border, static_cast<unsigned char>(230.0f * menu_t)));
+            DrawRectangleRec(button_rect, bg);
+            DrawRectangleLinesEx(button_rect, 1.8f, border);
+            ui::draw_text_in_rect(entry.label, 24,
+                                  {button_rect.x + 14.0f, button_rect.y + 12.0f, button_rect.width - 28.0f, 24.0f},
+                                  with_alpha(entry.enabled ? t.text : t.text_muted, static_cast<unsigned char>(255.0f * menu_t)),
+                                  ui::text_align::center);
+            ui::draw_text_in_rect(entry.detail, 13,
+                                  {button_rect.x + 16.0f, button_rect.y + 42.0f, button_rect.width - 32.0f, 18.0f},
+                                  with_alpha(entry.enabled ? t.text_muted : t.text_hint, static_cast<unsigned char>(220.0f * menu_t)),
+                                  ui::text_align::center);
+        }
+
+        if (!home_status_message_.empty()) {
+            ui::draw_text_in_rect(home_status_message_.c_str(), 16,
+                                  {0.0f, kHomeButtonRowY + kHomeButtonHeight + 22.0f,
+                                   static_cast<float>(kScreenWidth), 18.0f},
+                                  with_alpha(t.text_muted, static_cast<unsigned char>(230.0f * menu_t)),
+                                  ui::text_align::center);
+        }
+    }
+
     if (transitioning_to_song_select_) {
         transition_fade_.draw();
     }

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -38,6 +38,7 @@ constexpr float kHomeButtonGap = 18.0f;
 constexpr float kHomeAnimSpeed = 6.5f;
 constexpr float kHomeButtonRowY = 376.0f;
 constexpr float kHomeButtonIntroOffsetY = 24.0f;
+constexpr float kAccountChipInteractiveThreshold = 0.2f;
 constexpr ui::draw_layer kTitleModalLayer = ui::draw_layer::modal;
 
 struct home_entry {
@@ -131,7 +132,10 @@ Rectangle home_button_rect(int index, float anim_t) {
 
 }  // namespace
 
-title_scene::title_scene(scene_manager& manager) : scene(manager) {
+title_scene::title_scene(scene_manager& manager, bool start_with_home_open, bool play_intro_fade) :
+    scene(manager),
+    start_with_home_open_(start_with_home_open),
+    play_intro_fade_(play_intro_fade) {
 }
 
 void title_scene::start_transition(transition_target target) {
@@ -148,8 +152,16 @@ void title_scene::on_enter() {
     spectrum_visualizer_.reset();
     bgm_controller_.on_enter();
     auth_overlay::refresh_auth_state(auth_state_);
-    home_menu_open_ = false;
-    home_menu_anim_ = 0.0f;
+    if (play_intro_fade_) {
+        intro_fade_.restart(scene_fade::direction::in, 1.0f, 1.0f);
+        intro_hold_t_ = 0.5f;
+    } else {
+        intro_fade_.restart(scene_fade::direction::in, 0.0f, 0.0f);
+        intro_hold_t_ = 0.0f;
+    }
+    home_menu_open_ = start_with_home_open_;
+    suppress_home_pointer_until_release_ = false;
+    home_menu_anim_ = start_with_home_open_ ? 1.0f : 0.0f;
     home_menu_selected_index_ = 0;
     home_status_message_.clear();
     login_dialog_.open = false;
@@ -171,6 +183,11 @@ void title_scene::update(float dt) {
     spectrum_visualizer_.update();
     auth_overlay::poll_restore(auth_controller_, auth_state_, login_dialog_);
     auth_overlay::poll_request(auth_controller_, auth_state_, login_dialog_);
+    if (intro_hold_t_ > 0.0f) {
+        intro_hold_t_ = std::max(0.0f, intro_hold_t_ - dt);
+    } else {
+        intro_fade_.update(dt);
+    }
     if (login_dialog_.open) {
         login_dialog_.open_anim = std::min(1.0f, login_dialog_.open_anim + dt * 8.0f);
     } else {
@@ -206,7 +223,7 @@ void title_scene::update(float dt) {
         return;
     }
 
-    if (ui::is_clicked(kAccountChipRect)) {
+    if (home_menu_anim_ >= kAccountChipInteractiveThreshold && ui::is_clicked(kAccountChipRect)) {
         if (login_dialog_.open) {
             login_dialog_.open = false;
         } else {
@@ -224,7 +241,14 @@ void title_scene::update(float dt) {
         return;
     }
 
-    const bool account_hovered = ui::is_hovered(kAccountChipRect);
+    if (suppress_home_pointer_until_release_ &&
+        !IsMouseButtonDown(MOUSE_BUTTON_LEFT) &&
+        !IsMouseButtonDown(MOUSE_BUTTON_RIGHT)) {
+        suppress_home_pointer_until_release_ = false;
+    }
+
+    const bool account_hovered =
+        home_menu_anim_ >= kAccountChipInteractiveThreshold && ui::is_hovered(kAccountChipRect);
     const bool left_click_for_home =
         IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
         !account_hovered;
@@ -235,6 +259,7 @@ void title_scene::update(float dt) {
          left_click_for_home ||
          right_click_for_home)) {
         home_menu_open_ = true;
+        suppress_home_pointer_until_release_ = left_click_for_home || right_click_for_home;
         home_status_message_.clear();
         return;
     }
@@ -242,22 +267,25 @@ void title_scene::update(float dt) {
     if (home_menu_open_) {
         if (IsKeyPressed(KEY_ESCAPE) || IsMouseButtonPressed(MOUSE_BUTTON_RIGHT)) {
             home_menu_open_ = false;
+            suppress_home_pointer_until_release_ = false;
             home_status_message_.clear();
             return;
         }
 
-        for (int index = 0; index < static_cast<int>(kHomeEntries.size()); ++index) {
-            const Rectangle rect = home_button_rect(index, home_menu_anim_);
-            if (ui::is_hovered(rect)) {
-                home_menu_selected_index_ = index;
-            }
-            if (ui::is_clicked(rect)) {
-                if (kHomeEntries[static_cast<size_t>(index)].enabled) {
-                    start_transition(kHomeEntries[static_cast<size_t>(index)].target);
-                } else {
-                    home_status_message_ = "This route is still warming up.";
+        if (!suppress_home_pointer_until_release_) {
+            for (int index = 0; index < static_cast<int>(kHomeEntries.size()); ++index) {
+                const Rectangle rect = home_button_rect(index, home_menu_anim_);
+                if (ui::is_hovered(rect)) {
+                    home_menu_selected_index_ = index;
                 }
-                return;
+                if (ui::is_clicked(rect)) {
+                    if (kHomeEntries[static_cast<size_t>(index)].enabled) {
+                        start_transition(kHomeEntries[static_cast<size_t>(index)].target);
+                    } else {
+                        home_status_message_ = "This route is still warming up.";
+                    }
+                    return;
+                }
             }
         }
 
@@ -321,25 +349,29 @@ void title_scene::draw() {
     ui::draw_text_f("raythm", title_pos.x, title_pos.y, 124, t.text);
     ui::draw_text_f("trace the line before the beat disappears", subtitle_pos.x, subtitle_pos.y, 30, t.text_dim);
 
-    ui::draw_panel(kAccountChipRect);
-    const Rectangle avatar_rect = {kAccountChipRect.x + 12.0f, kAccountChipRect.y + 9.0f, 40.0f, 40.0f};
-    const Vector2 avatar_center = {avatar_rect.x + avatar_rect.width * 0.5f, avatar_rect.y + avatar_rect.height * 0.5f};
-    DrawCircleV(avatar_center, 20.0f, auth_state_.logged_in ? t.accent : t.row_selected);
-    const std::string avatar_label = make_avatar_label(auth_state_);
-    ui::draw_text_in_rect(avatar_label.c_str(), 18, avatar_rect,
-                          auth_state_.logged_in ? t.panel : t.text, ui::text_align::center);
-    const Rectangle account_name_rect = {
-        kAccountChipRect.x + 64.0f, kAccountChipRect.y + 8.0f, kAccountChipRect.width - 88.0f, 22.0f
-    };
-    draw_marquee_text(account_name_for(auth_state_), account_name_rect, 18, t.text, GetTime());
-    ui::draw_text_in_rect(account_status_for(auth_state_),
-                          13,
-                          {kAccountChipRect.x + 64.0f, kAccountChipRect.y + 30.0f, kAccountChipRect.width - 88.0f, 16.0f},
-                          auth_state_.logged_in && !auth_state_.email_verified ? t.error : t.text_muted,
-                          ui::text_align::left);
-    ui::draw_text_in_rect(">", 18,
-                          {kAccountChipRect.x + kAccountChipRect.width - 24.0f, kAccountChipRect.y + 12.0f, 12.0f, 24.0f},
-                          t.text_muted, ui::text_align::center);
+    if (menu_t > 0.01f) {
+        const unsigned char account_alpha = static_cast<unsigned char>(255.0f * menu_t);
+        DrawRectangleRec(kAccountChipRect, with_alpha(t.panel, account_alpha));
+        DrawRectangleLinesEx(kAccountChipRect, 2.0f, with_alpha(t.border, account_alpha));
+        const Rectangle avatar_rect = {kAccountChipRect.x + 12.0f, kAccountChipRect.y + 9.0f, 40.0f, 40.0f};
+        const Vector2 avatar_center = {avatar_rect.x + avatar_rect.width * 0.5f, avatar_rect.y + avatar_rect.height * 0.5f};
+        DrawCircleV(avatar_center, 20.0f, with_alpha(auth_state_.logged_in ? t.accent : t.row_selected, account_alpha));
+        const std::string avatar_label = make_avatar_label(auth_state_);
+        ui::draw_text_in_rect(avatar_label.c_str(), 18, avatar_rect,
+                              with_alpha(auth_state_.logged_in ? t.panel : t.text, account_alpha), ui::text_align::center);
+        const Rectangle account_name_rect = {
+            kAccountChipRect.x + 64.0f, kAccountChipRect.y + 8.0f, kAccountChipRect.width - 88.0f, 22.0f
+        };
+        draw_marquee_text(account_name_for(auth_state_), account_name_rect, 18, with_alpha(t.text, account_alpha), GetTime());
+        ui::draw_text_in_rect(account_status_for(auth_state_),
+                              13,
+                              {kAccountChipRect.x + 64.0f, kAccountChipRect.y + 30.0f, kAccountChipRect.width - 88.0f, 16.0f},
+                              with_alpha(auth_state_.logged_in && !auth_state_.email_verified ? t.error : t.text_muted, account_alpha),
+                              ui::text_align::left);
+        ui::draw_text_in_rect(">", 18,
+                              {kAccountChipRect.x + kAccountChipRect.width - 24.0f, kAccountChipRect.y + 12.0f, 12.0f, 24.0f},
+                              with_alpha(t.text_muted, account_alpha), ui::text_align::center);
+    }
 
     if (home_menu_anim_ > 0.01f) {
         for (int index = 0; index < static_cast<int>(kHomeEntries.size()); ++index) {
@@ -393,6 +425,11 @@ void title_scene::draw() {
 
     ui::flush_draw_queue();
 
+    if (intro_hold_t_ > 0.0f) {
+        ui::draw_fullscreen_overlay(BLACK);
+    } else {
+        intro_fade_.draw();
+    }
     if (transitioning_to_song_select_) {
         transition_fade_.draw();
     }

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -1,13 +1,21 @@
 #pragma once
 
 #include "scene.h"
+#include "network/auth_client.h"
 #include "shared/scene_fade.h"
 #include "title/title_bgm_controller.h"
 #include "title/title_spectrum_visualizer.h"
+#include <string>
 
 // タイトル画面。曲選択画面・設定画面への遷移を提供する。
 class title_scene final : public scene {
 public:
+    enum class transition_target {
+        song_select,
+        song_select_account,
+        song_create,
+    };
+
     explicit title_scene(scene_manager& manager);
 
     void on_enter() override;
@@ -16,13 +24,20 @@ public:
     void draw() override;
 
 private:
-    void start_song_select_transition();
+    void start_transition(transition_target target);
+    void refresh_auth_summary();
 
     bool quitting_ = false;
     scene_fade quit_fade_{scene_fade::direction::out, 1.5f, 1.0f};
     float esc_hold_t_ = 0.0f;
     bool transitioning_to_song_select_ = false;
     scene_fade transition_fade_{scene_fade::direction::out, 0.3f, 0.65f};
+    transition_target transition_target_ = transition_target::song_select;
+    bool home_menu_open_ = false;
+    float home_menu_anim_ = 0.0f;
+    int home_menu_selected_index_ = 0;
+    std::string home_status_message_;
+    auth::session_summary auth_summary_;
     title_bgm_controller bgm_controller_;
     title_spectrum_visualizer spectrum_visualizer_;
 };

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -17,7 +17,9 @@ public:
         song_create,
     };
 
-    explicit title_scene(scene_manager& manager);
+    explicit title_scene(scene_manager& manager,
+                         bool start_with_home_open = false,
+                         bool play_intro_fade = true);
 
     void on_enter() override;
     void on_exit() override;
@@ -32,8 +34,13 @@ private:
     float esc_hold_t_ = 0.0f;
     bool transitioning_to_song_select_ = false;
     scene_fade transition_fade_{scene_fade::direction::out, 0.3f, 0.65f};
+    scene_fade intro_fade_{scene_fade::direction::in, 0.45f, 1.0f};
+    float intro_hold_t_ = 0.0f;
     transition_target transition_target_ = transition_target::song_select;
+    bool start_with_home_open_ = false;
+    bool play_intro_fade_ = true;
     bool home_menu_open_ = false;
+    bool suppress_home_pointer_until_release_ = false;
     float home_menu_anim_ = 0.0f;
     int home_menu_selected_index_ = 0;
     std::string home_status_message_;

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include "scene.h"
-#include "network/auth_client.h"
+#include "shared/auth_overlay_controller.h"
 #include "shared/scene_fade.h"
+#include "song_select/song_select_login_dialog.h"
+#include "song_select/song_select_state.h"
 #include "title/title_bgm_controller.h"
 #include "title/title_spectrum_visualizer.h"
 #include <string>
@@ -12,7 +14,6 @@ class title_scene final : public scene {
 public:
     enum class transition_target {
         song_select,
-        song_select_account,
         song_create,
     };
 
@@ -25,7 +26,6 @@ public:
 
 private:
     void start_transition(transition_target target);
-    void refresh_auth_summary();
 
     bool quitting_ = false;
     scene_fade quit_fade_{scene_fade::direction::out, 1.5f, 1.0f};
@@ -37,7 +37,9 @@ private:
     float home_menu_anim_ = 0.0f;
     int home_menu_selected_index_ = 0;
     std::string home_status_message_;
-    auth::session_summary auth_summary_;
+    song_select::auth_state auth_state_;
+    song_select::login_dialog_state login_dialog_;
     title_bgm_controller bgm_controller_;
     title_spectrum_visualizer spectrum_visualizer_;
+    auth_overlay::controller auth_controller_;
 };


### PR DESCRIPTION
## 概要
- タイトル画面にシームレスな HOME 展開導線を追加
- 右上アカウントをグローバルオーバーレイ化
- タイトル演出と入力挙動を調整

## 変更内容
- タイトル中央ロゴから HOME へ展開するアニメーションを実装
- `PLAY / MULTIPLAY / ONLINE / CREATE` の横並び HOME を追加
- 右上アカウントチップを常設し、タイトル上でログインダイアログを開けるように変更
- タイトルと選曲画面で共通の auth overlay controller を使うよう整理
- スペクトラムの見た目と追従をチューニング
- 起動時の intro fade と、選曲画面から戻るときの HOME 展開済みタイトル表示を追加
- HOME 展開時の誤クリックやダイアログ操作時の入力干渉を修正

## 確認
- `cmake --build cmake-build-codex --target raythm -j 4`
- タイトルから HOME 展開、アカウント表示、選曲画面からタイトルへの復帰を手元で確認

Refs #251