### PR TITLE
UI 描画を高解像度仮想レンダリングへ寄せる

### DIFF
--- a/src/core/window_dialog_support.cpp
+++ b/src/core/window_dialog_support.cpp
@@ -30,8 +30,8 @@ namespace window_dialog_support {
 
 namespace {
 
-int g_last_windowed_width = 1280;
-int g_last_windowed_height = 720;
+int g_last_windowed_width = 1920;
+int g_last_windowed_height = 1080;
 
 }
 

--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -10,9 +10,9 @@ struct resolution_preset {
 };
 
 inline constexpr resolution_preset kResolutionPresets[] = {
-    {1280, 720, "1280x720"},
     {1920, 1080, "1920x1080"},
     {2560, 1440, "2560x1440"},
+    {3840, 2160, "3840x2160"},
 };
 inline constexpr int kResolutionPresetCount = 3;
 inline constexpr float kMinLaneWidth = 0.6f;
@@ -31,9 +31,9 @@ struct game_settings {
     float se_volume = 1.0f;
     int target_fps = 144;
     key_config keys;
-    int resolution_index = 1;  // デフォルト 1920x1080
-    int windowed_width = 1280;
-    int windowed_height = 720;
+    int resolution_index = 0;  // デフォルト 1920x1080
+    int windowed_width = 1920;
+    int windowed_height = 1080;
     bool fullscreen = false;
     bool dark_mode = false;
 };

--- a/src/mv/api/mv_builtins.cpp
+++ b/src/mv/api/mv_builtins.cpp
@@ -358,8 +358,8 @@ beat_grid_node extract_beat_grid(const std::shared_ptr<mv_object>& obj) {
     beat_grid_node n;
     n.x = static_cast<float>(as_number(obj->get_attr("x")));
     n.y = static_cast<float>(as_number(obj->get_attr("y")));
-    n.w = static_cast<float>(as_number(obj->get_attr("w"), 1280));
-    n.h = static_cast<float>(as_number(obj->get_attr("h"), 720));
+    n.w = static_cast<float>(as_number(obj->get_attr("w"), 1920));
+    n.h = static_cast<float>(as_number(obj->get_attr("h"), 1080));
     n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 1));
     n.beat_phase = static_cast<float>(as_number(obj->get_attr("beat_phase")));
     n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));

--- a/src/mv/api/mv_context.h
+++ b/src/mv/api/mv_context.h
@@ -50,8 +50,8 @@ struct context_input {
     int key_count = 4;
 
     // screen
-    float screen_w = 1280;
-    float screen_h = 720;
+    float screen_w = 1920;
+    float screen_h = 1080;
 };
 
 // Build the ctx mv_object from context_input.

--- a/src/mv/api/mv_scene.h
+++ b/src/mv/api/mv_scene.h
@@ -63,7 +63,7 @@ struct spectrum_bar_node {
 };
 
 struct beat_grid_node {
-    float x = 0, y = 0, w = 1280, h = 720;
+    float x = 0, y = 0, w = 1920, h = 1080;
     color stroke{255, 255, 255, 60};
     float thickness = 1.0f;
     float beat_phase = 0; // 0..1, fraction within current beat
@@ -71,7 +71,7 @@ struct beat_grid_node {
 };
 
 struct pulse_ring_node {
-    float cx = 640, cy = 360, radius = 100;
+    float cx = 960, cy = 540, radius = 100;
     color stroke{255, 255, 255, 255};
     float thickness = 3.0f;
     float beat_phase = 0; // drives expansion/fade

--- a/src/mv/lang/mv_vm.h
+++ b/src/mv/lang/mv_vm.h
@@ -437,8 +437,8 @@ protected:
 struct ctx_screen_object final : mv_object {
     ctx_screen_object() : mv_object(mv_object_kind::ctx_screen, "screen") {}
 
-    double w = 1280.0;
-    double h = 720.0;
+    double w = 1920.0;
+    double h = 1080.0;
 
 protected:
     std::optional<mv_value> get_known_attr(std::string_view name) const override {

--- a/src/mv/render/mv_renderer.cpp
+++ b/src/mv/render/mv_renderer.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 
 #include "ui/ui_font.h"
+#include "scenes/scene_common.h"
 
 namespace mv {
 
@@ -102,7 +103,7 @@ void draw_node(const pulse_ring_node& n) {
 
 void draw_node(const background_node& n) {
     Color col = to_raylib(n.fill, n.opacity);
-    DrawRectangle(0, 0, 1280, 720, col);
+    DrawRectangle(0, 0, kScreenWidth, kScreenHeight, col);
 }
 
 } // anonymous namespace
@@ -110,7 +111,7 @@ void draw_node(const background_node& n) {
 void render_scene(const scene& sc) {
     // Clear with scene clear color if alpha > 0
     if (sc.clear_color.a > 0) {
-        DrawRectangle(0, 0, 1280, 720,
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
                       to_raylib(sc.clear_color));
     }
 

--- a/src/mv/render/mv_renderer.h
+++ b/src/mv/render/mv_renderer.h
@@ -5,7 +5,7 @@
 namespace mv {
 
 // Render a scene using raylib 2D draw calls.
-// Assumes virtual_screen coordinate system (1280x720) is already active.
+// Assumes virtual_screen coordinate system (1920x1080) is already active.
 void render_scene(const scene& sc);
 
 } // namespace mv

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -224,7 +224,7 @@ void editor_scene::rebuild_hit_regions() const {
 void editor_scene::draw() {
     const auto& t = *g_theme;
     const double now = GetTime();
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     rebuild_hit_regions();
     ui::begin_draw_queue();
     ClearBackground(t.bg);

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -144,7 +144,7 @@ void mv_editor_scene::update(float dt) {
 }
 
 void mv_editor_scene::draw() {
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
     ui::begin_draw_queue();

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -166,7 +166,7 @@ void result_scene::poll_online_submit() {
 
 void result_scene::draw() {
     const auto& t = *g_theme;
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
 

--- a/src/scenes/scene_common.h
+++ b/src/scenes/scene_common.h
@@ -4,8 +4,8 @@
 
 // 仮想解像度。すべての2D UIはこの座標系で描画される。
 // 実際の表示は virtual_screen を通じてウィンドウサイズにスケーリングされる。
-constexpr int kScreenWidth = 1280;
-constexpr int kScreenHeight = 720;
+constexpr int kScreenWidth = 1920;
+constexpr int kScreenHeight = 1080;
 
 // メニュー系シーン共通のフレーム（グラデーション背景・角丸枠・タイトル文字列）を描画する。
 void draw_scene_frame(const char* title, const char* subtitle, Color accent);

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -62,7 +62,7 @@ void settings_scene::update(float dt) {
 
 void settings_scene::draw() {
     const auto& t = *g_theme;
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     ui::draw_panel(settings::kSidebarRect);

--- a/src/scenes/song_create_scene.cpp
+++ b/src/scenes/song_create_scene.cpp
@@ -126,7 +126,7 @@ void song_create_scene::draw() {
             break;
     }
 
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     ui::draw_header_block(kHeaderRect, content_title, content_subtitle);

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -846,7 +846,7 @@ void song_select_scene::update(float dt) {
 
 void song_select_scene::draw() {
     const auto& theme = *g_theme;
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(theme.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, theme.bg, theme.bg_alt);
     ui::begin_draw_queue();

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -341,7 +341,7 @@ void title_scene::draw() {
                                                          kTitleOpenHeaderRect.width - 10.0f, 30.0f},
                                                         ui::text_align::left);
     const Vector2 subtitle_pos = lerp_vec2(closed_subtitle_pos, open_subtitle_pos, menu_t);
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     ui::begin_draw_queue();

--- a/src/scenes/virtual_screen.cpp
+++ b/src/scenes/virtual_screen.cpp
@@ -34,7 +34,8 @@ void init() {
     render_target_ = LoadRenderTexture(kDesignWidth, kDesignHeight);
     ui_render_target_ = LoadRenderTexture(kDesignWidth * kUiRenderScale, kDesignHeight * kUiRenderScale);
     SetTextureFilter(render_target_.texture, TEXTURE_FILTER_BILINEAR);
-    SetTextureFilter(ui_render_target_.texture, TEXTURE_FILTER_BILINEAR);
+    // 高解像度 UI RT は最終拡大時にぼやけやすいため、まずは point で比較する。
+    SetTextureFilter(ui_render_target_.texture, TEXTURE_FILTER_POINT);
     active_mode_ = render_mode::none;
     present_mode_ = render_mode::standard;
     initialized_ = true;

--- a/src/scenes/virtual_screen.cpp
+++ b/src/scenes/virtual_screen.cpp
@@ -2,53 +2,98 @@
 
 namespace {
 RenderTexture2D render_target_{};
+RenderTexture2D ui_render_target_{};
 bool initialized_ = false;
+
+enum class render_mode {
+    none,
+    standard,
+    ui_highres,
+};
+
+render_mode active_mode_ = render_mode::none;
+render_mode present_mode_ = render_mode::standard;
+
+Camera2D make_ui_camera() {
+    Camera2D camera = {};
+    camera.offset = {0.0f, 0.0f};
+    camera.target = {0.0f, 0.0f};
+    camera.rotation = 0.0f;
+    camera.zoom = static_cast<float>(virtual_screen::kUiRenderScale);
+    return camera;
+}
+
+const RenderTexture2D& current_target(render_mode mode) {
+    return mode == render_mode::ui_highres ? ui_render_target_ : render_target_;
+}
 }  // namespace
 
 namespace virtual_screen {
 
 void init() {
     render_target_ = LoadRenderTexture(kDesignWidth, kDesignHeight);
+    ui_render_target_ = LoadRenderTexture(kDesignWidth * kUiRenderScale, kDesignHeight * kUiRenderScale);
+    SetTextureFilter(render_target_.texture, TEXTURE_FILTER_BILINEAR);
+    SetTextureFilter(ui_render_target_.texture, TEXTURE_FILTER_BILINEAR);
+    active_mode_ = render_mode::none;
+    present_mode_ = render_mode::standard;
     initialized_ = true;
 }
 
 void cleanup() {
     if (initialized_) {
         UnloadRenderTexture(render_target_);
+        UnloadRenderTexture(ui_render_target_);
         initialized_ = false;
+        active_mode_ = render_mode::none;
+        present_mode_ = render_mode::standard;
     }
 }
 
 void begin() {
     BeginTextureMode(render_target_);
+    active_mode_ = render_mode::standard;
+    present_mode_ = render_mode::standard;
+}
+
+void begin_ui() {
+    BeginTextureMode(ui_render_target_);
+    BeginMode2D(make_ui_camera());
+    active_mode_ = render_mode::ui_highres;
+    present_mode_ = render_mode::ui_highres;
 }
 
 void end() {
+    if (active_mode_ == render_mode::ui_highres) {
+        EndMode2D();
+    }
     EndTextureMode();
+    active_mode_ = render_mode::none;
 }
 
 void draw_to_screen(bool use_alpha) {
     const float screen_w = static_cast<float>(GetScreenWidth());
     const float screen_h = static_cast<float>(GetScreenHeight());
+    const RenderTexture2D& target = current_target(present_mode_);
+    const float source_w = static_cast<float>(target.texture.width);
+    const float source_h = static_cast<float>(target.texture.height);
 
     // 16:9 を前提としてウィンドウ全体にフィットさせる
-    const float scale_x = screen_w / static_cast<float>(kDesignWidth);
-    const float scale_y = screen_h / static_cast<float>(kDesignHeight);
+    const float scale_x = screen_w / source_w;
+    const float scale_y = screen_h / source_h;
     const float scale = (scale_x < scale_y) ? scale_x : scale_y;
 
-    const float dest_w = static_cast<float>(kDesignWidth) * scale;
-    const float dest_h = static_cast<float>(kDesignHeight) * scale;
+    const float dest_w = source_w * scale;
+    const float dest_h = source_h * scale;
     const float offset_x = (screen_w - dest_w) * 0.5f;
     const float offset_y = (screen_h - dest_h) * 0.5f;
 
     // RenderTexture は OpenGL 座標系で上下反転しているため source.height を負にする
-    const Rectangle source = {0.0f, 0.0f,
-                               static_cast<float>(kDesignWidth),
-                               -static_cast<float>(kDesignHeight)};
+    const Rectangle source = {0.0f, 0.0f, source_w, -source_h};
     const Rectangle dest = {offset_x, offset_y, dest_w, dest_h};
 
     const Color tint = use_alpha ? WHITE : WHITE;
-    DrawTexturePro(render_target_.texture, source, dest, {0.0f, 0.0f}, 0.0f, tint);
+    DrawTexturePro(target.texture, source, dest, {0.0f, 0.0f}, 0.0f, tint);
 }
 
 Vector2 get_virtual_mouse() {
@@ -56,19 +101,37 @@ Vector2 get_virtual_mouse() {
     const float screen_w = static_cast<float>(GetScreenWidth());
     const float screen_h = static_cast<float>(GetScreenHeight());
 
-    const float scale_x = screen_w / static_cast<float>(kDesignWidth);
-    const float scale_y = screen_h / static_cast<float>(kDesignHeight);
+    const float source_w = static_cast<float>(current_target(present_mode_).texture.width);
+    const float source_h = static_cast<float>(current_target(present_mode_).texture.height);
+    const float scale_x = screen_w / source_w;
+    const float scale_y = screen_h / source_h;
     const float scale = (scale_x < scale_y) ? scale_x : scale_y;
 
-    const float dest_w = static_cast<float>(kDesignWidth) * scale;
-    const float dest_h = static_cast<float>(kDesignHeight) * scale;
+    const float dest_w = source_w * scale;
+    const float dest_h = source_h * scale;
     const float offset_x = (screen_w - dest_w) * 0.5f;
     const float offset_y = (screen_h - dest_h) * 0.5f;
 
+    const float normalized_x = (physical.x - offset_x) / dest_w;
+    const float normalized_y = (physical.y - offset_y) / dest_h;
     return {
-        (physical.x - offset_x) / scale,
-        (physical.y - offset_y) / scale,
+        normalized_x * static_cast<float>(kDesignWidth),
+        normalized_y * static_cast<float>(kDesignHeight),
     };
+}
+
+float current_render_scale() {
+    return active_mode_ == render_mode::ui_highres ? static_cast<float>(kUiRenderScale) : 1.0f;
+}
+
+int current_render_width() {
+    const RenderTexture2D& target = current_target(active_mode_ == render_mode::none ? present_mode_ : active_mode_);
+    return target.texture.width;
+}
+
+int current_render_height() {
+    const RenderTexture2D& target = current_target(active_mode_ == render_mode::none ? present_mode_ : active_mode_);
+    return target.texture.height;
 }
 
 }  // namespace virtual_screen

--- a/src/scenes/virtual_screen.cpp
+++ b/src/scenes/virtual_screen.cpp
@@ -33,8 +33,7 @@ namespace virtual_screen {
 void init() {
     render_target_ = LoadRenderTexture(kDesignWidth, kDesignHeight);
     ui_render_target_ = LoadRenderTexture(kDesignWidth * kUiRenderScale, kDesignHeight * kUiRenderScale);
-    SetTextureFilter(render_target_.texture, TEXTURE_FILTER_BILINEAR);
-    // 高解像度 UI RT は最終拡大時にぼやけやすいため、まずは point で比較する。
+    SetTextureFilter(render_target_.texture, TEXTURE_FILTER_POINT);
     SetTextureFilter(ui_render_target_.texture, TEXTURE_FILTER_POINT);
     active_mode_ = render_mode::none;
     present_mode_ = render_mode::standard;
@@ -119,6 +118,14 @@ Vector2 get_virtual_mouse() {
         normalized_x * static_cast<float>(kDesignWidth),
         normalized_y * static_cast<float>(kDesignHeight),
     };
+}
+
+float design_to_screen_scale() {
+    const float screen_w = static_cast<float>(GetScreenWidth());
+    const float screen_h = static_cast<float>(GetScreenHeight());
+    const float scale_x = screen_w / static_cast<float>(kDesignWidth);
+    const float scale_y = screen_h / static_cast<float>(kDesignHeight);
+    return (scale_x < scale_y) ? scale_x : scale_y;
 }
 
 float current_render_scale() {

--- a/src/scenes/virtual_screen.h
+++ b/src/scenes/virtual_screen.h
@@ -2,12 +2,12 @@
 
 #include "raylib.h"
 
-// 仮想解像度（1280x720）で描画し、実際のウィンドウサイズにスケーリングする。
+// 仮想解像度（1920x1080）で描画し、実際のウィンドウサイズにスケーリングする。
 // メニューシーンなど2D UIはすべてこの仮想座標系で描画する。
 namespace virtual_screen {
 
-constexpr int kDesignWidth = 1280;
-constexpr int kDesignHeight = 720;
+constexpr int kDesignWidth = 1920;
+constexpr int kDesignHeight = 1080;
 constexpr int kUiRenderScale = 2;
 
 // InitWindow() の後に呼ぶ。RenderTexture を確保する。
@@ -20,7 +20,7 @@ void cleanup();
 void begin();
 
 // UI 品質優先の高解像度仮想スクリーンへの描画を開始する。
-// 論理座標は 1280x720 のまま維持しつつ、内部では高解像度 RT に描画する。
+// 論理座標は 1920x1080 のまま維持しつつ、内部では高解像度 RT に描画する。
 void begin_ui();
 
 // 仮想スクリーンへの描画を終了する。
@@ -33,7 +33,7 @@ void draw_to_screen(bool use_alpha = false);
 // 物理スクリーンのマウス座標を仮想座標に変換する。
 Vector2 get_virtual_mouse();
 
-// 1280x720 の論理座標が、実画面へどれだけ拡大されているかを返す。
+// 1920x1080 の論理座標が、実画面へどれだけ拡大されているかを返す。
 float design_to_screen_scale();
 
 // 現在の仮想スクリーン描画倍率を返す。通常描画は 1、高品質 UI 描画は 2。

--- a/src/scenes/virtual_screen.h
+++ b/src/scenes/virtual_screen.h
@@ -8,6 +8,7 @@ namespace virtual_screen {
 
 constexpr int kDesignWidth = 1280;
 constexpr int kDesignHeight = 720;
+constexpr int kUiRenderScale = 2;
 
 // InitWindow() の後に呼ぶ。RenderTexture を確保する。
 void init();
@@ -18,6 +19,10 @@ void cleanup();
 // 仮想スクリーンへの描画を開始する。以降の Draw 呼び出しは RenderTexture に書き込まれる。
 void begin();
 
+// UI 品質優先の高解像度仮想スクリーンへの描画を開始する。
+// 論理座標は 1280x720 のまま維持しつつ、内部では高解像度 RT に描画する。
+void begin_ui();
+
 // 仮想スクリーンへの描画を終了する。
 void end();
 
@@ -27,5 +32,12 @@ void draw_to_screen(bool use_alpha = false);
 
 // 物理スクリーンのマウス座標を仮想座標に変換する。
 Vector2 get_virtual_mouse();
+
+// 現在の仮想スクリーン描画倍率を返す。通常描画は 1、高品質 UI 描画は 2。
+float current_render_scale();
+
+// 現在の描画先 RenderTexture の実ピクセルサイズを返す。
+int current_render_width();
+int current_render_height();
 
 }  // namespace virtual_screen

--- a/src/scenes/virtual_screen.h
+++ b/src/scenes/virtual_screen.h
@@ -33,6 +33,9 @@ void draw_to_screen(bool use_alpha = false);
 // 物理スクリーンのマウス座標を仮想座標に変換する。
 Vector2 get_virtual_mouse();
 
+// 1280x720 の論理座標が、実画面へどれだけ拡大されているかを返す。
+float design_to_screen_scale();
+
 // 現在の仮想スクリーン描画倍率を返す。通常描画は 1、高品質 UI 描画は 2。
 float current_render_scale();
 

--- a/src/ui/ui_coord.h
+++ b/src/ui/ui_coord.h
@@ -5,6 +5,7 @@
 
 #include "raylib.h"
 #include "ui_font.h"
+#include "virtual_screen.h"
 
 // 描画境界の座標変換ヘルパー。
 // float → int の static_cast を一元管理し、呼び出し側の記述を簡潔にする。
@@ -67,14 +68,21 @@ inline void draw_rect_span(Rectangle rect, Color color) {
 // floor/ceil で端数を広めに取り、空矩形は画面外 1px に逃がして描画を無効化する。
 inline void begin_scissor_rect(Rectangle rect) {
     if (rect.width <= 0.0f || rect.height <= 0.0f) {
-        BeginScissorMode(GetRenderWidth(), GetRenderHeight(), 1, 1);
+        BeginScissorMode(virtual_screen::current_render_width(), virtual_screen::current_render_height(), 1, 1);
         return;
     }
 
-    const int sx = static_cast<int>(std::floor(rect.x));
-    const int sy = static_cast<int>(std::floor(rect.y));
-    const int sw = std::max(1, static_cast<int>(std::ceil(rect.x + rect.width) - std::floor(rect.x)));
-    const int sh = std::max(1, static_cast<int>(std::ceil(rect.y + rect.height) - std::floor(rect.y)));
+    const float render_scale = virtual_screen::current_render_scale();
+    const Rectangle scaled = {
+        rect.x * render_scale,
+        rect.y * render_scale,
+        rect.width * render_scale,
+        rect.height * render_scale,
+    };
+    const int sx = static_cast<int>(std::floor(scaled.x));
+    const int sy = static_cast<int>(std::floor(scaled.y));
+    const int sw = std::max(1, static_cast<int>(std::ceil(scaled.x + scaled.width) - std::floor(scaled.x)));
+    const int sh = std::max(1, static_cast<int>(std::ceil(scaled.y + scaled.height) - std::floor(scaled.y)));
     BeginScissorMode(sx, sy, sw, sh);
 }
 

--- a/src/ui/ui_draw.h
+++ b/src/ui/ui_draw.h
@@ -827,7 +827,7 @@ inline scrollbar_interaction update_vertical_scrollbar(Rectangle track_rect, flo
 
 // 画面全体を覆う半透明オーバーレイ。ポーズ画面やフェードイン/アウトに使用する。
 inline void draw_fullscreen_overlay(Color color) {
-    DrawRectangle(0, 0, 1280, 720, color);
+    DrawRectangle(0, 0, kScreenWidth, kScreenHeight, color);
 }
 
 inline void enqueue_fullscreen_overlay(Color color, draw_layer layer = draw_layer::overlay) {

--- a/src/ui/ui_font.cpp
+++ b/src/ui/ui_font.cpp
@@ -18,6 +18,7 @@ namespace {
 constexpr int kFontBaseSize = 48;
 constexpr float kCustomFontSizeScale = 0.8f;
 constexpr float kCustomFontSpacingOffset = 2.0f;
+constexpr float kSmallAsciiCustomFontThreshold = 16.0f;
 
 std::string g_font_path;
 Font g_font = {};
@@ -45,6 +46,18 @@ bool contains_non_ascii_bytes(const char* text) {
         ++cursor;
     }
     return false;
+}
+
+bool should_use_custom_font(const char* text, float font_size) {
+    if (!g_font_loaded || text == nullptr || *text == '\0') {
+        return false;
+    }
+
+    if (contains_non_ascii_bytes(text)) {
+        return true;
+    }
+
+    return font_size <= kSmallAsciiCustomFontThreshold;
 }
 
 std::string find_font_path() {
@@ -134,8 +147,8 @@ Font text_font() {
     return g_font_loaded ? g_font : GetFontDefault();
 }
 
-Font text_font_for_text(const char* text) {
-    if (g_font_loaded && contains_non_ascii_bytes(text)) {
+Font text_font_for_text(const char* text, float font_size) {
+    if (should_use_custom_font(text, font_size)) {
         return g_font;
     }
     return GetFontDefault();
@@ -144,6 +157,9 @@ Font text_font_for_text(const char* text) {
 float text_font_size_for_text(const char* text, float font_size) {
     if (g_font_loaded && contains_non_ascii_bytes(text)) {
         return snap_custom_font_size(font_size * kCustomFontSizeScale);
+    }
+    if (should_use_custom_font(text, font_size)) {
+        return snap_custom_font_size(font_size);
     }
     return font_size;
 }
@@ -157,7 +173,7 @@ float text_spacing_for_text(const char* text, float font_size, float spacing) {
         return spacing;
     }
 
-    const Font font = text_font_for_text(text);
+    const Font font = text_font_for_text(text, font_size);
     if (font.texture.id == GetFontDefault().texture.id && font.baseSize > 0) {
         return font_size / static_cast<float>(font.baseSize);
     }
@@ -196,7 +212,7 @@ Vector2 measure_text_size(const char* text, float font_size, float spacing) {
 
     ensure_text_glyphs(text);
     const float adjusted_font_size = text_font_size_for_text(text, font_size);
-    return MeasureTextEx(text_font_for_text(text), text, adjusted_font_size,
+    return MeasureTextEx(text_font_for_text(text, font_size), text, adjusted_font_size,
                          text_spacing_for_text(text, adjusted_font_size, spacing));
 }
 
@@ -207,11 +223,11 @@ void draw_text_auto(const char* text, Vector2 position, float font_size, float s
 
     ensure_text_glyphs(text);
     const float adjusted_font_size = text_font_size_for_text(text, font_size);
-    const bool uses_custom_font = g_font_loaded && contains_non_ascii_bytes(text);
+    const bool uses_custom_font = should_use_custom_font(text, font_size);
     const Vector2 draw_position = uses_custom_font
                                       ? Vector2{snap_custom_coordinate(position.x), snap_custom_coordinate(position.y)}
                                       : position;
-    DrawTextEx(text_font_for_text(text), text, draw_position, adjusted_font_size,
+    DrawTextEx(text_font_for_text(text, font_size), text, draw_position, adjusted_font_size,
                text_spacing_for_text(text, adjusted_font_size, spacing), color);
 }
 

--- a/src/ui/ui_font.cpp
+++ b/src/ui/ui_font.cpp
@@ -10,6 +10,7 @@
 
 #include "core/app_paths.h"
 #include "core/path_utils.h"
+#include "virtual_screen.h"
 
 namespace ui {
 
@@ -18,7 +19,6 @@ namespace {
 constexpr int kFontBaseSize = 48;
 constexpr float kCustomFontSizeScale = 0.8f;
 constexpr float kCustomFontSpacingOffset = 2.0f;
-constexpr float kSmallAsciiCustomFontThreshold = 16.0f;
 
 std::string g_font_path;
 Font g_font = {};
@@ -31,6 +31,25 @@ float snap_custom_font_size(float font_size) {
 
 float snap_custom_coordinate(float value) {
     return std::round(value);
+}
+
+float snap_default_font_size(float font_size) {
+    const float screen_scale = virtual_screen::design_to_screen_scale();
+    if (screen_scale <= 0.0f) {
+        return font_size;
+    }
+
+    const float physical_size = std::max(1.0f, std::round(font_size * screen_scale));
+    return physical_size / screen_scale;
+}
+
+float snap_default_coordinate(float value) {
+    const float screen_scale = virtual_screen::design_to_screen_scale();
+    if (screen_scale <= 0.0f) {
+        return value;
+    }
+
+    return std::round(value * screen_scale) / screen_scale;
 }
 
 bool contains_non_ascii_bytes(const char* text) {
@@ -46,18 +65,6 @@ bool contains_non_ascii_bytes(const char* text) {
         ++cursor;
     }
     return false;
-}
-
-bool should_use_custom_font(const char* text, float font_size) {
-    if (!g_font_loaded || text == nullptr || *text == '\0') {
-        return false;
-    }
-
-    if (contains_non_ascii_bytes(text)) {
-        return true;
-    }
-
-    return font_size <= kSmallAsciiCustomFontThreshold;
 }
 
 std::string find_font_path() {
@@ -147,8 +154,8 @@ Font text_font() {
     return g_font_loaded ? g_font : GetFontDefault();
 }
 
-Font text_font_for_text(const char* text, float font_size) {
-    if (should_use_custom_font(text, font_size)) {
+Font text_font_for_text(const char* text) {
+    if (g_font_loaded && contains_non_ascii_bytes(text)) {
         return g_font;
     }
     return GetFontDefault();
@@ -158,10 +165,7 @@ float text_font_size_for_text(const char* text, float font_size) {
     if (g_font_loaded && contains_non_ascii_bytes(text)) {
         return snap_custom_font_size(font_size * kCustomFontSizeScale);
     }
-    if (should_use_custom_font(text, font_size)) {
-        return snap_custom_font_size(font_size);
-    }
-    return font_size;
+    return snap_default_font_size(font_size);
 }
 
 float text_spacing_for_text(const char* text, float font_size, float spacing) {
@@ -170,12 +174,12 @@ float text_spacing_for_text(const char* text, float font_size, float spacing) {
     }
 
     if (spacing != 0.0f) {
-        return spacing;
+        return snap_default_font_size(spacing);
     }
 
-    const Font font = text_font_for_text(text, font_size);
+    const Font font = text_font_for_text(text);
     if (font.texture.id == GetFontDefault().texture.id && font.baseSize > 0) {
-        return font_size / static_cast<float>(font.baseSize);
+        return snap_default_font_size(font_size) / static_cast<float>(font.baseSize);
     }
     return 0.0f;
 }
@@ -212,7 +216,7 @@ Vector2 measure_text_size(const char* text, float font_size, float spacing) {
 
     ensure_text_glyphs(text);
     const float adjusted_font_size = text_font_size_for_text(text, font_size);
-    return MeasureTextEx(text_font_for_text(text, font_size), text, adjusted_font_size,
+    return MeasureTextEx(text_font_for_text(text), text, adjusted_font_size,
                          text_spacing_for_text(text, adjusted_font_size, spacing));
 }
 
@@ -223,11 +227,11 @@ void draw_text_auto(const char* text, Vector2 position, float font_size, float s
 
     ensure_text_glyphs(text);
     const float adjusted_font_size = text_font_size_for_text(text, font_size);
-    const bool uses_custom_font = should_use_custom_font(text, font_size);
+    const bool uses_custom_font = g_font_loaded && contains_non_ascii_bytes(text);
     const Vector2 draw_position = uses_custom_font
                                       ? Vector2{snap_custom_coordinate(position.x), snap_custom_coordinate(position.y)}
-                                      : position;
-    DrawTextEx(text_font_for_text(text, font_size), text, draw_position, adjusted_font_size,
+                                      : Vector2{snap_default_coordinate(position.x), snap_default_coordinate(position.y)};
+    DrawTextEx(text_font_for_text(text), text, draw_position, adjusted_font_size,
                text_spacing_for_text(text, adjusted_font_size, spacing), color);
 }
 

--- a/src/ui/ui_font.h
+++ b/src/ui/ui_font.h
@@ -10,7 +10,7 @@ void initialize_text_font();
 void shutdown_text_font();
 
 Font text_font();
-Font text_font_for_text(const char* text);
+Font text_font_for_text(const char* text, float font_size);
 float text_font_size_for_text(const char* text, float font_size);
 float text_spacing_for_text(const char* text, float font_size, float spacing = 0.0f);
 void ensure_text_glyphs(const char* text);

--- a/src/ui/ui_font.h
+++ b/src/ui/ui_font.h
@@ -10,7 +10,7 @@ void initialize_text_font();
 void shutdown_text_font();
 
 Font text_font();
-Font text_font_for_text(const char* text, float font_size);
+Font text_font_for_text(const char* text);
 float text_font_size_for_text(const char* text, float font_size);
 float text_spacing_for_text(const char* text, float font_size, float spacing = 0.0f);
 void ensure_text_glyphs(const char* text);


### PR DESCRIPTION
## 概要
- 小さい英字 UI テキストのガビり対策として、高解像度 UI RenderTexture の基盤を追加
- その上で、可変解像度でも崩れにくい UI typography / snapping の実験を進める
- さらに、思い切って UI の論理解像度基準を `1920x1080` へ上げる試行を追加

## 変更内容
- `virtual_screen` に高解像度 UI 用 RenderTexture を追加
- 2D UI シーンを高解像度 UI パスへ移行
- scissor が高解像度描画でも崩れないよう `ui_coord` を調整
- UI 用 RenderTexture のフィルタは `POINT` ベースに設定
- `default font` の雰囲気は維持したまま、実画面倍率に応じて font size / position をスナップする計算を追加
- UI の基準解像度を `1280x720` から `1920x1080` へ変更
- 設定の既定ウィンドウサイズ、MV の screen defaults、fullscreen overlay など、画面寸法に依存する基準値を新しい論理解像度へ追従

## 方向性
狙いは単純な 4K 化ではなく、`720p / 1080p / 4K` をまたいでも UI テキストが安定して見える描画基盤に寄せること。

今回はそのために、
- 高解像度 UI レイヤー
- 可変解像度向け typography snapping
- UI 論理解像度を 1920x1080 に引き上げる試行
をまとめて試している。

## まだ見たいこと
- 実機での見え方比較
- `1920x1080` 論理解像度化で主要画面のレイアウトがどこまで自然か
- 小さい英字の `潰れ / ぼやけ / ジャギー` のバランス
- default font を維持したままどこまで安定させられるか
- 3D シーンや他 UI への波及確認

## 確認
- `cmake --build cmake-build-codex --target raythm -j 4`

Refs #255