### PR TITLE
Add client authoritative scoring ruleset flow

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,6 +122,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/player_note_offsets.h
         src/gameplay/ranking_service.cpp
         src/gameplay/ranking_service.h
+        src/gameplay/scoring_ruleset_runtime.cpp
+        src/gameplay/scoring_ruleset_runtime.h
         src/gameplay/score_system.cpp
         src/gameplay/score_system.h
         src/gameplay/song_loader.cpp
@@ -453,6 +455,8 @@ add_executable(judge_system_smoke
 
 add_executable(score_system_smoke
         src/models/data_models.h
+        src/gameplay/scoring_ruleset_runtime.cpp
+        src/gameplay/scoring_ruleset_runtime.h
         src/gameplay/score_system.cpp
         src/gameplay/score_system.h
         src/tests/score_system_smoke.cpp)
@@ -463,6 +467,8 @@ add_executable(ranking_service_smoke
         src/models/data_models.h
         src/gameplay/ranking_service.cpp
         src/gameplay/ranking_service.h
+        src/gameplay/scoring_ruleset_runtime.cpp
+        src/gameplay/scoring_ruleset_runtime.h
         src/network/auth_client.cpp
         src/network/auth_client.h
         src/network/ranking_client.cpp
@@ -491,6 +497,8 @@ add_executable(play_flow_controller_smoke
         src/gameplay/input_handler.h
         src/gameplay/judge_system.cpp
         src/gameplay/judge_system.h
+        src/gameplay/scoring_ruleset_runtime.cpp
+        src/gameplay/scoring_ruleset_runtime.h
         src/gameplay/score_system.cpp
         src/gameplay/score_system.h
         src/gameplay/timing_engine.cpp

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -98,6 +98,10 @@ std::filesystem::path auth_session_path() {
     return app_data_root() / "auth_session.json";
 }
 
+std::filesystem::path scoring_ruleset_cache_path() {
+    return app_data_root() / "scoring_ruleset_cache.txt";
+}
+
 std::filesystem::path mvs_root() {
     return app_data_root() / "mvs";
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -44,6 +44,9 @@ std::filesystem::path chart_offsets_path();
 // AppData/Local/raythm/auth_session.json
 std::filesystem::path auth_session_path();
 
+// AppData/Local/raythm/scoring_ruleset_cache.txt
+std::filesystem::path scoring_ruleset_cache_path();
+
 // AppData/Local/raythm/mvs/
 std::filesystem::path mvs_root();
 

--- a/src/gameplay/judge_system.cpp
+++ b/src/gameplay/judge_system.cpp
@@ -12,12 +12,15 @@ void judge_system::init(const std::vector<note_data>& notes, const timing_engine
     active_hold_indices_.fill(std::nullopt);
     judge_events_.clear();
 
+    int next_event_index = 0;
     for (size_t i = 0; i < notes.size(); ++i) {
         const note_data& note = notes[i];
         note_state state;
         state.note_ref = note;
         state.target_ms = engine.tick_to_ms(note.tick);
         state.end_target_ms = engine.tick_to_ms(note.type == note_type::hold ? note.end_tick : note.tick);
+        state.head_event_index = next_event_index++;
+        state.tail_event_index = note.type == note_type::hold ? next_event_index++ : state.head_event_index;
         note_states_.push_back(state);
         if (note.lane >= 0 && note.lane < kMaxLanes) {
             lane_note_indices_[static_cast<size_t>(note.lane)].push_back(i);
@@ -134,7 +137,7 @@ void judge_system::handle_hold_release(const input_event& event) {
     active_hold.reset();
     judge_emit_options options;
     options.play_hitsound = false;
-    emit_judge(state.result, release_offset_ms, state.note_ref.lane, options);
+    emit_judge(state.result, release_offset_ms, state.note_ref.lane, state.tail_event_index, options);
 }
 
 void judge_system::handle_press(const input_event& event) {
@@ -162,7 +165,7 @@ void judge_system::handle_press(const input_event& event) {
     if (candidate.is_holding()) {
         active_hold_indices_[static_cast<size_t>(event.lane)] = *candidate_index;
     }
-    emit_judge(result, offset_ms, event.lane);
+    emit_judge(result, offset_ms, event.lane, candidate.head_event_index);
 }
 
 void judge_system::resolve_hold_completions(double current_ms) {
@@ -199,7 +202,7 @@ void judge_system::resolve_auto_misses(double current_ms) {
             // head が最大判定幅を超えたら、そのノートはもう叩けない。
             state.progress = note_progress_state::completed;
             state.result = judge_result::miss;
-            emit_judge(judge_result::miss, offset_ms, state.note_ref.lane);
+            emit_judge(judge_result::miss, offset_ms, state.note_ref.lane, state.head_event_index);
             ++head_index;
         }
     }
@@ -257,18 +260,20 @@ void judge_system::complete_held_note(size_t note_index, bool emit_display_judge
     options.play_hitsound = false;
     options.apply_gameplay_effects = true;
     options.show_feedback = emit_display_judge;
-    emit_judge(judge_result::perfect, 0.0, state.note_ref.lane, options);
+    emit_judge(judge_result::perfect, 0.0, state.note_ref.lane, state.tail_event_index, options);
 }
 
-void judge_system::emit_judge(judge_result result, double offset_ms, int lane) {
-    emit_judge(result, offset_ms, lane, judge_emit_options{});
+void judge_system::emit_judge(judge_result result, double offset_ms, int lane, int event_index) {
+    emit_judge(result, offset_ms, lane, event_index, judge_emit_options{});
 }
 
 void judge_system::emit_judge(judge_result result, double offset_ms, int lane,
+                              int event_index,
                               judge_emit_options options) {
     judge_event event{result, offset_ms, lane,
                       options.play_hitsound,
                       options.apply_gameplay_effects,
-                      options.show_feedback};
+                      options.show_feedback,
+                      event_index};
     judge_events_.push_back(event);
 }

--- a/src/gameplay/judge_system.h
+++ b/src/gameplay/judge_system.h
@@ -40,9 +40,9 @@ private:
     void advance_lane_head_index(int lane);
     std::optional<size_t> find_press_candidate(int lane, double timestamp_ms);
     void complete_held_note(size_t note_index, bool emit_display_judge);
-    void emit_judge(judge_result result, double offset_ms, int lane);
+    void emit_judge(judge_result result, double offset_ms, int lane, int event_index);
     void emit_judge(judge_result result, double offset_ms, int lane,
-                    judge_emit_options options);
+                    int event_index, judge_emit_options options);
 
     std::vector<note_state> note_states_;
     // Each lane keeps its own ordered note list and next unresolved head index.

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -8,6 +8,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <mutex>
 #include <sstream>
 #include <ctime>
 #include <string_view>
@@ -17,6 +18,7 @@
 #include "network/auth_client.h"
 #include "network/ranking_client.h"
 #include "path_utils.h"
+#include "scoring_ruleset_runtime.h"
 #include "updater/update_verify.h"
 
 #ifdef _WIN32
@@ -30,6 +32,7 @@ constexpr std::string_view kFileHeaderV1 = "RAYTHM_LOCAL_RANKING_V1";
 constexpr std::string_view kFileHeaderV2 = "RAYTHM_LOCAL_RANKING_V2";
 constexpr std::string_view kFileHeaderV3 = "RAYTHM_LOCAL_RANKING_V3";
 constexpr std::string_view kFileHeaderV4 = "RAYTHM_LOCAL_RANKING_V4";
+constexpr std::string_view kFileHeaderV5 = "RAYTHM_LOCAL_RANKING_V5";
 constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
 
 std::string trim(std::string_view value) {
@@ -88,41 +91,178 @@ std::string current_local_player_display_name() {
     return "Guest";
 }
 
-std::string serialize_entries(const std::vector<ranking_service::entry>& entries) {
+std::string local_rank_label(rank clear_rank) {
+    switch (clear_rank) {
+        case rank::ss: return "ss";
+        case rank::s: return "s";
+        case rank::aa: return "aa";
+        case rank::a: return "a";
+        case rank::b: return "b";
+        case rank::c: return "c";
+        case rank::f: return "f";
+    }
+
+    return "f";
+}
+
+rank parse_rank_label_local(std::string_view value) {
+    std::string normalized = trim(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    if (normalized == "ss") return rank::ss;
+    if (normalized == "s") return rank::s;
+    if (normalized == "aa") return rank::aa;
+    if (normalized == "a") return rank::a;
+    if (normalized == "b") return rank::b;
+    if (normalized == "c") return rank::c;
+    return rank::f;
+}
+
+std::string judge_result_label(judge_result result) {
+    switch (result) {
+        case judge_result::perfect: return "perfect";
+        case judge_result::great: return "great";
+        case judge_result::good: return "good";
+        case judge_result::bad: return "bad";
+        case judge_result::miss: return "miss";
+    }
+
+    return "miss";
+}
+
+std::optional<judge_result> parse_judge_result_label(std::string_view value) {
+    std::string normalized = trim(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    if (normalized == "perfect") return judge_result::perfect;
+    if (normalized == "great") return judge_result::great;
+    if (normalized == "good") return judge_result::good;
+    if (normalized == "bad") return judge_result::bad;
+    if (normalized == "miss") return judge_result::miss;
+    return std::nullopt;
+}
+
+std::string serialize_note_results(const std::vector<note_result_entry>& note_results) {
     std::ostringstream out;
-    out << kFileHeaderV4 << '\n';
-    for (const ranking_service::entry& entry : entries) {
-        out << std::fixed << std::setprecision(4) << entry.accuracy << '\t'
-            << (entry.is_full_combo ? 1 : 0) << '\t'
-            << entry.max_combo << '\t'
-            << entry.score << '\t'
-            << entry.recorded_at << '\t'
-            << sanitize_player_display_name(entry.player_display_name) << '\n';
+    for (size_t i = 0; i < note_results.size(); ++i) {
+        const note_result_entry& entry = note_results[i];
+        if (i > 0) {
+            out << ';';
+        }
+        out << entry.event_index << ','
+            << judge_result_label(entry.result) << ','
+            << std::fixed << std::setprecision(3) << entry.offset_ms;
     }
     return out.str();
 }
 
-enum class file_version { v1, v2, v3, v4 };
+std::optional<std::vector<note_result_entry>> parse_note_results(std::string_view value) {
+    std::vector<note_result_entry> note_results;
+    std::istringstream row{std::string(value)};
+    std::string token;
+    while (std::getline(row, token, ';')) {
+        if (token.empty()) {
+            continue;
+        }
 
-std::vector<ranking_service::entry> parse_entries(const std::string& content) {
-    std::vector<ranking_service::entry> entries;
+        std::istringstream event_row(token);
+        std::string event_index_token;
+        std::string result_token;
+        std::string offset_token;
+        if (!std::getline(event_row, event_index_token, ',') ||
+            !std::getline(event_row, result_token, ',') ||
+            !std::getline(event_row, offset_token)) {
+            return std::nullopt;
+        }
+
+        const std::optional<judge_result> parsed_result = parse_judge_result_label(result_token);
+        if (!parsed_result.has_value()) {
+            return std::nullopt;
+        }
+
+        try {
+            note_results.push_back(note_result_entry{
+                .event_index = std::stoi(trim(event_index_token)),
+                .result = *parsed_result,
+                .offset_ms = std::stod(trim(offset_token)),
+            });
+        } catch (...) {
+            return std::nullopt;
+        }
+    }
+
+    return note_results;
+}
+
+struct stored_local_record {
+    std::string recorded_at;
+    std::string player_display_name;
+    std::vector<note_result_entry> note_results;
+    std::optional<ranking_service::entry> legacy_entry;
+};
+
+ranking_service::entry resolve_record_entry(const stored_local_record& record,
+                                           const scoring_ruleset_runtime::ruleset& ruleset) {
+    if (record.legacy_entry.has_value()) {
+        ranking_service::entry entry = *record.legacy_entry;
+        entry.recorded_at = record.recorded_at;
+        entry.player_display_name = sanitize_player_display_name(record.player_display_name);
+        entry.verified = false;
+        return entry;
+    }
+
+    const scoring_ruleset_runtime::computed_result computed =
+        scoring_ruleset_runtime::compute_result_for(ruleset, record.note_results);
+    return ranking_service::entry{
+        .placement = 0,
+        .player_display_name = sanitize_player_display_name(record.player_display_name),
+        .accuracy = computed.accuracy,
+        .is_full_combo = computed.is_full_combo,
+        .max_combo = computed.max_combo,
+        .score = computed.score,
+        .recorded_at = record.recorded_at,
+        .verified = false,
+        .resolved_clear_rank = computed.clear_rank,
+    };
+}
+
+std::string serialize_records(const std::vector<stored_local_record>& records) {
+    std::ostringstream out;
+    out << kFileHeaderV5 << '\n';
+    for (const stored_local_record& record : records) {
+        if (record.legacy_entry.has_value()) {
+            const ranking_service::entry& entry = *record.legacy_entry;
+            out << "legacy" << '\t'
+                << record.recorded_at << '\t'
+                << sanitize_player_display_name(record.player_display_name) << '\t'
+                << std::fixed << std::setprecision(4) << entry.accuracy << '\t'
+                << (entry.is_full_combo ? 1 : 0) << '\t'
+                << entry.max_combo << '\t'
+                << entry.score << '\t'
+                << local_rank_label(entry.resolved_clear_rank) << '\n';
+            continue;
+        }
+
+        out << "record" << '\t'
+            << record.recorded_at << '\t'
+            << sanitize_player_display_name(record.player_display_name) << '\t'
+            << serialize_note_results(record.note_results) << '\n';
+    }
+    return out.str();
+}
+
+std::vector<stored_local_record> parse_records(const std::string& content) {
+    std::vector<stored_local_record> records;
     std::istringstream input(content);
     std::string line;
     if (!std::getline(input, line)) {
-        return entries;
+        return records;
     }
     const std::string header = trim(line);
-    file_version version;
-    if (header == kFileHeaderV4) {
-        version = file_version::v4;
-    } else if (header == kFileHeaderV3) {
-        version = file_version::v3;
-    } else if (header == kFileHeaderV2) {
-        version = file_version::v2;
-    } else if (header == kFileHeaderV1) {
-        version = file_version::v1;
-    } else {
-        return entries;
+    if (header != kFileHeaderV5) {
+        return records;
     }
 
     while (std::getline(input, line)) {
@@ -133,76 +273,60 @@ std::vector<ranking_service::entry> parse_entries(const std::string& content) {
         std::istringstream row(line);
 
         try {
-            ranking_service::entry entry;
+            stored_local_record record;
+            std::string kind_token, recorded_at_token, player_token;
+            if (!std::getline(row, kind_token, '\t') ||
+                !std::getline(row, recorded_at_token, '\t') ||
+                !std::getline(row, player_token, '\t')) {
+                continue;
+            }
 
-            if (version == file_version::v4 || version == file_version::v3) {
-                // V3: accuracy \t is_full_combo \t max_combo \t score \t timestamp
-                // V4: accuracy \t is_full_combo \t max_combo \t score \t timestamp \t player_display_name
-                std::string accuracy_token, fc_token, combo_token, score_token, timestamp_token, player_token;
+            record.recorded_at = trim(recorded_at_token);
+            record.player_display_name = sanitize_player_display_name(player_token);
+            const std::string kind = trim(kind_token);
+
+            if (kind == "record") {
+                std::string note_results_token;
+                if (!std::getline(row, note_results_token)) {
+                    continue;
+                }
+                const std::optional<std::vector<note_result_entry>> note_results =
+                    parse_note_results(note_results_token);
+                if (!note_results.has_value()) {
+                    continue;
+                }
+                record.note_results = *note_results;
+            } else if (kind == "legacy") {
+                std::string accuracy_token, fc_token, combo_token, score_token, rank_token;
                 if (!std::getline(row, accuracy_token, '\t') ||
                     !std::getline(row, fc_token, '\t') ||
                     !std::getline(row, combo_token, '\t') ||
-                    !std::getline(row, score_token, '\t')) {
+                    !std::getline(row, score_token, '\t') ||
+                    !std::getline(row, rank_token)) {
                     continue;
                 }
-                if (version == file_version::v4) {
-                    if (!std::getline(row, timestamp_token, '\t')) {
-                        continue;
-                    }
-                } else {
-                    if (!std::getline(row, timestamp_token)) {
-                        continue;
-                    }
-                }
+
+                ranking_service::entry entry;
                 entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
                 entry.is_full_combo = trim(fc_token) == "1";
                 entry.max_combo = std::clamp(std::stoi(trim(combo_token)), 0, 999999);
                 entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
-                entry.recorded_at = trim(timestamp_token);
-                if (version == file_version::v4 && std::getline(row, player_token)) {
-                    entry.player_display_name = sanitize_player_display_name(player_token);
-                } else {
-                    entry.player_display_name = "Guest";
-                }
+                entry.recorded_at = record.recorded_at;
+                entry.player_display_name = record.player_display_name;
+                entry.verified = false;
+                entry.resolved_clear_rank = parse_rank_label_local(rank_token);
+                record.legacy_entry = std::move(entry);
             } else {
-                // V1/V2: rank \t accuracy \t [max_combo \t] score \t timestamp
-                std::string rank_token, accuracy_token, combo_token, score_token, timestamp_token;
-                if (!std::getline(row, rank_token, '\t') ||
-                    !std::getline(row, accuracy_token, '\t')) {
-                    continue;
-                }
-                if (version == file_version::v2) {
-                    if (!std::getline(row, combo_token, '\t') ||
-                        !std::getline(row, score_token, '\t') ||
-                        !std::getline(row, timestamp_token)) {
-                        continue;
-                    }
-                } else {
-                    if (!std::getline(row, score_token, '\t') ||
-                        !std::getline(row, timestamp_token)) {
-                        continue;
-                    }
-                }
-
-                entry.accuracy = std::clamp(std::stof(trim(accuracy_token)), 0.0f, 100.0f);
-                entry.max_combo = (version == file_version::v2) ? std::clamp(std::stoi(trim(combo_token)), 0, 999999) : 0;
-                entry.score = std::clamp(std::stoi(trim(score_token)), 0, 1000000);
-                entry.recorded_at = trim(timestamp_token);
-
-                // V1/V2 にはフルコンボ情報がないので、保存された rank が SS/S ならフルコンボとみなす。
-                const int stored_rank = std::clamp(std::stoi(trim(rank_token)), 0, 6);
-                entry.is_full_combo = (stored_rank == static_cast<int>(rank::ss) || stored_rank == static_cast<int>(rank::s));
-                entry.player_display_name = "Guest";
+                continue;
             }
 
-            entry.verified = false;
-            entries.push_back(std::move(entry));
+            records.push_back(std::move(record));
         } catch (...) {
             continue;
         }
     }
 
-    return entries;
+    return records;
 }
 
 bool ranking_entry_better(const ranking_service::entry& left, const ranking_service::entry& right) {
@@ -217,6 +341,216 @@ bool ranking_entry_better(const ranking_service::entry& left, const ranking_serv
 
 bool chart_obviously_eligible_for_online_ranking(const chart_meta& chart) {
     return !chart.chart_id.empty() && chart.is_public;
+}
+
+std::optional<auth::session> load_online_session_for_ruleset() {
+    const auth::session_summary summary = auth::load_session_summary();
+    if (!summary.logged_in) {
+        return std::nullopt;
+    }
+
+    return auth::load_saved_session();
+}
+
+std::string display_ruleset_server_url() {
+    const auth::session_summary summary = auth::load_session_summary();
+    if (!summary.server_url.empty()) {
+        return auth::normalize_server_url(summary.server_url);
+    }
+
+    return auth::normalize_server_url(auth::kDefaultServerUrl);
+}
+
+struct cached_scoring_ruleset_state {
+    std::mutex mutex;
+    std::string server_url;
+    std::optional<ranking_client::scoring_ruleset> ruleset;
+};
+
+cached_scoring_ruleset_state& scoring_ruleset_cache() {
+    static cached_scoring_ruleset_state cache;
+    return cache;
+}
+
+std::string rank_to_label(rank clear_rank) {
+    switch (clear_rank) {
+        case rank::ss: return "ss";
+        case rank::s: return "s";
+        case rank::aa: return "aa";
+        case rank::a: return "a";
+        case rank::b: return "b";
+        case rank::c: return "c";
+        case rank::f: return "f";
+    }
+
+    return "f";
+}
+
+rank parse_rank_label(std::string_view value) {
+    std::string normalized = trim(value);
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    if (normalized == "ss") return rank::ss;
+    if (normalized == "s") return rank::s;
+    if (normalized == "aa") return rank::aa;
+    if (normalized == "a") return rank::a;
+    if (normalized == "b") return rank::b;
+    if (normalized == "c") return rank::c;
+    return rank::f;
+}
+
+bool save_cached_ruleset_to_disk(const std::string& server_url,
+                                 const ranking_client::scoring_ruleset& ruleset) {
+    app_paths::ensure_directories();
+    std::ofstream output(app_paths::scoring_ruleset_cache_path(), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "server_url\t" << server_url << '\n';
+    output << "active\t" << (ruleset.active ? 1 : 0) << '\n';
+    output << "accepted_input\t" << ruleset.accepted_input << '\n';
+    output << "ruleset_version\t" << ruleset.ruleset_version << '\n';
+    output << "score_model\t" << ruleset.score_model << '\n';
+    output << "max_score\t" << ruleset.max_score << '\n';
+    output << "judge_values\t"
+           << ruleset.judge_values[0] << ','
+           << ruleset.judge_values[1] << ','
+           << ruleset.judge_values[2] << ','
+           << ruleset.judge_values[3] << ','
+           << ruleset.judge_values[4] << '\n';
+    for (const auto& threshold : ruleset.rank_thresholds) {
+        output << "rank_threshold\t"
+               << rank_to_label(threshold.clear_rank) << ','
+               << threshold.min_accuracy << ','
+               << (threshold.requires_full_combo ? 1 : 0) << '\n';
+    }
+    return output.good();
+}
+
+std::optional<std::pair<std::string, ranking_client::scoring_ruleset>> load_cached_ruleset_from_disk() {
+    std::ifstream input(app_paths::scoring_ruleset_cache_path(), std::ios::binary);
+    if (!input.is_open()) {
+        return std::nullopt;
+    }
+
+    ranking_client::scoring_ruleset ruleset = scoring_ruleset_runtime::make_default_ruleset();
+    std::string server_url;
+    std::string line;
+    std::vector<scoring_ruleset_runtime::rank_threshold> thresholds;
+    while (std::getline(input, line)) {
+        if (line.empty()) {
+            continue;
+        }
+        const size_t tab = line.find('\t');
+        if (tab == std::string::npos) {
+            continue;
+        }
+        const std::string key = trim(line.substr(0, tab));
+        const std::string value = line.substr(tab + 1);
+        if (key == "server_url") {
+            server_url = trim(value);
+        } else if (key == "active") {
+            ruleset.active = trim(value) == "1";
+        } else if (key == "accepted_input") {
+            ruleset.accepted_input = trim(value);
+        } else if (key == "ruleset_version") {
+            ruleset.ruleset_version = trim(value);
+        } else if (key == "score_model") {
+            ruleset.score_model = trim(value);
+        } else if (key == "max_score") {
+            try {
+                ruleset.max_score = std::stoi(trim(value));
+            } catch (...) {
+                return std::nullopt;
+            }
+        } else if (key == "judge_values") {
+            std::array<int, 5> judge_values = {};
+            std::istringstream row(value);
+            std::string token;
+            for (size_t i = 0; i < judge_values.size(); ++i) {
+                if (!std::getline(row, token, ',')) {
+                    return std::nullopt;
+                }
+                try {
+                    judge_values[i] = std::stoi(trim(token));
+                } catch (...) {
+                    return std::nullopt;
+                }
+            }
+            ruleset.judge_values = judge_values;
+        } else if (key == "rank_threshold") {
+            std::istringstream row(value);
+            std::string label_token, accuracy_token, fc_token;
+            if (!std::getline(row, label_token, ',') ||
+                !std::getline(row, accuracy_token, ',') ||
+                !std::getline(row, fc_token, ',')) {
+                return std::nullopt;
+            }
+            try {
+                thresholds.push_back(scoring_ruleset_runtime::rank_threshold{
+                    .clear_rank = parse_rank_label(label_token),
+                    .min_accuracy = std::stof(trim(accuracy_token)),
+                    .requires_full_combo = trim(fc_token) == "1",
+                });
+            } catch (...) {
+                return std::nullopt;
+            }
+        }
+    }
+
+    if (server_url.empty()) {
+        return std::nullopt;
+    }
+    if (!thresholds.empty()) {
+        ruleset.rank_thresholds = std::move(thresholds);
+    }
+    return std::make_pair(server_url, ruleset);
+}
+
+void store_cached_ruleset(const std::string& server_url,
+                         const ranking_client::scoring_ruleset& ruleset) {
+    auto& cache = scoring_ruleset_cache();
+    std::scoped_lock lock(cache.mutex);
+    cache.server_url = server_url;
+    cache.ruleset = ruleset;
+    scoring_ruleset_runtime::apply_server_ruleset(ruleset);
+    save_cached_ruleset_to_disk(server_url, ruleset);
+}
+
+std::optional<ranking_client::scoring_ruleset> load_cached_ruleset_for_server(const std::string& server_url) {
+    auto& cache = scoring_ruleset_cache();
+    {
+        std::scoped_lock lock(cache.mutex);
+        if (cache.server_url == server_url && cache.ruleset.has_value()) {
+            return cache.ruleset;
+        }
+    }
+
+    const auto persisted = load_cached_ruleset_from_disk();
+    if (!persisted.has_value() || persisted->first != server_url) {
+        return std::nullopt;
+    }
+
+    {
+        std::scoped_lock lock(cache.mutex);
+        cache.server_url = persisted->first;
+        cache.ruleset = persisted->second;
+    }
+    scoring_ruleset_runtime::apply_server_ruleset(persisted->second);
+    return persisted->second;
+}
+
+std::optional<ranking_client::scoring_ruleset> fetch_and_cache_scoring_ruleset(const std::string& server_url) {
+    const ranking_client::scoring_ruleset_operation_result ruleset_request =
+        ranking_client::fetch_scoring_ruleset(server_url);
+    if (!ruleset_request.success || !ruleset_request.ruleset.has_value()) {
+        return std::nullopt;
+    }
+
+    store_cached_ruleset(server_url, *ruleset_request.ruleset);
+    return ruleset_request.ruleset;
 }
 
 std::string lowercase(std::string value) {
@@ -402,7 +736,7 @@ bool crypt_unprotect_utf8(const std::vector<std::byte>& ciphertext, std::string&
 }
 #endif
 
-std::vector<ranking_service::entry> load_local_entries(const std::string& chart_id) {
+std::vector<stored_local_record> load_local_records(const std::string& chart_id) {
     if (chart_id.empty()) {
         return {};
     }
@@ -425,18 +759,18 @@ std::vector<ranking_service::entry> load_local_entries(const std::string& chart_
     if (!crypt_unprotect_utf8(encrypted, plaintext)) {
         return {};
     }
-    return parse_entries(plaintext);
+    return parse_records(plaintext);
 #else
-    return parse_entries(std::string(bytes.begin(), bytes.end()));
+    return parse_records(std::string(bytes.begin(), bytes.end()));
 #endif
 }
 
-bool save_local_entries(const std::string& chart_id, const std::vector<ranking_service::entry>& entries) {
+bool save_local_records(const std::string& chart_id, const std::vector<stored_local_record>& records) {
     if (chart_id.empty()) {
         return false;
     }
 
-    const std::string plaintext = serialize_entries(entries);
+    const std::string plaintext = serialize_records(records);
     app_paths::ensure_directories();
     const std::filesystem::path path = app_paths::local_ranking_path(chart_id);
 
@@ -517,7 +851,12 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
         return result;
     }
 
-    result.entries = load_local_entries(chart_id);
+    const std::vector<stored_local_record> records = load_local_records(chart_id);
+    const scoring_ruleset_runtime::ruleset ruleset = scoring_ruleset_runtime::current_ruleset();
+    result.entries.reserve(records.size());
+    for (const stored_local_record& record : records) {
+        result.entries.push_back(resolve_record_entry(record, ruleset));
+    }
     std::sort(result.entries.begin(), result.entries.end(), ranking_entry_better);
     if (limit > 0 && static_cast<int>(result.entries.size()) > limit) {
         result.entries.resize(static_cast<size_t>(limit));
@@ -541,30 +880,57 @@ local_submit_result submit_local_result_detailed(const chart_meta& chart, const 
         return submission;
     }
 
-    std::vector<entry> entries = load_local_entries(chart.chart_id);
+    std::vector<stored_local_record> records = load_local_records(chart.chart_id);
+    const scoring_ruleset_runtime::ruleset ruleset = scoring_ruleset_runtime::current_ruleset();
+    std::vector<entry> entries;
+    entries.reserve(records.size());
+    for (const stored_local_record& record : records) {
+        entries.push_back(resolve_record_entry(record, ruleset));
+    }
     std::sort(entries.begin(), entries.end(), ranking_entry_better);
 
-    entry new_entry{
-        .placement = 0,
-        .player_display_name = current_local_player_display_name(),
-        .accuracy = result.accuracy,
-        .is_full_combo = result.is_full_combo,
-        .max_combo = result.max_combo,
-        .score = result.score,
-        .recorded_at = current_timestamp_utc(),
-        .verified = false,
+    const std::string recorded_at = current_timestamp_utc();
+    const std::string player_display_name = current_local_player_display_name();
+    stored_local_record new_record{
+        .recorded_at = recorded_at,
+        .player_display_name = player_display_name,
     };
+    entry new_entry;
+    if (!result.note_results.empty()) {
+        new_record.note_results = result.note_results;
+        new_entry = resolve_record_entry(new_record, ruleset);
+    } else {
+        new_entry = entry{
+            .placement = 0,
+            .player_display_name = player_display_name,
+            .accuracy = result.accuracy,
+            .is_full_combo = result.is_full_combo,
+            .max_combo = result.max_combo,
+            .score = result.score,
+            .recorded_at = recorded_at,
+            .verified = false,
+            .resolved_clear_rank = result.clear_rank,
+        };
+        new_record.legacy_entry = new_entry;
+    }
 
     submission.best_updated =
         entries.empty() || ranking_entry_better(new_entry, entries.front());
 
+    records.push_back(new_record);
     entries.push_back(new_entry);
     std::sort(entries.begin(), entries.end(), ranking_entry_better);
     if (entries.size() > 50) {
         entries.resize(50);
     }
+    std::sort(records.begin(), records.end(), [&ruleset](const stored_local_record& left, const stored_local_record& right) {
+        return ranking_entry_better(resolve_record_entry(left, ruleset), resolve_record_entry(right, ruleset));
+    });
+    if (records.size() > 50) {
+        records.resize(50);
+    }
 
-    submission.success = save_local_entries(chart.chart_id, entries);
+    submission.success = save_local_records(chart.chart_id, records);
     if (submission.success) {
         submission.submitted_entry = std::move(new_entry);
     }
@@ -579,10 +945,37 @@ bool should_attempt_online_submit(const local_submit_result& local_result) {
     return local_result.success && local_result.submitted_entry.has_value();
 }
 
+bool warm_scoring_ruleset_cache(bool force_refresh) {
+    const std::string server_url = display_ruleset_server_url();
+    if (server_url.empty()) {
+        return false;
+    }
+
+    if (!force_refresh) {
+        if (const std::optional<ranking_client::scoring_ruleset> cached =
+                load_cached_ruleset_for_server(server_url);
+            cached.has_value()) {
+            scoring_ruleset_runtime::apply_server_ruleset(*cached);
+            return true;
+        }
+    }
+
+    return fetch_and_cache_scoring_ruleset(server_url).has_value();
+}
+
+bool refresh_scoring_ruleset_cache_for_chart_start(const chart_meta& chart, bool force_refresh) {
+    if (!chart_obviously_eligible_for_online_ranking(chart)) {
+        return false;
+    }
+
+    return warm_scoring_ruleset_cache(force_refresh);
+}
+
 online_submit_result submit_online_result(const song_data& song,
                                           const std::string& chart_path,
                                           const chart_meta& chart,
-                                          const entry& submitted_entry) {
+                                          const result_data& result,
+                                          const std::string& recorded_at) {
     online_submit_result submission;
     if (!chart_obviously_eligible_for_online_ranking(chart)) {
         return submission;
@@ -611,6 +1004,23 @@ online_submit_result submit_online_result(const song_data& song,
         return submission;
     }
 
+    std::optional<ranking_client::scoring_ruleset> ruleset =
+        load_cached_ruleset_for_server(stored->server_url);
+    if (!ruleset.has_value()) {
+        ruleset = fetch_and_cache_scoring_ruleset(stored->server_url);
+    }
+
+    if (!ruleset.has_value()) {
+        submission.message = "Failed to fetch scoring ruleset.";
+        return submission;
+    }
+
+    if (!ruleset->active ||
+        ruleset->accepted_input != "note_results_v1") {
+        submission.message = "The server does not accept this ranking submission format.";
+        return submission;
+    }
+
     submission.attempted = true;
 
     ranking_client::submit_operation_result request =
@@ -618,7 +1028,9 @@ online_submit_result submit_online_result(const song_data& song,
             stored->server_url,
             stored->access_token,
             chart.chart_id,
-            submitted_entry);
+            result,
+            recorded_at,
+            ruleset->ruleset_version);
 
     if (request.unauthorized) {
         const auth::operation_result restored = auth::restore_saved_session();
@@ -634,7 +1046,9 @@ online_submit_result submit_online_result(const song_data& song,
             restored.session_data->server_url,
             restored.session_data->access_token,
             chart.chart_id,
-            submitted_entry);
+            result,
+            recorded_at,
+            ruleset->ruleset_version);
     }
 
     submission.success = request.success;

--- a/src/gameplay/ranking_service.h
+++ b/src/gameplay/ranking_service.h
@@ -22,8 +22,9 @@ struct entry {
     int score = 0;
     std::string recorded_at;
     bool verified = false;
+    rank resolved_clear_rank = rank::f;
 
-    rank clear_rank() const { return compute_rank(accuracy, is_full_combo); }
+    rank clear_rank() const { return resolved_clear_rank; }
 };
 
 struct listing {
@@ -51,9 +52,12 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
 local_submit_result submit_local_result_detailed(const chart_meta& chart, const result_data& result);
 bool submit_local_result(const chart_meta& chart, const result_data& result);
 bool should_attempt_online_submit(const local_submit_result& local_result);
+bool warm_scoring_ruleset_cache(bool force_refresh = false);
+bool refresh_scoring_ruleset_cache_for_chart_start(const chart_meta& chart, bool force_refresh = true);
 online_submit_result submit_online_result(const song_data& song,
                                           const std::string& chart_path,
                                           const chart_meta& chart,
-                                          const entry& entry);
+                                          const result_data& result,
+                                          const std::string& recorded_at);
 
 }  // namespace ranking_service

--- a/src/gameplay/score_system.cpp
+++ b/src/gameplay/score_system.cpp
@@ -3,13 +3,6 @@
 #include <algorithm>
 
 namespace {
-constexpr int kMaxScore = 1000000;
-constexpr int kPerfectBase = 1000;
-constexpr int kGreatBase = 800;
-constexpr int kGoodBase = 500;
-constexpr int kBadBase = 200;
-constexpr int kMissBase = 0;
-
 size_t judge_index(judge_result result) {
     switch (result) {
         case judge_result::perfect:
@@ -27,23 +20,6 @@ size_t judge_index(judge_result result) {
     return 4;
 }
 
-int base_score(judge_result result) {
-    switch (result) {
-        case judge_result::perfect:
-            return kPerfectBase;
-        case judge_result::great:
-            return kGreatBase;
-        case judge_result::good:
-            return kGoodBase;
-        case judge_result::bad:
-            return kBadBase;
-        case judge_result::miss:
-            return kMissBase;
-    }
-
-    return 0;
-}
-
 double combo_score_multiplier(int combo, int total_notes) {
     if (total_notes <= 0) {
         return 1.0;
@@ -53,20 +29,23 @@ double combo_score_multiplier(int combo, int total_notes) {
     return progress * progress;
 }
 
-double max_raw_score_for_total_notes(int total_notes) {
+double max_raw_score_for_total_notes(const scoring_ruleset_runtime::ruleset& ruleset, int total_notes) {
     if (total_notes <= 0) {
         return 0.0;
     }
 
     double max_score = 0.0;
     for (int combo = 1; combo <= total_notes; ++combo) {
-        max_score += static_cast<double>(kPerfectBase) * combo_score_multiplier(combo, total_notes);
+        max_score += static_cast<double>(
+            scoring_ruleset_runtime::judge_value_for(ruleset, judge_result::perfect)) *
+            combo_score_multiplier(combo, total_notes);
     }
     return max_score;
 }
 }
 
 void score_system::init(int total_notes) {
+    ruleset_ = scoring_ruleset_runtime::current_ruleset();
     total_notes_ = std::max(total_notes, 0);
     raw_score_ = 0.0;
     combo_ = 0;
@@ -76,11 +55,20 @@ void score_system::init(int total_notes) {
     slow_count_ = 0;
     offset_sum_ = 0.0;
     judged_notes_ = 0;
+    note_results_.clear();
+    note_results_.reserve(static_cast<size_t>(total_notes_));
 }
 
 void score_system::on_judge(const judge_event& event) {
     ++judge_counts_[judge_index(event.result)];
     ++judged_notes_;
+    if (event.event_index >= 0) {
+        note_results_.push_back(note_result_entry{
+            .event_index = event.event_index,
+            .result = event.result,
+            .offset_ms = event.offset_ms,
+        });
+    }
 
     if (event.offset_ms < 0.0) {
         ++fast_count_;
@@ -96,7 +84,7 @@ void score_system::on_judge(const judge_event& event) {
         max_combo_ = std::max(max_combo_, combo_);
     }
 
-    const int raw = base_score(event.result);
+    const int raw = scoring_ruleset_runtime::judge_value_for(ruleset_, event.result);
     raw_score_ += static_cast<double>(raw) * combo_score_multiplier(combo_, total_notes_);
 }
 
@@ -113,12 +101,13 @@ float score_system::get_live_accuracy() const {
         return 0.0f;
     }
 
-    const double max_achievement_points = static_cast<double>(judged_notes_ * kPerfectBase);
+    const int perfect_value = scoring_ruleset_runtime::judge_value_for(ruleset_, judge_result::perfect);
+    const double max_achievement_points = static_cast<double>(judged_notes_ * perfect_value);
     const double earned_achievement_points =
-        judge_counts_[judge_index(judge_result::perfect)] * kPerfectBase +
-        judge_counts_[judge_index(judge_result::great)] * kGreatBase +
-        judge_counts_[judge_index(judge_result::good)] * kGoodBase +
-        judge_counts_[judge_index(judge_result::bad)] * kBadBase;
+        judge_counts_[judge_index(judge_result::perfect)] * scoring_ruleset_runtime::judge_value_for(ruleset_, judge_result::perfect) +
+        judge_counts_[judge_index(judge_result::great)] * scoring_ruleset_runtime::judge_value_for(ruleset_, judge_result::great) +
+        judge_counts_[judge_index(judge_result::good)] * scoring_ruleset_runtime::judge_value_for(ruleset_, judge_result::good) +
+        judge_counts_[judge_index(judge_result::bad)] * scoring_ruleset_runtime::judge_value_for(ruleset_, judge_result::bad);
     return static_cast<float>((earned_achievement_points / max_achievement_points) * 100.0);
 }
 
@@ -135,20 +124,21 @@ result_data score_system::get_result_data() const {
     result.is_all_perfect = judged_notes_ > 0 &&
                             judge_counts_[judge_index(judge_result::perfect)] == judged_notes_;
     result.accuracy = get_live_accuracy();
+    result.note_results = note_results_;
 
-    result.clear_rank = compute_rank(result.accuracy, result.is_full_combo);
+    result.clear_rank = scoring_ruleset_runtime::compute_rank_for(ruleset_, result.accuracy, result.is_full_combo);
 
     return result;
 }
 
 int score_system::normalized_score() const {
-    const double max_raw_score = max_raw_score_for_total_notes(total_notes_);
+    const double max_raw_score = max_raw_score_for_total_notes(ruleset_, total_notes_);
     if (max_raw_score <= 0.0) {
         return 0;
     }
 
     const double normalized = raw_score_ / max_raw_score;
-    return static_cast<int>(std::clamp(normalized, 0.0, 1.0) * kMaxScore);
+    return static_cast<int>(std::clamp(normalized, 0.0, 1.0) * ruleset_.max_score);
 }
 
 void gauge::on_judge(judge_result result) {

--- a/src/gameplay/score_system.h
+++ b/src/gameplay/score_system.h
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <array>
+#include <vector>
 
 #include "data_models.h"
+#include "scoring_ruleset_runtime.h"
 
 class score_system {
 public:
@@ -25,6 +27,8 @@ private:
     int slow_count_ = 0;
     double offset_sum_ = 0.0;
     int judged_notes_ = 0;
+    std::vector<note_result_entry> note_results_;
+    scoring_ruleset_runtime::ruleset ruleset_ = scoring_ruleset_runtime::make_default_ruleset();
 };
 
 class gauge {

--- a/src/gameplay/scoring_ruleset_runtime.cpp
+++ b/src/gameplay/scoring_ruleset_runtime.cpp
@@ -1,0 +1,137 @@
+#include "scoring_ruleset_runtime.h"
+
+#include <algorithm>
+#include <mutex>
+
+namespace {
+
+size_t judge_index(judge_result result) {
+    switch (result) {
+        case judge_result::perfect: return 0;
+        case judge_result::great: return 1;
+        case judge_result::good: return 2;
+        case judge_result::bad: return 3;
+        case judge_result::miss: return 4;
+    }
+
+    return 4;
+}
+
+std::mutex& ruleset_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+scoring_ruleset_runtime::ruleset& active_ruleset() {
+    static scoring_ruleset_runtime::ruleset ruleset_data =
+        scoring_ruleset_runtime::make_default_ruleset();
+    return ruleset_data;
+}
+
+}  // namespace
+
+namespace scoring_ruleset_runtime {
+
+ruleset make_default_ruleset() {
+    ruleset result;
+    result.rank_thresholds = {
+        {.clear_rank = rank::ss, .min_accuracy = 100.0f, .requires_full_combo = true},
+        {.clear_rank = rank::s, .min_accuracy = 95.0f, .requires_full_combo = true},
+        {.clear_rank = rank::aa, .min_accuracy = 95.0f, .requires_full_combo = false},
+        {.clear_rank = rank::a, .min_accuracy = 90.0f, .requires_full_combo = false},
+        {.clear_rank = rank::b, .min_accuracy = 80.0f, .requires_full_combo = false},
+        {.clear_rank = rank::c, .min_accuracy = 70.0f, .requires_full_combo = false},
+        {.clear_rank = rank::f, .min_accuracy = 0.0f, .requires_full_combo = false},
+    };
+    return result;
+}
+
+ruleset current_ruleset() {
+    std::scoped_lock lock(ruleset_mutex());
+    return active_ruleset();
+}
+
+void apply_server_ruleset(const ruleset& ruleset_data) {
+    std::scoped_lock lock(ruleset_mutex());
+    active_ruleset() = ruleset_data;
+}
+
+int judge_value_for(const ruleset& ruleset_data, judge_result result) {
+    return ruleset_data.judge_values[judge_index(result)];
+}
+
+rank compute_rank_for(const ruleset& ruleset_data, float accuracy, bool is_full_combo) {
+    for (const rank_threshold& threshold : ruleset_data.rank_thresholds) {
+        if (accuracy < threshold.min_accuracy) {
+            continue;
+        }
+        if (threshold.requires_full_combo && !is_full_combo) {
+            continue;
+        }
+        return threshold.clear_rank;
+    }
+
+    return rank::f;
+}
+
+computed_result compute_result_for(const ruleset& ruleset_data,
+                                   const std::vector<note_result_entry>& note_results) {
+    computed_result result;
+    if (note_results.empty()) {
+        return result;
+    }
+
+    const int perfect_value = judge_value_for(ruleset_data, judge_result::perfect);
+    int combo = 0;
+    double raw_score = 0.0;
+    const int total_notes = static_cast<int>(note_results.size());
+
+    auto combo_score_multiplier = [total_notes](int combo_value) {
+        if (total_notes <= 0) {
+            return 1.0;
+        }
+        const double progress = std::clamp(static_cast<double>(combo_value) / static_cast<double>(total_notes), 0.0, 1.0);
+        return progress * progress;
+    };
+
+    double max_raw_score = 0.0;
+    for (int max_combo_index = 1; max_combo_index <= total_notes; ++max_combo_index) {
+        max_raw_score += static_cast<double>(perfect_value) * combo_score_multiplier(max_combo_index);
+    }
+
+    double earned_achievement_points = 0.0;
+    for (const note_result_entry& note_result : note_results) {
+        const size_t index = judge_index(note_result.result);
+        result.judge_counts[index] += 1;
+
+        if (note_result.result == judge_result::bad || note_result.result == judge_result::miss) {
+            combo = 0;
+        } else {
+            combo += 1;
+            result.max_combo = std::max(result.max_combo, combo);
+        }
+
+        const int judge_value = judge_value_for(ruleset_data, note_result.result);
+        raw_score += static_cast<double>(judge_value) * combo_score_multiplier(combo);
+        if (note_result.result != judge_result::miss) {
+            earned_achievement_points += static_cast<double>(judge_value);
+        }
+    }
+
+    const double max_achievement_points = static_cast<double>(total_notes * perfect_value);
+    result.accuracy =
+        max_achievement_points <= 0.0
+            ? 0.0f
+            : static_cast<float>((earned_achievement_points / max_achievement_points) * 100.0);
+    result.score =
+        max_raw_score <= 0.0
+            ? 0
+            : static_cast<int>(std::clamp(raw_score / max_raw_score, 0.0, 1.0) * ruleset_data.max_score);
+    result.is_full_combo =
+        result.judge_counts[judge_index(judge_result::bad)] == 0 &&
+        result.judge_counts[judge_index(judge_result::miss)] == 0;
+    result.clear_rank = compute_rank_for(ruleset_data, result.accuracy, result.is_full_combo);
+    return result;
+}
+
+}  // namespace scoring_ruleset_runtime

--- a/src/gameplay/scoring_ruleset_runtime.h
+++ b/src/gameplay/scoring_ruleset_runtime.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <array>
+#include <string>
+#include <vector>
+
+#include "data_models.h"
+
+namespace scoring_ruleset_runtime {
+
+struct rank_threshold {
+    rank clear_rank = rank::f;
+    float min_accuracy = 0.0f;
+    bool requires_full_combo = false;
+};
+
+struct ruleset {
+    bool active = true;
+    std::string accepted_input = "note_results_v1";
+    std::string ruleset_version = "local-default";
+    std::string score_model = "combo-progress-squared";
+    int max_score = 1'000'000;
+    std::array<int, 5> judge_values = {1000, 800, 500, 200, 0};
+    std::vector<rank_threshold> rank_thresholds;
+};
+
+struct computed_result {
+    int score = 0;
+    float accuracy = 0.0f;
+    bool is_full_combo = false;
+    int max_combo = 0;
+    rank clear_rank = rank::f;
+    std::array<int, 5> judge_counts = {};
+};
+
+ruleset make_default_ruleset();
+ruleset current_ruleset();
+void apply_server_ruleset(const ruleset& ruleset_data);
+
+int judge_value_for(const ruleset& ruleset_data, judge_result result);
+rank compute_rank_for(const ruleset& ruleset_data, float accuracy, bool is_full_combo);
+computed_result compute_result_for(const ruleset& ruleset_data,
+                                   const std::vector<note_result_entry>& note_results);
+
+}  // namespace scoring_ruleset_runtime

--- a/src/models/data_models.h
+++ b/src/models/data_models.h
@@ -124,6 +124,8 @@ struct note_state {
     note_data note_ref;
     double target_ms = 0.0;
     double end_target_ms = 0.0;
+    int head_event_index = -1;
+    int tail_event_index = -1;
     note_progress_state progress = note_progress_state::pending;
     judge_result result = judge_result::miss;
 
@@ -148,6 +150,7 @@ struct judge_event {
     bool play_hitsound = true;
     bool apply_gameplay_effects = true;
     bool show_feedback = true;
+    int event_index = -1;
 };
 
 // 達成率に応じたランク種別。
@@ -172,6 +175,12 @@ inline rank compute_rank(float accuracy, bool is_full_combo) {
     return rank::f;
 }
 
+struct note_result_entry {
+    int event_index = -1;
+    judge_result result = judge_result::miss;
+    double offset_ms = 0.0;
+};
+
 // リザルト画面で表示する集計結果。
 struct result_data {
     int score = 0;
@@ -185,4 +194,5 @@ struct result_data {
     bool failed = false;
     bool is_full_combo = false;
     bool is_all_perfect = false;
+    std::vector<note_result_entry> note_results;
 };

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -523,6 +523,7 @@ std::optional<ranking_service::entry> parse_ranking_entry(const std::string& con
     const auto score = extract_json_int(content, "score");
     const auto recorded_at = extract_json_string(content, "recorded_at");
     const auto verified = extract_json_bool(content, "verified");
+    const std::string clear_rank_label = extract_json_string(content, "clear_rank").value_or("");
     if (!placement.has_value() ||
         !accuracy.has_value() ||
         !is_full_combo.has_value() ||
@@ -542,6 +543,20 @@ std::optional<ranking_service::entry> parse_ranking_entry(const std::string& con
         .score = *score,
         .recorded_at = *recorded_at,
         .verified = *verified,
+        .resolved_clear_rank = clear_rank_label.empty()
+            ? scoring_ruleset_runtime::compute_rank_for(
+                scoring_ruleset_runtime::current_ruleset(),
+                *accuracy,
+                *is_full_combo)
+            : [&clear_rank_label]() {
+                if (clear_rank_label == "ss") return rank::ss;
+                if (clear_rank_label == "s") return rank::s;
+                if (clear_rank_label == "aa") return rank::aa;
+                if (clear_rank_label == "a") return rank::a;
+                if (clear_rank_label == "b") return rank::b;
+                if (clear_rank_label == "c") return rank::c;
+                return rank::f;
+            }(),
     };
 }
 
@@ -581,13 +596,42 @@ std::string build_manifest_url(const std::string& server_url, const std::string&
     return server_url + "/charts/" + chart_id + "/official-manifest";
 }
 
-std::string build_submit_payload(const ranking_service::entry& entry) {
+std::string judge_result_label(judge_result result) {
+    switch (result) {
+        case judge_result::perfect: return "perfect";
+        case judge_result::great: return "great";
+        case judge_result::good: return "good";
+        case judge_result::bad: return "bad";
+        case judge_result::miss: return "miss";
+    }
+
+    return "miss";
+}
+
+std::string build_note_results_json(const std::vector<note_result_entry>& note_results) {
+    std::string json = "[";
+    for (size_t i = 0; i < note_results.size(); ++i) {
+        const note_result_entry& entry = note_results[i];
+        if (i > 0) {
+            json += ",";
+        }
+        json += "{";
+        json += "\"event_index\":" + std::to_string(entry.event_index) + ",";
+        json += "\"result\":\"" + judge_result_label(entry.result) + "\",";
+        json += "\"offset_ms\":" + std::to_string(entry.offset_ms);
+        json += "}";
+    }
+    json += "]";
+    return json;
+}
+
+std::string build_submit_payload(const result_data& result,
+                                 const std::string& recorded_at,
+                                 const std::string& ruleset_version) {
     return "{"
-        "\"score\":" + std::to_string(entry.score) + ","
-        "\"accuracy\":" + std::to_string(entry.accuracy) + ","
-        "\"is_full_combo\":" + std::string(entry.is_full_combo ? "true" : "false") + ","
-        "\"max_combo\":" + std::to_string(entry.max_combo) + ","
-        "\"recorded_at\":\"" + escape_json_string(entry.recorded_at) + "\""
+        "\"recorded_at\":\"" + escape_json_string(recorded_at) + "\","
+        "\"ruleset_version\":\"" + escape_json_string(ruleset_version) + "\","
+        "\"note_results\":" + build_note_results_json(result.note_results) +
         "}";
 }
 
@@ -621,6 +665,72 @@ std::optional<ranking_client::official_manifest> parse_official_manifest_respons
         .audio_sha256 = extract_json_string(body, "audio_sha256").value_or(""),
         .jacket_sha256 = extract_json_string(body, "jacket_sha256").value_or(""),
         .chart_sha256 = extract_json_string(body, "chart_sha256").value_or(""),
+    };
+}
+
+std::optional<ranking_client::scoring_ruleset> parse_scoring_ruleset_response(const std::string& body) {
+    const auto active = extract_json_bool(body, "active");
+    const auto accepted_input = extract_json_string(body, "accepted_input");
+    const auto ruleset_version = extract_json_string(body, "ruleset_version");
+    const auto score_model = extract_json_string(body, "score_model");
+    const auto max_score = extract_json_int(body, "max_score");
+    const auto judges_object = extract_json_object(body, "judges");
+    const auto thresholds_array = extract_json_array(body, "rank_thresholds");
+    if (!active.has_value() || !accepted_input.has_value() || !ruleset_version.has_value() ||
+        !score_model.has_value() || !max_score.has_value() ||
+        !judges_object.has_value() || !thresholds_array.has_value()) {
+        return std::nullopt;
+    }
+
+    const auto perfect = extract_json_int(*judges_object, "perfect");
+    const auto great = extract_json_int(*judges_object, "great");
+    const auto good = extract_json_int(*judges_object, "good");
+    const auto bad = extract_json_int(*judges_object, "bad");
+    const auto miss = extract_json_int(*judges_object, "miss");
+    if (!perfect.has_value() || !great.has_value() || !good.has_value() ||
+        !bad.has_value() || !miss.has_value()) {
+        return std::nullopt;
+    }
+
+    std::vector<scoring_ruleset_runtime::rank_threshold> rank_thresholds;
+    for (const std::string& object : extract_json_objects_from_array(*thresholds_array)) {
+        const auto rank_label = extract_json_string(object, "rank");
+        const auto min_accuracy = extract_json_float(object, "min_accuracy");
+        const auto requires_full_combo = extract_json_bool(object, "requires_full_combo");
+        if (!rank_label.has_value() || !min_accuracy.has_value() || !requires_full_combo.has_value()) {
+            return std::nullopt;
+        }
+
+        rank parsed_rank = rank::f;
+        if (*rank_label == "ss") {
+            parsed_rank = rank::ss;
+        } else if (*rank_label == "s") {
+            parsed_rank = rank::s;
+        } else if (*rank_label == "aa") {
+            parsed_rank = rank::aa;
+        } else if (*rank_label == "a") {
+            parsed_rank = rank::a;
+        } else if (*rank_label == "b") {
+            parsed_rank = rank::b;
+        } else if (*rank_label == "c") {
+            parsed_rank = rank::c;
+        }
+
+        rank_thresholds.push_back(scoring_ruleset_runtime::rank_threshold{
+            .clear_rank = parsed_rank,
+            .min_accuracy = *min_accuracy,
+            .requires_full_combo = *requires_full_combo,
+        });
+    }
+
+    return ranking_client::scoring_ruleset{
+        .active = *active,
+        .accepted_input = *accepted_input,
+        .ruleset_version = *ruleset_version,
+        .score_model = *score_model,
+        .max_score = *max_score,
+        .judge_values = {*perfect, *great, *good, *bad, *miss},
+        .rank_thresholds = std::move(rank_thresholds),
     };
 }
 
@@ -707,7 +817,9 @@ operation_result fetch_chart_ranking(const std::string& server_url,
 submit_operation_result submit_chart_ranking(const std::string& server_url,
                                              const std::string& access_token,
                                              const std::string& chart_id,
-                                             const ranking_service::entry& entry) {
+                                             const result_data& result,
+                                             const std::string& recorded_at,
+                                             const std::string& ruleset_version) {
     if (server_url.empty()) {
         return {
             .success = false,
@@ -735,7 +847,7 @@ submit_operation_result submit_chart_ranking(const std::string& server_url,
             {"Content-Type", "application/json"},
             {"User-Agent", "raythm/0.1"},
         },
-        build_submit_payload(entry));
+        build_submit_payload(result, recorded_at, ruleset_version));
 
     if (!response.error_message.empty()) {
         return {
@@ -779,6 +891,55 @@ submit_operation_result submit_chart_ranking(const std::string& server_url,
         .unauthorized = false,
         .message = submission->message,
         .submission = submission,
+    };
+}
+
+scoring_ruleset_operation_result fetch_scoring_ruleset(const std::string& server_url) {
+    if (server_url.empty()) {
+        return {
+            .success = false,
+            .message = "No server URL is configured.",
+            .ruleset = std::nullopt,
+        };
+    }
+
+    const http_response response = send_request(
+        "GET",
+        server_url + "/scoring/ruleset",
+        {
+            {"Accept", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .ruleset = std::nullopt,
+        };
+    }
+
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .message = extract_json_string(response.body, "message").value_or("Failed to fetch scoring ruleset."),
+            .ruleset = std::nullopt,
+        };
+    }
+
+    const std::optional<scoring_ruleset> ruleset = parse_scoring_ruleset_response(response.body);
+    if (!ruleset.has_value()) {
+        return {
+            .success = false,
+            .message = "Server returned an unexpected scoring ruleset response.",
+            .ruleset = std::nullopt,
+        };
+    }
+
+    return {
+        .success = true,
+        .message = {},
+        .ruleset = ruleset,
     };
 }
 

--- a/src/network/ranking_client.h
+++ b/src/network/ranking_client.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 
+#include "scoring_ruleset_runtime.h"
 #include "ranking_service.h"
 
 namespace ranking_client {
@@ -35,6 +36,14 @@ struct submit_operation_result {
     std::optional<submit_response> submission;
 };
 
+using scoring_ruleset = scoring_ruleset_runtime::ruleset;
+
+struct scoring_ruleset_operation_result {
+    bool success = false;
+    std::string message;
+    std::optional<scoring_ruleset> ruleset;
+};
+
 struct official_manifest {
     bool available = false;
     std::string message;
@@ -60,7 +69,11 @@ operation_result fetch_chart_ranking(const std::string& server_url,
 submit_operation_result submit_chart_ranking(const std::string& server_url,
                                              const std::string& access_token,
                                              const std::string& chart_id,
-                                             const ranking_service::entry& entry);
+                                             const result_data& result,
+                                             const std::string& recorded_at,
+                                             const std::string& ruleset_version);
+
+scoring_ruleset_operation_result fetch_scoring_ruleset(const std::string& server_url);
 
 manifest_operation_result fetch_official_chart_manifest(const std::string& server_url,
                                                         const std::string& chart_id);

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -102,13 +102,14 @@ void result_scene::on_enter() {
             const song_data song = song_;
             const std::string chart_path = chart_path_;
             const chart_meta chart = chart_;
-            const ranking_service::entry entry = *local_result.submitted_entry;
-            std::thread([task, song, chart_path, chart, entry]() {
-                ranking_service::online_submit_result result =
-                    ranking_service::submit_online_result(song, chart_path, chart, entry);
+            const std::string recorded_at = local_result.submitted_entry->recorded_at;
+            const result_data result_payload = result_;
+            std::thread([task, song, chart_path, chart, result_payload, recorded_at]() {
+                ranking_service::online_submit_result submit_result =
+                    ranking_service::submit_online_result(song, chart_path, chart, result_payload, recorded_at);
                 {
                     std::scoped_lock lock(task->mutex);
-                    task->result = std::move(result);
+                    task->result = std::move(submit_result);
                 }
                 task->done.store(true);
             }).detach();

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -245,6 +245,7 @@ bool song_select_scene::handle_song_list_pointer(Vector2 mouse, bool left_presse
             const auto filtered = song_select::filtered_charts_for_selected_song(state_);
             const song_select::chart_option* chart = song_select::selected_chart_for(state_, filtered);
             if (song != nullptr && chart != nullptr) {
+                ranking_service::refresh_scoring_ruleset_cache_for_chart_start(chart->meta, true);
                 manager_.change_scene(song_select::make_play_scene(manager_, *song, *chart));
             }
         } else {
@@ -508,6 +509,7 @@ void song_select_scene::update(float dt) {
         if (song != nullptr && chart != nullptr) {
             if (IsKeyPressed(KEY_ENTER)) {
                 song_select::close_context_menu(state_);
+                ranking_service::refresh_scoring_ruleset_cache_for_chart_start(chart->meta, true);
                 manager_.change_scene(song_select::make_play_scene(manager_, *song, *chart));
                 return;
             }

--- a/src/scenes/title/play_session_controller.cpp
+++ b/src/scenes/title/play_session_controller.cpp
@@ -8,6 +8,10 @@
 
 namespace title_play_session {
 
+void warm_scoring_ruleset() {
+    ranking_service::warm_scoring_ruleset_cache(false);
+}
+
 void reload_catalog(song_select::state& state,
                     song_select::preview_controller& preview_controller,
                     const std::string& preferred_song_id,
@@ -44,6 +48,7 @@ bool start_selected_chart(scene_manager& manager,
     if (song == nullptr || chart == nullptr) {
         return false;
     }
+    ranking_service::refresh_scoring_ruleset_cache_for_chart_start(chart->meta, true);
     preview_controller.stop();
     manager.change_scene(song_select::make_play_scene(manager, *song, *chart));
     return true;

--- a/src/scenes/title/play_session_controller.h
+++ b/src/scenes/title/play_session_controller.h
@@ -14,6 +14,7 @@ void reload_catalog(song_select::state& state,
                     const std::string& preferred_song_id = "",
                     const std::string& preferred_chart_id = "",
                     bool sync_media_now = false);
+void warm_scoring_ruleset();
 
 void sync_media(song_select::state& state, song_select::preview_controller& preview_controller);
 void reload_ranking(song_select::state& state);

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -408,6 +408,7 @@ void title_scene::on_enter() {
     song_select::reset_for_enter(play_state_);
     play_state_.ranking_panel.selected_source = ranking_service::source::local;
     auth_overlay::refresh_auth_state(play_state_.auth);
+    title_play_session::warm_scoring_ruleset();
     // Preload song/chart catalog once on scene entry so HOME -> PLAY animation
     // does not have to wait for difficulty calculation and local rank scanning.
     title_play_session::reload_catalog(play_state_, preview_controller_,

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -25,18 +25,20 @@ int main() {
     chart.chart_id = "smoke-chart";
 
     result_data lower_result;
-    lower_result.clear_rank = rank::a;
-    lower_result.accuracy = 92.5f;
-    lower_result.is_full_combo = false;
-    lower_result.max_combo = 321;
-    lower_result.score = 654321;
+    lower_result.note_results = {
+        {.event_index = 0, .result = judge_result::perfect, .offset_ms = -4.0},
+        {.event_index = 1, .result = judge_result::great, .offset_ms = 7.0},
+        {.event_index = 2, .result = judge_result::good, .offset_ms = 12.0},
+        {.event_index = 3, .result = judge_result::perfect, .offset_ms = -2.0},
+    };
 
     result_data higher_result;
-    higher_result.clear_rank = rank::s;
-    higher_result.accuracy = 97.25f;
-    higher_result.is_full_combo = true;
-    higher_result.max_combo = 654;
-    higher_result.score = 765432;
+    higher_result.note_results = {
+        {.event_index = 0, .result = judge_result::perfect, .offset_ms = -1.0},
+        {.event_index = 1, .result = judge_result::perfect, .offset_ms = 2.0},
+        {.event_index = 2, .result = judge_result::perfect, .offset_ms = -3.0},
+        {.event_index = 3, .result = judge_result::perfect, .offset_ms = 1.0},
+    };
 
     const ranking_service::local_submit_result lower_submission =
         ranking_service::submit_local_result_detailed(chart, lower_result);
@@ -69,8 +71,8 @@ int main() {
     const ranking_service::listing local_listing =
         ranking_service::load_chart_ranking(chart.chart_id, ranking_service::source::local, 50);
     if (local_listing.entries.size() != 3 ||
-        local_listing.entries[0].score != higher_result.score ||
-        local_listing.entries[0].max_combo != higher_result.max_combo ||
+        local_listing.entries[0].score <= local_listing.entries[1].score ||
+        local_listing.entries[0].max_combo != 4 ||
         local_listing.entries[0].placement != 1 ||
         local_listing.entries[1].placement != 2 ||
         local_listing.entries[2].placement != 3) {


### PR DESCRIPTION
## 概要
- クライアント側で認証済みスコアリング・ルールセットの実行環境を追加し、ローカルにキャッシュする
- `note_results + ruleset_version` を使用してオンラインランキングを送信し、起動時およびチャート開始時にルールセットを更新する
- ローカルランキングを `V5` プレイ記録ストレージに切り替え、現在のルールセットに基づいて再計算する

## 検証
- `cmake --build cmake-build-codex --target raythm score_system_smoke ranking_service_smoke -j 4`
- `score_system_smoke.exe`
- `ranking_service_smoke.exe`
- Ubuntuサーバーでの手動フロー検証：アプリ起動 -> PLAY -> 公式チャート -> 結果 -> ランキング送信

