### PR TITLE
作成アップロードとオンラインカタログ機能を追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,6 +144,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/timing_engine.h
         src/network/auth_client.cpp
         src/network/auth_client.h
+        src/network/json_helpers.cpp
+        src/network/json_helpers.h
         src/network/ranking_client.cpp
         src/network/ranking_client.h
         src/updater/update_verify.cpp
@@ -497,6 +499,8 @@ add_executable(ranking_service_smoke
         src/gameplay/scoring_ruleset_runtime.h
         src/network/auth_client.cpp
         src/network/auth_client.h
+        src/network/json_helpers.cpp
+        src/network/json_helpers.h
         src/network/ranking_client.cpp
         src/network/ranking_client.h
         src/updater/update_verify.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/title/play_session_controller.h
         src/scenes/title/title_header_view.cpp
         src/scenes/title/title_header_view.h
+        src/scenes/title/create_upload_client.cpp
+        src/scenes/title/create_upload_client.h
         src/scenes/title/online_download_internal.h
         src/scenes/title/online_download_catalog.cpp
         src/scenes/title/online_download_remote_client.cpp

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -98,6 +98,10 @@ std::filesystem::path auth_session_path() {
     return app_data_root() / "auth_session.json";
 }
 
+std::filesystem::path upload_mapping_path() {
+    return app_data_root() / "upload_mappings.txt";
+}
+
 std::filesystem::path scoring_ruleset_cache_path() {
     return app_data_root() / "scoring_ruleset_cache.txt";
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -44,6 +44,9 @@ std::filesystem::path chart_offsets_path();
 // AppData/Local/raythm/auth_session.json
 std::filesystem::path auth_session_path();
 
+// AppData/Local/raythm/upload_mappings.txt
+std::filesystem::path upload_mapping_path();
+
 // AppData/Local/raythm/scoring_ruleset_cache.txt
 std::filesystem::path scoring_ruleset_cache_path();
 

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -1,6 +1,5 @@
 #include "network/auth_client.h"
 
-#include <cctype>
 #include <filesystem>
 #include <fstream>
 #include <optional>
@@ -12,6 +11,7 @@
 #include <vector>
 
 #include "app_paths.h"
+#include "network/json_helpers.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -20,6 +20,7 @@
 
 namespace {
 namespace fs = std::filesystem;
+namespace json = network::json;
 
 struct http_response {
     int status_code = 0;
@@ -41,36 +42,6 @@ constexpr int kSendTimeoutMs = 5000;
 constexpr int kReceiveTimeoutMs = 5000;
 #endif
 
-std::string trim(std::string_view value) {
-    size_t start = 0;
-    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
-        ++start;
-    }
-
-    size_t end = value.size();
-    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
-        --end;
-    }
-
-    return std::string(value.substr(start, end - start));
-}
-
-std::string escape_json_string(const std::string& value) {
-    std::string result;
-    result.reserve(value.size() + 8);
-    for (const char ch : value) {
-        switch (ch) {
-            case '\\': result += "\\\\"; break;
-            case '"': result += "\\\""; break;
-            case '\n': result += "\\n"; break;
-            case '\r': result += "\\r"; break;
-            case '\t': result += "\\t"; break;
-            default: result += ch; break;
-        }
-    }
-    return result;
-}
-
 std::string read_file(const fs::path& path) {
     std::ifstream input(path, std::ios::binary);
     if (!input.is_open()) {
@@ -82,145 +53,18 @@ std::string read_file(const fs::path& path) {
     return buffer.str();
 }
 
-std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
-    const std::string token = "\"" + key + "\"";
-    const size_t key_pos = content.find(token);
-    if (key_pos == std::string::npos) {
-        return std::nullopt;
-    }
-    return key_pos + token.size();
-}
-
-std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
-    const auto key_end = find_json_key(content, key);
-    if (!key_end.has_value()) {
-        return std::nullopt;
-    }
-
-    const size_t colon_pos = content.find(':', *key_end);
-    if (colon_pos == std::string::npos) {
-        return std::nullopt;
-    }
-
-    size_t start = colon_pos + 1;
-    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
-        ++start;
-    }
-
-    if (start >= content.size()) {
-        return std::nullopt;
-    }
-
-    return start;
-}
-
-std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '"') {
-        return std::nullopt;
-    }
-
-    std::string result;
-    bool escaping = false;
-    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (escaping) {
-            switch (ch) {
-                case 'n': result += '\n'; break;
-                case 'r': result += '\r'; break;
-                case 't': result += '\t'; break;
-                default: result += ch; break;
-            }
-            escaping = false;
-            continue;
-        }
-
-        if (ch == '\\') {
-            escaping = true;
-            continue;
-        }
-
-        if (ch == '"') {
-            return result;
-        }
-
-        result += ch;
-    }
-
-    return std::nullopt;
-}
-
-std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '{') {
-        return std::nullopt;
-    }
-
-    size_t depth = 0;
-    bool in_string = false;
-    bool escaping = false;
-    for (size_t index = *start_opt; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-
-        if (ch == '{') {
-            ++depth;
-        } else if (ch == '}') {
-            --depth;
-            if (depth == 0) {
-                return content.substr(*start_opt, index - *start_opt + 1);
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value()) {
-        return std::nullopt;
-    }
-
-    if (content.compare(*start_opt, 4, "true") == 0) {
-        return true;
-    }
-
-    if (content.compare(*start_opt, 5, "false") == 0) {
-        return false;
-    }
-
-    return std::nullopt;
-}
-
 std::optional<auth::public_user> parse_user_object(const std::string& content) {
-    const std::optional<std::string> id = extract_json_string(content, "id");
-    std::optional<std::string> email = extract_json_string(content, "email");
+    const std::optional<std::string> id = json::extract_string(content, "id");
+    std::optional<std::string> email = json::extract_string(content, "email");
     if (!email.has_value()) {
-        email = extract_json_string(content, "username");
+        email = json::extract_string(content, "username");
     }
-    const std::optional<std::string> display_name = extract_json_string(content, "displayName");
+    const std::optional<std::string> display_name = json::extract_string(content, "displayName");
     if (!id.has_value() || !email.has_value() || !display_name.has_value()) {
         return std::nullopt;
     }
 
-    const bool email_verified = extract_json_bool(content, "emailVerified").value_or(false);
+    const bool email_verified = json::extract_bool(content, "emailVerified").value_or(false);
 
     return auth::public_user{
         .id = *id,
@@ -231,9 +75,9 @@ std::optional<auth::public_user> parse_user_object(const std::string& content) {
 }
 
 std::optional<auth::session> parse_auth_session_response(const std::string& body, const std::string& server_url) {
-    const std::optional<std::string> access_token = extract_json_string(body, "accessToken");
-    const std::optional<std::string> refresh_token = extract_json_string(body, "refreshToken");
-    const std::optional<std::string> user_object = extract_json_object(body, "user");
+    const std::optional<std::string> access_token = json::extract_string(body, "accessToken");
+    const std::optional<std::string> refresh_token = json::extract_string(body, "refreshToken");
+    const std::optional<std::string> user_object = json::extract_object(body, "user");
     if (!access_token.has_value() || !refresh_token.has_value() || !user_object.has_value()) {
         return std::nullopt;
     }
@@ -252,7 +96,7 @@ std::optional<auth::session> parse_auth_session_response(const std::string& body
 }
 
 std::optional<auth::public_user> parse_me_response(const std::string& body) {
-    const std::optional<std::string> user_object = extract_json_object(body, "user");
+    const std::optional<std::string> user_object = json::extract_object(body, "user");
     if (!user_object.has_value()) {
         return std::nullopt;
     }
@@ -261,7 +105,7 @@ std::optional<auth::public_user> parse_me_response(const std::string& body) {
 }
 
 std::string parse_error_message(const std::string& body, std::string fallback) {
-    const std::optional<std::string> message = extract_json_string(body, "message");
+    const std::optional<std::string> message = json::extract_string(body, "message");
     return message.value_or(std::move(fallback));
 }
 
@@ -273,13 +117,13 @@ bool write_session_file(const auth::session& session_data) {
     }
 
     output << "{\n";
-    output << "  \"serverUrl\": \"" << escape_json_string(session_data.server_url) << "\",\n";
-    output << "  \"accessToken\": \"" << escape_json_string(session_data.access_token) << "\",\n";
-    output << "  \"refreshToken\": \"" << escape_json_string(session_data.refresh_token) << "\",\n";
+    output << "  \"serverUrl\": \"" << json::escape_string(session_data.server_url) << "\",\n";
+    output << "  \"accessToken\": \"" << json::escape_string(session_data.access_token) << "\",\n";
+    output << "  \"refreshToken\": \"" << json::escape_string(session_data.refresh_token) << "\",\n";
     output << "  \"user\": {\n";
-    output << "    \"id\": \"" << escape_json_string(session_data.user.id) << "\",\n";
-    output << "    \"email\": \"" << escape_json_string(session_data.user.email) << "\",\n";
-    output << "    \"displayName\": \"" << escape_json_string(session_data.user.display_name) << "\",\n";
+    output << "    \"id\": \"" << json::escape_string(session_data.user.id) << "\",\n";
+    output << "    \"email\": \"" << json::escape_string(session_data.user.email) << "\",\n";
+    output << "    \"displayName\": \"" << json::escape_string(session_data.user.display_name) << "\",\n";
     output << "    \"emailVerified\": " << (session_data.user.email_verified ? "true" : "false") << "\n";
     output << "  }\n";
     output << "}\n";
@@ -524,7 +368,7 @@ auth::operation_result parse_auth_response(const http_response& response,
 namespace auth {
 
 std::string normalize_server_url(const std::string& server_url) {
-    std::string normalized = trim(server_url);
+    std::string normalized = json::trim(server_url);
     while (!normalized.empty() && normalized.back() == '/') {
         normalized.pop_back();
     }
@@ -537,10 +381,10 @@ std::optional<session> load_saved_session() {
         return std::nullopt;
     }
 
-    const std::optional<std::string> server_url = extract_json_string(content, "serverUrl");
-    const std::optional<std::string> access_token = extract_json_string(content, "accessToken");
-    const std::optional<std::string> refresh_token = extract_json_string(content, "refreshToken");
-    const std::optional<std::string> user_object = extract_json_object(content, "user");
+    const std::optional<std::string> server_url = json::extract_string(content, "serverUrl");
+    const std::optional<std::string> access_token = json::extract_string(content, "accessToken");
+    const std::optional<std::string> refresh_token = json::extract_string(content, "refreshToken");
+    const std::optional<std::string> user_object = json::extract_object(content, "user");
     if (!server_url.has_value() || !access_token.has_value() || !refresh_token.has_value() || !user_object.has_value()) {
         return std::nullopt;
     }
@@ -601,12 +445,12 @@ operation_result register_user(const std::string& server_url,
         };
     }
 
-    const std::string trimmed_display_name = trim(display_name);
+    const std::string trimmed_display_name = json::trim(display_name);
     const std::string body =
         "{"
-        "\"email\":\"" + escape_json_string(trim(email)) + "\","
-        "\"displayName\":\"" + escape_json_string(trimmed_display_name) + "\","
-        "\"password\":\"" + escape_json_string(password) + "\""
+        "\"email\":\"" + json::escape_string(json::trim(email)) + "\","
+        "\"displayName\":\"" + json::escape_string(trimmed_display_name) + "\","
+        "\"password\":\"" + json::escape_string(password) + "\""
         "}";
 
     const http_response response = send_request(
@@ -636,8 +480,8 @@ operation_result login_user(const std::string& server_url,
 
     const std::string body =
         "{"
-        "\"email\":\"" + escape_json_string(trim(email)) + "\","
-        "\"password\":\"" + escape_json_string(password) + "\""
+        "\"email\":\"" + json::escape_string(json::trim(email)) + "\","
+        "\"password\":\"" + json::escape_string(password) + "\""
         "}";
 
     const http_response response = send_request(
@@ -712,7 +556,7 @@ operation_result restore_saved_session() {
 
     const std::string refresh_body =
         "{"
-        "\"refreshToken\":\"" + escape_json_string(stored->refresh_token) + "\""
+        "\"refreshToken\":\"" + json::escape_string(stored->refresh_token) + "\""
         "}";
 
     const http_response refresh_response = send_request(
@@ -780,7 +624,7 @@ operation_result logout_saved_session() {
 
     const std::string body =
         "{"
-        "\"refreshToken\":\"" + escape_json_string(stored->refresh_token) + "\""
+        "\"refreshToken\":\"" + json::escape_string(stored->refresh_token) + "\""
         "}";
 
     const http_response response = send_request(

--- a/src/network/json_helpers.cpp
+++ b/src/network/json_helpers.cpp
@@ -1,0 +1,309 @@
+#include "network/json_helpers.h"
+
+#include <cctype>
+
+namespace network::json {
+namespace {
+
+std::optional<size_t> find_key_end(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+    return key_pos + token.size();
+}
+
+}  // namespace
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::string escape_string(const std::string& value) {
+    std::string result;
+    result.reserve(value.size() + 8);
+    for (const char ch : value) {
+        switch (ch) {
+            case '\\': result += "\\\\"; break;
+            case '"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default: result += ch; break;
+        }
+    }
+    return result;
+}
+
+std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
+    const auto key_end = find_key_end(content, key);
+    if (!key_end.has_value()) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', *key_end);
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
+        ++start;
+    }
+
+    if (start >= content.size()) {
+        return std::nullopt;
+    }
+
+    return start;
+}
+
+std::optional<std::string> extract_string(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '"') {
+        return std::nullopt;
+    }
+
+    std::string result;
+    bool escaping = false;
+    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (escaping) {
+            switch (ch) {
+                case 'n': result += '\n'; break;
+                case 'r': result += '\r'; break;
+                case 't': result += '\t'; break;
+                default: result += ch; break;
+            }
+            escaping = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            return result;
+        }
+
+        result += ch;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> extract_object(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '{') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            ++depth;
+        } else if (ch == '}') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::optional<bool> extract_bool(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    if (content.compare(*start_opt, 4, "true") == 0) {
+        return true;
+    }
+
+    if (content.compare(*start_opt, 5, "false") == 0) {
+        return false;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<int> extract_int(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t end = *start_opt;
+    if (content[end] == '-') {
+        ++end;
+    }
+    while (end < content.size() && std::isdigit(static_cast<unsigned char>(content[end]))) {
+        ++end;
+    }
+    if (end == *start_opt) {
+        return std::nullopt;
+    }
+
+    try {
+        return std::stoi(content.substr(*start_opt, end - *start_opt));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<float> extract_float(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value()) {
+        return std::nullopt;
+    }
+
+    size_t end = *start_opt;
+    if (content[end] == '-') {
+        ++end;
+    }
+    while (end < content.size()) {
+        const char ch = content[end];
+        if (!(std::isdigit(static_cast<unsigned char>(ch)) || ch == '.')) {
+            break;
+        }
+        ++end;
+    }
+    if (end == *start_opt) {
+        return std::nullopt;
+    }
+
+    try {
+        return std::stof(content.substr(*start_opt, end - *start_opt));
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<std::string> extract_array(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '[') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '[') {
+            ++depth;
+        } else if (ch == ']') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::vector<std::string> extract_objects_from_array(const std::string& array_content) {
+    std::vector<std::string> objects;
+    size_t index = 0;
+    while (index < array_content.size()) {
+        index = array_content.find('{', index);
+        if (index == std::string::npos) {
+            break;
+        }
+
+        const size_t start = index;
+        size_t depth = 0;
+        bool in_string = false;
+        bool escaping = false;
+        for (; index < array_content.size(); ++index) {
+            const char ch = array_content[index];
+            if (in_string) {
+                if (escaping) {
+                    escaping = false;
+                    continue;
+                }
+                if (ch == '\\') {
+                    escaping = true;
+                } else if (ch == '"') {
+                    in_string = false;
+                }
+                continue;
+            }
+
+            if (ch == '"') {
+                in_string = true;
+                continue;
+            }
+
+            if (ch == '{') {
+                ++depth;
+            } else if (ch == '}') {
+                --depth;
+                if (depth == 0) {
+                    objects.push_back(array_content.substr(start, index - start + 1));
+                    ++index;
+                    break;
+                }
+            }
+        }
+    }
+    return objects;
+}
+
+}  // namespace network::json

--- a/src/network/json_helpers.h
+++ b/src/network/json_helpers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace network::json {
+
+std::string trim(std::string_view value);
+std::string escape_string(const std::string& value);
+
+std::optional<size_t> find_value_start(const std::string& content, const std::string& key);
+std::optional<std::string> extract_string(const std::string& content, const std::string& key);
+std::optional<std::string> extract_object(const std::string& content, const std::string& key);
+std::optional<bool> extract_bool(const std::string& content, const std::string& key);
+std::optional<int> extract_int(const std::string& content, const std::string& key);
+std::optional<float> extract_float(const std::string& content, const std::string& key);
+std::optional<std::string> extract_array(const std::string& content, const std::string& key);
+std::vector<std::string> extract_objects_from_array(const std::string& array_content);
+
+}  // namespace network::json

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -1,11 +1,12 @@
 #include "network/ranking_client.h"
 
-#include <cctype>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <utility>
 #include <vector>
+
+#include "network/json_helpers.h"
 
 #ifdef _WIN32
 #include <windows.h>
@@ -13,6 +14,7 @@
 #endif
 
 namespace {
+namespace json = network::json;
 
 struct http_response {
     int status_code = 0;
@@ -33,304 +35,6 @@ constexpr int kConnectTimeoutMs = 5000;
 constexpr int kSendTimeoutMs = 5000;
 constexpr int kReceiveTimeoutMs = 5000;
 #endif
-
-std::string trim(std::string_view value) {
-    size_t start = 0;
-    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
-        ++start;
-    }
-
-    size_t end = value.size();
-    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
-        --end;
-    }
-
-    return std::string(value.substr(start, end - start));
-}
-
-std::string escape_json_string(const std::string& value) {
-    std::string result;
-    result.reserve(value.size() + 8);
-    for (const char ch : value) {
-        switch (ch) {
-            case '\\': result += "\\\\"; break;
-            case '"': result += "\\\""; break;
-            case '\n': result += "\\n"; break;
-            case '\r': result += "\\r"; break;
-            case '\t': result += "\\t"; break;
-            default: result += ch; break;
-        }
-    }
-    return result;
-}
-
-std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
-    const std::string token = "\"" + key + "\"";
-    const size_t key_pos = content.find(token);
-    if (key_pos == std::string::npos) {
-        return std::nullopt;
-    }
-    return key_pos + token.size();
-}
-
-std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
-    const auto key_end = find_json_key(content, key);
-    if (!key_end.has_value()) {
-        return std::nullopt;
-    }
-
-    const size_t colon_pos = content.find(':', *key_end);
-    if (colon_pos == std::string::npos) {
-        return std::nullopt;
-    }
-
-    size_t start = colon_pos + 1;
-    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
-        ++start;
-    }
-
-    if (start >= content.size()) {
-        return std::nullopt;
-    }
-
-    return start;
-}
-
-std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '"') {
-        return std::nullopt;
-    }
-
-    std::string result;
-    bool escaping = false;
-    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (escaping) {
-            switch (ch) {
-                case 'n': result += '\n'; break;
-                case 'r': result += '\r'; break;
-                case 't': result += '\t'; break;
-                default: result += ch; break;
-            }
-            escaping = false;
-            continue;
-        }
-
-        if (ch == '\\') {
-            escaping = true;
-            continue;
-        }
-
-        if (ch == '"') {
-            return result;
-        }
-
-        result += ch;
-    }
-
-    return std::nullopt;
-}
-
-std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '{') {
-        return std::nullopt;
-    }
-
-    size_t depth = 0;
-    bool in_string = false;
-    bool escaping = false;
-    for (size_t index = *start_opt; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-
-        if (ch == '{') {
-            ++depth;
-        } else if (ch == '}') {
-            --depth;
-            if (depth == 0) {
-                return content.substr(*start_opt, index - *start_opt + 1);
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-std::optional<bool> extract_json_bool(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value()) {
-        return std::nullopt;
-    }
-
-    if (content.compare(*start_opt, 4, "true") == 0) {
-        return true;
-    }
-
-    if (content.compare(*start_opt, 5, "false") == 0) {
-        return false;
-    }
-
-    return std::nullopt;
-}
-
-std::optional<int> extract_json_int(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value()) {
-        return std::nullopt;
-    }
-
-    size_t end = *start_opt;
-    if (content[end] == '-') {
-        ++end;
-    }
-    while (end < content.size() && std::isdigit(static_cast<unsigned char>(content[end]))) {
-        ++end;
-    }
-    if (end == *start_opt) {
-        return std::nullopt;
-    }
-
-    try {
-        return std::stoi(content.substr(*start_opt, end - *start_opt));
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-std::optional<float> extract_json_float(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value()) {
-        return std::nullopt;
-    }
-
-    size_t end = *start_opt;
-    if (content[end] == '-') {
-        ++end;
-    }
-    while (end < content.size()) {
-        const char ch = content[end];
-        if (!(std::isdigit(static_cast<unsigned char>(ch)) || ch == '.')) {
-            break;
-        }
-        ++end;
-    }
-    if (end == *start_opt) {
-        return std::nullopt;
-    }
-
-    try {
-        return std::stof(content.substr(*start_opt, end - *start_opt));
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-std::optional<std::string> extract_json_array(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '[') {
-        return std::nullopt;
-    }
-
-    size_t depth = 0;
-    bool in_string = false;
-    bool escaping = false;
-    for (size_t index = *start_opt; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-
-        if (ch == '[') {
-            ++depth;
-        } else if (ch == ']') {
-            --depth;
-            if (depth == 0) {
-                return content.substr(*start_opt, index - *start_opt + 1);
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-std::vector<std::string> extract_json_objects_from_array(const std::string& content) {
-    std::vector<std::string> objects;
-    bool in_string = false;
-    bool escaping = false;
-    size_t object_start = std::string::npos;
-    size_t depth = 0;
-
-    for (size_t index = 0; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-
-        if (ch == '{') {
-            if (depth == 0) {
-                object_start = index;
-            }
-            ++depth;
-        } else if (ch == '}') {
-            if (depth == 0) {
-                continue;
-            }
-            --depth;
-            if (depth == 0 && object_start != std::string::npos) {
-                objects.push_back(content.substr(object_start, index - object_start + 1));
-                object_start = std::string::npos;
-            }
-        }
-    }
-
-    return objects;
-}
 
 #ifdef _WIN32
 std::wstring to_wstring(std::string_view value) {
@@ -512,18 +216,18 @@ http_response send_request(const std::string&,
 
 std::optional<ranking_service::entry> parse_ranking_entry(const std::string& content) {
     std::string player_display_name;
-    if (const auto player_object = extract_json_object(content, "player"); player_object.has_value()) {
-        player_display_name = extract_json_string(*player_object, "display_name").value_or("");
+    if (const auto player_object = json::extract_object(content, "player"); player_object.has_value()) {
+        player_display_name = json::extract_string(*player_object, "display_name").value_or("");
     }
 
-    const auto placement = extract_json_int(content, "placement");
-    const auto accuracy = extract_json_float(content, "accuracy");
-    const auto is_full_combo = extract_json_bool(content, "is_full_combo");
-    const auto max_combo = extract_json_int(content, "max_combo");
-    const auto score = extract_json_int(content, "score");
-    const auto recorded_at = extract_json_string(content, "recorded_at");
-    const auto verified = extract_json_bool(content, "verified");
-    const std::string clear_rank_label = extract_json_string(content, "clear_rank").value_or("");
+    const auto placement = json::extract_int(content, "placement");
+    const auto accuracy = json::extract_float(content, "accuracy");
+    const auto is_full_combo = json::extract_bool(content, "is_full_combo");
+    const auto max_combo = json::extract_int(content, "max_combo");
+    const auto score = json::extract_int(content, "score");
+    const auto recorded_at = json::extract_string(content, "recorded_at");
+    const auto verified = json::extract_bool(content, "verified");
+    const std::string clear_rank_label = json::extract_string(content, "clear_rank").value_or("");
     if (!placement.has_value() ||
         !accuracy.has_value() ||
         !is_full_combo.has_value() ||
@@ -561,19 +265,19 @@ std::optional<ranking_service::entry> parse_ranking_entry(const std::string& con
 }
 
 std::optional<ranking_client::listing_response> parse_listing_response(const std::string& body) {
-    const bool available = extract_json_bool(body, "available").value_or(false);
-    const std::string message = extract_json_string(body, "message").value_or("");
+    const bool available = json::extract_bool(body, "available").value_or(false);
+    const std::string message = json::extract_string(body, "message").value_or("");
 
     ranking_client::listing_response listing;
     listing.available = available;
     listing.message = message;
 
-    const std::optional<std::string> entries_array = extract_json_array(body, "entries");
+    const std::optional<std::string> entries_array = json::extract_array(body, "entries");
     if (!entries_array.has_value()) {
         return listing;
     }
 
-    for (const std::string& object : extract_json_objects_from_array(*entries_array)) {
+    for (const std::string& object : json::extract_objects_from_array(*entries_array)) {
         const auto entry = parse_ranking_entry(object);
         if (entry.has_value()) {
             listing.entries.push_back(*entry);
@@ -629,19 +333,19 @@ std::string build_submit_payload(const result_data& result,
                                  const std::string& recorded_at,
                                  const std::string& ruleset_version) {
     return "{"
-        "\"recorded_at\":\"" + escape_json_string(recorded_at) + "\","
-        "\"ruleset_version\":\"" + escape_json_string(ruleset_version) + "\","
+        "\"recorded_at\":\"" + json::escape_string(recorded_at) + "\","
+        "\"ruleset_version\":\"" + json::escape_string(ruleset_version) + "\","
         "\"note_results\":" + build_note_results_json(result.note_results) +
         "}";
 }
 
 std::optional<ranking_client::submit_response> parse_submit_response(const std::string& body) {
     ranking_client::submit_response response;
-    response.available = extract_json_bool(body, "available").value_or(true);
-    response.updated = extract_json_bool(body, "updated").value_or(false);
-    response.message = extract_json_string(body, "message").value_or("");
+    response.available = json::extract_bool(body, "available").value_or(true);
+    response.updated = json::extract_bool(body, "updated").value_or(false);
+    response.message = json::extract_string(body, "message").value_or("");
 
-    if (const auto entry_object = extract_json_object(body, "entry"); entry_object.has_value()) {
+    if (const auto entry_object = json::extract_object(body, "entry"); entry_object.has_value()) {
         response.entry = parse_ranking_entry(*entry_object);
     }
 
@@ -649,54 +353,54 @@ std::optional<ranking_client::submit_response> parse_submit_response(const std::
 }
 
 std::optional<ranking_client::official_manifest> parse_official_manifest_response(const std::string& body) {
-    const auto available = extract_json_bool(body, "available");
-    const auto chart_id = extract_json_string(body, "chart_id");
-    const auto song_id = extract_json_string(body, "song_id");
+    const auto available = json::extract_bool(body, "available");
+    const auto chart_id = json::extract_string(body, "chart_id");
+    const auto song_id = json::extract_string(body, "song_id");
     if (!available.has_value() || !chart_id.has_value() || !song_id.has_value()) {
         return std::nullopt;
     }
 
     return ranking_client::official_manifest{
         .available = *available,
-        .message = extract_json_string(body, "message").value_or(""),
+        .message = json::extract_string(body, "message").value_or(""),
         .chart_id = *chart_id,
         .song_id = *song_id,
-        .song_json_sha256 = extract_json_string(body, "song_json_sha256").value_or(""),
-        .audio_sha256 = extract_json_string(body, "audio_sha256").value_or(""),
-        .jacket_sha256 = extract_json_string(body, "jacket_sha256").value_or(""),
-        .chart_sha256 = extract_json_string(body, "chart_sha256").value_or(""),
+        .song_json_sha256 = json::extract_string(body, "song_json_sha256").value_or(""),
+        .audio_sha256 = json::extract_string(body, "audio_sha256").value_or(""),
+        .jacket_sha256 = json::extract_string(body, "jacket_sha256").value_or(""),
+        .chart_sha256 = json::extract_string(body, "chart_sha256").value_or(""),
     };
 }
 
 std::optional<ranking_client::scoring_ruleset> parse_scoring_ruleset_response(const std::string& body) {
-    const auto active = extract_json_bool(body, "active");
-    const auto accepted_input = extract_json_string(body, "accepted_input");
-    const auto ruleset_version = extract_json_string(body, "ruleset_version");
-    const auto score_model = extract_json_string(body, "score_model");
-    const auto max_score = extract_json_int(body, "max_score");
-    const auto judges_object = extract_json_object(body, "judges");
-    const auto thresholds_array = extract_json_array(body, "rank_thresholds");
+    const auto active = json::extract_bool(body, "active");
+    const auto accepted_input = json::extract_string(body, "accepted_input");
+    const auto ruleset_version = json::extract_string(body, "ruleset_version");
+    const auto score_model = json::extract_string(body, "score_model");
+    const auto max_score = json::extract_int(body, "max_score");
+    const auto judges_object = json::extract_object(body, "judges");
+    const auto thresholds_array = json::extract_array(body, "rank_thresholds");
     if (!active.has_value() || !accepted_input.has_value() || !ruleset_version.has_value() ||
         !score_model.has_value() || !max_score.has_value() ||
         !judges_object.has_value() || !thresholds_array.has_value()) {
         return std::nullopt;
     }
 
-    const auto perfect = extract_json_int(*judges_object, "perfect");
-    const auto great = extract_json_int(*judges_object, "great");
-    const auto good = extract_json_int(*judges_object, "good");
-    const auto bad = extract_json_int(*judges_object, "bad");
-    const auto miss = extract_json_int(*judges_object, "miss");
+    const auto perfect = json::extract_int(*judges_object, "perfect");
+    const auto great = json::extract_int(*judges_object, "great");
+    const auto good = json::extract_int(*judges_object, "good");
+    const auto bad = json::extract_int(*judges_object, "bad");
+    const auto miss = json::extract_int(*judges_object, "miss");
     if (!perfect.has_value() || !great.has_value() || !good.has_value() ||
         !bad.has_value() || !miss.has_value()) {
         return std::nullopt;
     }
 
     std::vector<scoring_ruleset_runtime::rank_threshold> rank_thresholds;
-    for (const std::string& object : extract_json_objects_from_array(*thresholds_array)) {
-        const auto rank_label = extract_json_string(object, "rank");
-        const auto min_accuracy = extract_json_float(object, "min_accuracy");
-        const auto requires_full_combo = extract_json_bool(object, "requires_full_combo");
+    for (const std::string& object : json::extract_objects_from_array(*thresholds_array)) {
+        const auto rank_label = json::extract_string(object, "rank");
+        const auto min_accuracy = json::extract_float(object, "min_accuracy");
+        const auto requires_full_combo = json::extract_bool(object, "requires_full_combo");
         if (!rank_label.has_value() || !min_accuracy.has_value() || !requires_full_combo.has_value()) {
             return std::nullopt;
         }
@@ -791,7 +495,7 @@ operation_result fetch_chart_ranking(const std::string& server_url,
         return {
             .success = false,
             .unauthorized = false,
-            .message = extract_json_string(response.body, "message").value_or("Failed to load online rankings."),
+            .message = json::extract_string(response.body, "message").value_or("Failed to load online rankings."),
             .listing = std::nullopt,
         };
     }
@@ -871,7 +575,7 @@ submit_operation_result submit_chart_ranking(const std::string& server_url,
         return {
             .success = false,
             .unauthorized = false,
-            .message = extract_json_string(response.body, "message").value_or("Failed to submit online ranking."),
+            .message = json::extract_string(response.body, "message").value_or("Failed to submit online ranking."),
             .submission = std::nullopt,
         };
     }
@@ -922,7 +626,7 @@ scoring_ruleset_operation_result fetch_scoring_ruleset(const std::string& server
     if (response.status_code < 200 || response.status_code >= 300) {
         return {
             .success = false,
-            .message = extract_json_string(response.body, "message").value_or("Failed to fetch scoring ruleset."),
+            .message = json::extract_string(response.body, "message").value_or("Failed to fetch scoring ruleset."),
             .ruleset = std::nullopt,
         };
     }
@@ -972,7 +676,7 @@ manifest_operation_result fetch_official_chart_manifest(const std::string& serve
     if (response.status_code < 200 || response.status_code >= 300) {
         return {
             .success = false,
-            .message = extract_json_string(response.body, "message").value_or("Failed to fetch official manifest."),
+            .message = json::extract_string(response.body, "message").value_or("Failed to fetch official manifest."),
             .manifest = std::nullopt,
         };
     }

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -1,6 +1,10 @@
 #include "shared/auth_overlay_controller.h"
 
 #include <chrono>
+#include <exception>
+#include <future>
+#include <thread>
+#include <utility>
 
 #include "core/window_dialog_support.h"
 
@@ -8,6 +12,26 @@ namespace {
 
 std::string register_web_url() {
     return auth::normalize_server_url(auth::kDefaultServerUrl) + "/register";
+}
+
+template <typename Fn>
+std::future<auth::operation_result> start_auth_task(Fn task) {
+    std::promise<auth::operation_result> promise;
+    std::future<auth::operation_result> future = promise.get_future();
+    std::thread([promise = std::move(promise), task = std::move(task)]() mutable {
+        auth::operation_result result;
+        try {
+            result = task();
+        } catch (const std::exception& ex) {
+            result.success = false;
+            result.message = ex.what();
+        } catch (...) {
+            result.success = false;
+            result.message = "Authentication request failed.";
+        }
+        promise.set_value(std::move(result));
+    }).detach();
+    return future;
 }
 
 }  // namespace
@@ -24,7 +48,7 @@ void refresh_auth_state(song_select::auth_state& auth_state) {
 
 void start_restore(controller& controller_state, song_select::login_dialog_state&) {
     controller_state.restore_active = true;
-    controller_state.restore_future = std::async(std::launch::async, []() {
+    controller_state.restore_future = start_auth_task([]() {
         return auth::restore_saved_session();
     });
 }
@@ -54,19 +78,19 @@ void start_request(controller& controller_state,
     switch (command) {
     case song_select::login_dialog_command::request_restore:
         dialog_state.status_message = "Restoring session...";
-        controller_state.request_future = std::async(std::launch::async, []() {
+        controller_state.request_future = start_auth_task([]() {
             return auth::restore_saved_session();
         });
         break;
     case song_select::login_dialog_command::request_login:
         dialog_state.status_message = "Connecting to raythm-Server...";
-        controller_state.request_future = std::async(std::launch::async, [server_url, email, password]() {
+        controller_state.request_future = start_auth_task([server_url, email, password]() {
             return auth::login_user(server_url, email, password);
         });
         break;
     case song_select::login_dialog_command::request_logout:
         dialog_state.status_message = "Logging out...";
-        controller_state.request_future = std::async(std::launch::async, []() {
+        controller_state.request_future = start_auth_task([]() {
             return auth::logout_saved_session();
         });
         break;

--- a/src/scenes/song_select/song_transfer_controller.cpp
+++ b/src/scenes/song_select/song_transfer_controller.cpp
@@ -1,6 +1,9 @@
 #include "song_transfer_controller.h"
 
 #include <chrono>
+#include <exception>
+#include <future>
+#include <thread>
 #include <utility>
 
 namespace song_select::transfer {
@@ -13,28 +16,44 @@ void controller::on_exit() {
 void controller::start_song_import_prepare(const state& catalog_state, std::string source_path) {
     prepare_active_ = true;
     busy_label_ = "Reading song package...";
-    background_song_import_prepare_ = std::async(
-        std::launch::async,
-        [catalog_state, source_path = std::move(source_path)]() {
-            return prepare_song_import_from_path(catalog_state, source_path);
-        });
+    std::promise<song_import_prepare_result> promise;
+    background_song_import_prepare_ = promise.get_future();
+    std::thread([promise = std::move(promise), catalog_state, source_path = std::move(source_path)]() mutable {
+        try {
+            promise.set_value(prepare_song_import_from_path(catalog_state, source_path));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 void controller::start_song_export(song_export_request request) {
     transfer_active_ = true;
     busy_label_ = "Exporting song package...";
-    background_transfer_ = std::async(std::launch::async, [request = std::move(request)]() {
-        return export_song_package(request);
-    });
+    std::promise<transfer_result> promise;
+    background_transfer_ = promise.get_future();
+    std::thread([promise = std::move(promise), request = std::move(request)]() mutable {
+        try {
+            promise.set_value(export_song_package(request));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 void controller::start_song_import(song_import_request request) {
     transfer_active_ = true;
     busy_label_ = "Importing song package...";
     pending_song_import_request_ = request;
-    background_transfer_ = std::async(std::launch::async, [request = std::move(request)]() {
-        return import_song_package(request);
-    });
+    std::promise<transfer_result> promise;
+    background_transfer_ = promise.get_future();
+    std::thread([promise = std::move(promise), request = std::move(request)]() mutable {
+        try {
+            promise.set_value(import_song_package(request));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 std::optional<song_import_prepare_result> controller::poll_song_import_prepare() {
@@ -47,7 +66,19 @@ std::optional<song_import_prepare_result> controller::poll_song_import_prepare()
 
     prepare_active_ = false;
     busy_label_.clear();
-    return background_song_import_prepare_.get();
+    try {
+        return background_song_import_prepare_.get();
+    } catch (const std::exception& ex) {
+        song_import_prepare_result result;
+        result.transfer.success = false;
+        result.transfer.message = ex.what();
+        return result;
+    } catch (...) {
+        song_import_prepare_result result;
+        result.transfer.success = false;
+        result.transfer.message = "Failed to read song package.";
+        return result;
+    }
 }
 
 std::optional<transfer_result> controller::poll_background_transfer() {
@@ -60,7 +91,16 @@ std::optional<transfer_result> controller::poll_background_transfer() {
 
     transfer_active_ = false;
     busy_label_.clear();
-    transfer_result result = background_transfer_.get();
+    transfer_result result;
+    try {
+        result = background_transfer_.get();
+    } catch (const std::exception& ex) {
+        result.success = false;
+        result.message = ex.what();
+    } catch (...) {
+        result.success = false;
+        result.message = "Song transfer failed.";
+    }
     clear_pending_song_import_request(true);
     return result;
 }

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -1,8 +1,12 @@
 #include "song_select_scene.h"
 
 #include <algorithm>
+#include <chrono>
 #include <cmath>
+#include <exception>
 #include <filesystem>
+#include <future>
+#include <thread>
 #include <utility>
 
 #include "core/app_paths.h"
@@ -59,6 +63,10 @@ void song_select_scene::on_enter() {
     if (state_.auth.logged_in) {
         auth_overlay::start_restore(auth_controller_, state_.login_dialog);
     }
+    catalog_loading_ = false;
+    catalog_reload_pending_ = false;
+    pending_catalog_song_id_.clear();
+    pending_catalog_chart_id_.clear();
     reload_song_library(preferred_song_id_, preferred_chart_id_);
 }
 
@@ -72,8 +80,54 @@ void song_select_scene::on_exit() {
 
 void song_select_scene::reload_song_library(const std::string& preferred_song_id,
                                             const std::string& preferred_chart_id) {
-    song_select::apply_catalog(state_, song_select::load_catalog(), preferred_song_id, preferred_chart_id);
+    if (catalog_loading_) {
+        catalog_reload_pending_ = true;
+        pending_catalog_song_id_ = preferred_song_id;
+        pending_catalog_chart_id_ = preferred_chart_id;
+        state_.catalog_loading = true;
+        return;
+    }
+
+    preferred_song_id_ = preferred_song_id;
+    preferred_chart_id_ = preferred_chart_id;
+    catalog_loading_ = true;
+    state_.catalog_loading = true;
+    std::promise<song_select::catalog_data> promise;
+    catalog_future_ = promise.get_future();
+    std::thread([promise = std::move(promise)]() mutable {
+        try {
+            promise.set_value(song_select::load_catalog());
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+void song_select_scene::poll_song_library_reload() {
+    if (!catalog_loading_) {
+        return;
+    }
+    if (catalog_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    try {
+        song_select::apply_catalog(state_, catalog_future_.get(), preferred_song_id_, preferred_chart_id_);
+    } catch (const std::exception& ex) {
+        song_select::apply_catalog(state_, {}, preferred_song_id_, preferred_chart_id_);
+        state_.load_errors = {ex.what()};
+    }
+    catalog_loading_ = false;
     sync_selected_song_media();
+
+    if (!catalog_reload_pending_) {
+        return;
+    }
+
+    catalog_reload_pending_ = false;
+    reload_song_library(pending_catalog_song_id_, pending_catalog_chart_id_);
+    pending_catalog_song_id_.clear();
+    pending_catalog_chart_id_.clear();
 }
 
 void song_select_scene::sync_selected_song_media() {
@@ -82,16 +136,74 @@ void song_select_scene::sync_selected_song_media() {
 }
 
 void song_select_scene::reload_selected_chart_ranking() {
+    if (ranking_loading_) {
+        ++ranking_generation_;
+        ranking_reload_pending_ = true;
+        if (state_.ranking_panel.selected_source == ranking_service::source::online) {
+            state_.ranking_panel.listing = {};
+            state_.ranking_panel.listing.ranking_source = state_.ranking_panel.selected_source;
+            state_.ranking_panel.listing.available = false;
+            state_.ranking_panel.listing.message = "Loading online rankings...";
+        }
+        return;
+    }
+
     const auto filtered = song_select::filtered_charts_for_selected_song(state_);
     const song_select::chart_option* chart = song_select::selected_chart_for(state_, filtered);
     const std::string chart_id = chart != nullptr ? chart->meta.chart_id : "";
-    state_.ranking_panel.listing =
-        ranking_service::load_chart_ranking(chart_id, state_.ranking_panel.selected_source, 50);
+    const ranking_service::source source = state_.ranking_panel.selected_source;
+    ++ranking_generation_;
+    ranking_pending_generation_ = ranking_generation_;
     state_.ranking_panel.source_dropdown_open = false;
     state_.ranking_panel.scroll_y = 0.0f;
     state_.ranking_panel.scroll_y_target = 0.0f;
     state_.ranking_panel.scrollbar_dragging = false;
     state_.ranking_panel.scrollbar_drag_offset = 0.0f;
+    if (source == ranking_service::source::online) {
+        state_.ranking_panel.listing = {};
+        state_.ranking_panel.listing.ranking_source = source;
+        state_.ranking_panel.listing.available = false;
+        state_.ranking_panel.listing.message = "Loading online rankings...";
+    }
+
+    ranking_loading_ = true;
+    std::promise<ranking_service::listing> promise;
+    ranking_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), chart_id, source]() mutable {
+        try {
+            promise.set_value(ranking_service::load_chart_ranking(chart_id, source, 50));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+void song_select_scene::poll_selected_chart_ranking() {
+    if (!ranking_loading_) {
+        return;
+    }
+    if (ranking_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    ranking_service::listing listing;
+    try {
+        listing = ranking_future_.get();
+    } catch (const std::exception& ex) {
+        listing.available = false;
+        listing.message = ex.what();
+        listing.ranking_source = state_.ranking_panel.selected_source;
+    }
+    ranking_loading_ = false;
+    const bool stale = ranking_pending_generation_ != ranking_generation_;
+    if (!stale) {
+        state_.ranking_panel.listing = std::move(listing);
+    }
+
+    if (ranking_reload_pending_) {
+        ranking_reload_pending_ = false;
+        reload_selected_chart_ranking();
+    }
 }
 
 void song_select_scene::refresh_auth_state() {
@@ -246,7 +358,6 @@ bool song_select_scene::handle_song_list_pointer(Vector2 mouse, bool left_presse
             const auto filtered = song_select::filtered_charts_for_selected_song(state_);
             const song_select::chart_option* chart = song_select::selected_chart_for(state_, filtered);
             if (song != nullptr && chart != nullptr) {
-                ranking_service::refresh_scoring_ruleset_cache_for_chart_start(chart->meta, true);
                 manager_.change_scene(song_select::make_play_scene(manager_, *song, *chart));
             }
         } else {
@@ -306,6 +417,8 @@ void song_select_scene::update(float dt) {
 
     preview_controller_.update(dt, song_select::selected_song(state_));
     song_select::tick_animations(state_, dt);
+    poll_song_library_reload();
+    poll_selected_chart_ranking();
     if (const auto restore_result = auth_overlay::poll_restore(auth_controller_, state_.auth, state_.login_dialog);
         restore_result.should_show_notice) {
         song_select::queue_status_message(state_, restore_result.notice_message, restore_result.notice_is_error);
@@ -505,7 +618,6 @@ void song_select_scene::update(float dt) {
         if (song != nullptr && chart != nullptr) {
             if (IsKeyPressed(KEY_ENTER)) {
                 song_select::close_context_menu(state_);
-                ranking_service::refresh_scoring_ruleset_cache_for_chart_start(chart->meta, true);
                 manager_.change_scene(song_select::make_play_scene(manager_, *song, *chart));
                 return;
             }

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <future>
 #include <optional>
 #include <string>
 
@@ -30,12 +31,14 @@ public:
 private:
     void reload_song_library(const std::string& preferred_song_id = "",
                              const std::string& preferred_chart_id = "");
+    void poll_song_library_reload();
     void sync_selected_song_media();
     void apply_delete_result(const song_select::delete_result& result);
     void apply_transfer_result(const song_select::transfer_result& result);
     bool adjust_selected_song_local_offset(int delta_ms);
     bool apply_recent_result_offset();
     void reload_selected_chart_ranking();
+    void poll_selected_chart_ranking();
     void refresh_auth_state();
     bool handle_song_list_pointer(Vector2 mouse, bool left_pressed, bool right_pressed);
     void open_overwrite_song_confirmation(song_select::song_import_request request);
@@ -45,8 +48,18 @@ private:
     song_select::preview_controller preview_controller_;
     std::string preferred_song_id_;
     std::string preferred_chart_id_;
+    std::string pending_catalog_song_id_;
+    std::string pending_catalog_chart_id_;
     std::optional<song_select::recent_result_offset> recent_result_offset_;
     bool open_login_dialog_on_enter_ = false;
+    std::future<song_select::catalog_data> catalog_future_;
+    bool catalog_loading_ = false;
+    bool catalog_reload_pending_ = false;
+    std::future<ranking_service::listing> ranking_future_;
+    bool ranking_loading_ = false;
+    bool ranking_reload_pending_ = false;
+    int ranking_generation_ = 0;
+    int ranking_pending_generation_ = 0;
     auth_overlay::controller auth_controller_;
     song_select::transfer::controller transfer_controller_;
 };

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -1,0 +1,1221 @@
+#include "title/create_upload_client.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "app_paths.h"
+#include "network/auth_client.h"
+#include "path_utils.h"
+#include "title/online_download_remote_client.h"
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef NOGDI
+#define NOGDI
+#endif
+#ifndef NOUSER
+#define NOUSER
+#endif
+#include <windows.h>
+#include <winhttp.h>
+#endif
+
+namespace title_create_upload {
+namespace {
+namespace fs = std::filesystem;
+
+struct http_response {
+    int status_code = 0;
+    std::string body;
+    std::string error_message;
+};
+
+struct song_mapping_entry {
+    std::string server_url;
+    std::string local_song_id;
+    std::string remote_song_id;
+};
+
+struct chart_mapping_entry {
+    std::string server_url;
+    std::string local_chart_id;
+    std::string local_song_id;
+    std::string remote_chart_id;
+    std::string remote_song_id;
+};
+
+struct upload_mapping_store {
+    std::vector<song_mapping_entry> songs;
+    std::vector<chart_mapping_entry> charts;
+};
+
+struct multipart_field {
+    std::string name;
+    std::string value;
+};
+
+struct multipart_file {
+    std::string name;
+    std::string filename;
+    std::string content_type;
+    std::vector<unsigned char> bytes;
+};
+
+struct upload_request_result {
+    bool success = false;
+    bool not_found = false;
+    bool updated_existing = false;
+    std::string message;
+    std::string remote_song_id;
+    std::string remote_chart_id;
+};
+
+#ifdef _WIN32
+struct http_url_parts {
+    std::wstring host;
+    std::wstring path_and_query;
+    INTERNET_PORT port = INTERNET_DEFAULT_HTTP_PORT;
+    bool secure = false;
+};
+
+constexpr int kResolveTimeoutMs = 5000;
+constexpr int kConnectTimeoutMs = 5000;
+constexpr int kSendTimeoutMs = 15000;
+constexpr int kReceiveTimeoutMs = 15000;
+#endif
+
+std::string trim_ascii(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start])) != 0) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1])) != 0) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::string strip_trailing_cr(std::string value) {
+    while (!value.empty() && (value.back() == '\r' || value.back() == '\n')) {
+        value.pop_back();
+    }
+    return value;
+}
+
+std::vector<std::string> split_tab_fields(const std::string& line) {
+    std::vector<std::string> fields;
+    size_t start = 0;
+    while (start <= line.size()) {
+        const size_t end = line.find('\t', start);
+        if (end == std::string::npos) {
+            fields.push_back(line.substr(start));
+            break;
+        }
+        fields.push_back(line.substr(start, end - start));
+        start = end + 1;
+    }
+    return fields;
+}
+
+std::string escape_json_string(const std::string& value) {
+    std::string result;
+    result.reserve(value.size() + 8);
+    for (const char ch : value) {
+        switch (ch) {
+            case '\\': result += "\\\\"; break;
+            case '"': result += "\\\""; break;
+            case '\n': result += "\\n"; break;
+            case '\r': result += "\\r"; break;
+            case '\t': result += "\\t"; break;
+            default: result += ch; break;
+        }
+    }
+    return result;
+}
+
+std::string escape_multipart_header_value(const std::string& value) {
+    std::string result;
+    result.reserve(value.size());
+    for (const char ch : value) {
+        if (ch == '\\' || ch == '"') {
+            result.push_back('\\');
+        }
+        result.push_back(ch);
+    }
+    return result;
+}
+
+std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+    return key_pos + token.size();
+}
+
+std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
+    const auto key_end = find_json_key(content, key);
+    if (!key_end.has_value()) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', *key_end);
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start])) != 0) {
+        ++start;
+    }
+
+    if (start >= content.size()) {
+        return std::nullopt;
+    }
+
+    return start;
+}
+
+std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '"') {
+        return std::nullopt;
+    }
+
+    std::string result;
+    bool escaping = false;
+    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (escaping) {
+            switch (ch) {
+                case 'n': result += '\n'; break;
+                case 'r': result += '\r'; break;
+                case 't': result += '\t'; break;
+                default: result += ch; break;
+            }
+            escaping = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaping = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            return result;
+        }
+
+        result += ch;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
+    const auto start_opt = find_value_start(content, key);
+    if (!start_opt.has_value() || content[*start_opt] != '{') {
+        return std::nullopt;
+    }
+
+    size_t depth = 0;
+    bool in_string = false;
+    bool escaping = false;
+    for (size_t index = *start_opt; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (in_string) {
+            if (escaping) {
+                escaping = false;
+                continue;
+            }
+            if (ch == '\\') {
+                escaping = true;
+            } else if (ch == '"') {
+                in_string = false;
+            }
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = true;
+            continue;
+        }
+
+        if (ch == '{') {
+            ++depth;
+        } else if (ch == '}') {
+            --depth;
+            if (depth == 0) {
+                return content.substr(*start_opt, index - *start_opt + 1);
+            }
+        }
+    }
+
+    return std::nullopt;
+}
+
+std::string parse_error_message(const http_response& response, std::string fallback) {
+    if (const std::optional<std::string> message = extract_json_string(response.body, "message");
+        message.has_value() && !message->empty()) {
+        return *message;
+    }
+    if (!response.error_message.empty()) {
+        return response.error_message;
+    }
+    return fallback;
+}
+
+upload_mapping_store load_upload_mappings() {
+    upload_mapping_store store;
+
+    std::ifstream input(app_paths::upload_mapping_path(), std::ios::binary);
+    if (!input.is_open()) {
+        return store;
+    }
+
+    enum class section {
+        none,
+        songs,
+        charts,
+    };
+
+    section current_section = section::none;
+    std::string line;
+    while (std::getline(input, line)) {
+        line = strip_trailing_cr(line);
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+        if (line == "[songs]") {
+            current_section = section::songs;
+            continue;
+        }
+        if (line == "[charts]") {
+            current_section = section::charts;
+            continue;
+        }
+
+        const std::vector<std::string> fields = split_tab_fields(line);
+        if (current_section == section::songs && fields.size() >= 3) {
+            store.songs.push_back(song_mapping_entry{
+                .server_url = fields[0],
+                .local_song_id = fields[1],
+                .remote_song_id = fields[2],
+            });
+        } else if (current_section == section::charts && fields.size() >= 5) {
+            store.charts.push_back(chart_mapping_entry{
+                .server_url = fields[0],
+                .local_chart_id = fields[1],
+                .local_song_id = fields[2],
+                .remote_chart_id = fields[3],
+                .remote_song_id = fields[4],
+            });
+        }
+    }
+
+    return store;
+}
+
+bool save_upload_mappings(const upload_mapping_store& store) {
+    app_paths::ensure_directories();
+
+    std::ofstream output(app_paths::upload_mapping_path(), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "# raythm upload mappings v1\n";
+    output << "[songs]\n";
+    for (const song_mapping_entry& entry : store.songs) {
+        output << entry.server_url << '\t'
+               << entry.local_song_id << '\t'
+               << entry.remote_song_id << '\n';
+    }
+    output << "[charts]\n";
+    for (const chart_mapping_entry& entry : store.charts) {
+        output << entry.server_url << '\t'
+               << entry.local_chart_id << '\t'
+               << entry.local_song_id << '\t'
+               << entry.remote_chart_id << '\t'
+               << entry.remote_song_id << '\n';
+    }
+
+    return output.good();
+}
+
+std::optional<std::string> find_song_mapping(const upload_mapping_store& store,
+                                             const std::string& server_url,
+                                             const std::string& local_song_id) {
+    for (const song_mapping_entry& entry : store.songs) {
+        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
+            return entry.remote_song_id;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> find_chart_mapping(const upload_mapping_store& store,
+                                              const std::string& server_url,
+                                              const std::string& local_chart_id) {
+    for (const chart_mapping_entry& entry : store.charts) {
+        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
+            return entry.remote_chart_id;
+        }
+    }
+    return std::nullopt;
+}
+
+void remove_chart_mapping(upload_mapping_store& store,
+                          const std::string& server_url,
+                          const std::string& local_chart_id) {
+    std::erase_if(store.charts, [&](const chart_mapping_entry& entry) {
+        return entry.server_url == server_url && entry.local_chart_id == local_chart_id;
+    });
+}
+
+void remove_song_mapping(upload_mapping_store& store,
+                         const std::string& server_url,
+                         const std::string& local_song_id) {
+    std::erase_if(store.songs, [&](const song_mapping_entry& entry) {
+        return entry.server_url == server_url && entry.local_song_id == local_song_id;
+    });
+    std::erase_if(store.charts, [&](const chart_mapping_entry& entry) {
+        return entry.server_url == server_url && entry.local_song_id == local_song_id;
+    });
+}
+
+void store_song_mapping(upload_mapping_store& store,
+                        const std::string& server_url,
+                        const std::string& local_song_id,
+                        const std::string& remote_song_id) {
+    if (local_song_id.empty() || remote_song_id.empty()) {
+        return;
+    }
+
+    bool found = false;
+    for (song_mapping_entry& entry : store.songs) {
+        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
+            found = true;
+            if (entry.remote_song_id != remote_song_id) {
+                entry.remote_song_id = remote_song_id;
+                std::erase_if(store.charts, [&](const chart_mapping_entry& chart_entry) {
+                    return chart_entry.server_url == server_url &&
+                           chart_entry.local_song_id == local_song_id;
+                });
+            }
+            break;
+        }
+    }
+
+    if (!found) {
+        store.songs.push_back(song_mapping_entry{
+            .server_url = server_url,
+            .local_song_id = local_song_id,
+            .remote_song_id = remote_song_id,
+        });
+    }
+}
+
+void store_chart_mapping(upload_mapping_store& store,
+                         const std::string& server_url,
+                         const std::string& local_chart_id,
+                         const std::string& local_song_id,
+                         const std::string& remote_chart_id,
+                         const std::string& remote_song_id) {
+    if (local_chart_id.empty() || remote_chart_id.empty()) {
+        return;
+    }
+
+    for (chart_mapping_entry& entry : store.charts) {
+        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
+            entry.local_song_id = local_song_id;
+            entry.remote_chart_id = remote_chart_id;
+            entry.remote_song_id = remote_song_id;
+            return;
+        }
+    }
+
+    store.charts.push_back(chart_mapping_entry{
+        .server_url = server_url,
+        .local_chart_id = local_chart_id,
+        .local_song_id = local_song_id,
+        .remote_chart_id = remote_chart_id,
+        .remote_song_id = remote_song_id,
+    });
+}
+
+bool read_binary_file(const fs::path& path,
+                      std::vector<unsigned char>& bytes,
+                      std::string& error_message) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        error_message = "Failed to open a local file for upload.";
+        return false;
+    }
+
+    bytes.assign(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+    if (!input.good() && !input.eof()) {
+        error_message = "Failed to read a local file for upload.";
+        return false;
+    }
+
+    return true;
+}
+
+bool read_text_file(const fs::path& path,
+                    std::string& content,
+                    std::string& error_message) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        error_message = "Failed to open a local chart file for upload.";
+        return false;
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    if (!input.good() && !input.eof()) {
+        error_message = "Failed to read a local chart file for upload.";
+        return false;
+    }
+
+    content = buffer.str();
+    return true;
+}
+
+std::string lower_ascii(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
+        return static_cast<char>(std::tolower(ch));
+    });
+    return value;
+}
+
+std::string detect_audio_content_type(const fs::path& path) {
+    const std::string extension = lower_ascii(path.extension().string());
+    if (extension == ".ogg") {
+        return "audio/ogg";
+    }
+    return "audio/mpeg";
+}
+
+std::string detect_image_content_type(const fs::path& path) {
+    const std::string extension = lower_ascii(path.extension().string());
+    if (extension == ".png") {
+        return "image/png";
+    }
+    if (extension == ".webp") {
+        return "image/webp";
+    }
+    return "image/jpeg";
+}
+
+std::string build_external_links_json(const song_meta& meta) {
+    struct external_link {
+        const char* label;
+        const std::string* url;
+    };
+
+    const external_link links[] = {
+        {"YouTube", &meta.sns_youtube},
+        {"Niconico", &meta.sns_niconico},
+        {"X", &meta.sns_x},
+    };
+
+    std::ostringstream stream;
+    stream << '[';
+    bool first = true;
+    for (const external_link& link : links) {
+        if (link.url == nullptr || link.url->empty()) {
+            continue;
+        }
+
+        if (!first) {
+            stream << ',';
+        }
+        first = false;
+        stream << "{\"url\":\"" << escape_json_string(*link.url)
+               << "\",\"label\":\"" << escape_json_string(link.label) << "\"}";
+    }
+    stream << ']';
+    return stream.str();
+}
+
+std::string make_multipart_boundary() {
+    const auto nonce = static_cast<unsigned long long>(
+        std::chrono::high_resolution_clock::now().time_since_epoch().count());
+    return "----raythmBoundary" + std::to_string(nonce);
+}
+
+std::string build_multipart_body(const std::vector<multipart_field>& fields,
+                                 const std::vector<multipart_file>& files,
+                                 const std::string& boundary) {
+    std::string body;
+    const auto append = [&](std::string_view value) {
+        body.append(value.data(), value.size());
+    };
+
+    for (const multipart_field& field : fields) {
+        append("--");
+        append(boundary);
+        append("\r\nContent-Disposition: form-data; name=\"");
+        append(escape_multipart_header_value(field.name));
+        append("\"\r\n\r\n");
+        append(field.value);
+        append("\r\n");
+    }
+
+    for (const multipart_file& file : files) {
+        append("--");
+        append(boundary);
+        append("\r\nContent-Disposition: form-data; name=\"");
+        append(escape_multipart_header_value(file.name));
+        append("\"; filename=\"");
+        append(escape_multipart_header_value(file.filename));
+        append("\"\r\nContent-Type: ");
+        append(file.content_type);
+        append("\r\n\r\n");
+        if (!file.bytes.empty()) {
+            body.append(reinterpret_cast<const char*>(file.bytes.data()), file.bytes.size());
+        }
+        append("\r\n");
+    }
+
+    append("--");
+    append(boundary);
+    append("--\r\n");
+    return body;
+}
+
+#ifdef _WIN32
+std::wstring widen_utf8(const std::string& input) {
+    if (input.empty()) {
+        return {};
+    }
+
+    const int required = MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, nullptr, 0);
+    if (required <= 0) {
+        return {};
+    }
+
+    std::wstring output(static_cast<size_t>(required), L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, input.c_str(), -1, output.data(), required);
+    output.resize(static_cast<size_t>(required) - 1);
+    return output;
+}
+
+std::string describe_winhttp_error(DWORD error_code) {
+    switch (error_code) {
+        case ERROR_WINHTTP_TIMEOUT:
+            return "The connection to raythm-server timed out.";
+        case ERROR_WINHTTP_CANNOT_CONNECT:
+            return "Could not connect to raythm-server.";
+        case ERROR_WINHTTP_CONNECTION_ERROR:
+            return "The connection to raythm-server was interrupted.";
+        case ERROR_WINHTTP_NAME_NOT_RESOLVED:
+            return "The server name could not be resolved.";
+        case ERROR_WINHTTP_INVALID_URL:
+            return "The server URL is invalid.";
+        case ERROR_WINHTTP_UNRECOGNIZED_SCHEME:
+            return "The server URL scheme is not supported.";
+        case ERROR_WINHTTP_SECURE_FAILURE:
+            return "A secure connection to raythm-server could not be established.";
+        default:
+            return "Failed to communicate with raythm-server.";
+    }
+}
+
+std::optional<http_url_parts> parse_url(const std::string& url) {
+    const std::wstring wide_url = widen_utf8(url);
+    if (wide_url.empty()) {
+        return std::nullopt;
+    }
+
+    URL_COMPONENTS components{};
+    components.dwStructSize = sizeof(components);
+    components.dwSchemeLength = static_cast<DWORD>(-1);
+    components.dwHostNameLength = static_cast<DWORD>(-1);
+    components.dwUrlPathLength = static_cast<DWORD>(-1);
+    components.dwExtraInfoLength = static_cast<DWORD>(-1);
+
+    if (WinHttpCrackUrl(wide_url.c_str(), static_cast<DWORD>(wide_url.size()), 0, &components) == FALSE) {
+        return std::nullopt;
+    }
+
+    http_url_parts parts;
+    parts.host.assign(components.lpszHostName, components.dwHostNameLength);
+    parts.path_and_query.assign(components.lpszUrlPath, components.dwUrlPathLength);
+    parts.path_and_query.append(components.lpszExtraInfo, components.dwExtraInfoLength);
+    parts.port = components.nPort;
+    parts.secure = components.nScheme == INTERNET_SCHEME_HTTPS;
+    return parts;
+}
+
+http_response send_request(const std::string& method,
+                           const std::string& url,
+                           const std::string& body,
+                           const std::vector<std::pair<std::string, std::string>>& headers) {
+    http_response response;
+    const auto parts = parse_url(url);
+    if (!parts.has_value()) {
+        response.error_message = "Invalid server URL.";
+        return response;
+    }
+
+    HINTERNET session = WinHttpOpen(L"raythm/0.1",
+                                    WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                    WINHTTP_NO_PROXY_NAME,
+                                    WINHTTP_NO_PROXY_BYPASS,
+                                    0);
+    if (session == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        return response;
+    }
+
+    WinHttpSetTimeouts(session, kResolveTimeoutMs, kConnectTimeoutMs, kSendTimeoutMs, kReceiveTimeoutMs);
+
+    HINTERNET connection = WinHttpConnect(session, parts->host.c_str(), parts->port, 0);
+    if (connection == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    const std::wstring wide_method = widen_utf8(method);
+    HINTERNET request = WinHttpOpenRequest(connection,
+                                           wide_method.c_str(),
+                                           parts->path_and_query.c_str(),
+                                           nullptr,
+                                           WINHTTP_NO_REFERER,
+                                           WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                           parts->secure ? WINHTTP_FLAG_SECURE : 0);
+    if (request == nullptr) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    std::wstring header_block;
+    for (const auto& [name, value] : headers) {
+        header_block += widen_utf8(name);
+        header_block += L": ";
+        header_block += widen_utf8(value);
+        header_block += L"\r\n";
+    }
+
+    LPVOID request_body = body.empty() ? WINHTTP_NO_REQUEST_DATA : const_cast<char*>(body.data());
+    const DWORD request_body_size = static_cast<DWORD>(body.size());
+    const BOOL sent = WinHttpSendRequest(
+        request,
+        header_block.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : header_block.c_str(),
+        header_block.empty() ? 0 : static_cast<DWORD>(-1L),
+        request_body,
+        request_body_size,
+        request_body_size,
+        0);
+    if (sent == FALSE || WinHttpReceiveResponse(request, nullptr) == FALSE) {
+        response.error_message = describe_winhttp_error(GetLastError());
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+
+    DWORD status_code = 0;
+    DWORD status_code_size = sizeof(status_code);
+    if (WinHttpQueryHeaders(request,
+                            WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER,
+                            WINHTTP_HEADER_NAME_BY_INDEX,
+                            &status_code,
+                            &status_code_size,
+                            WINHTTP_NO_HEADER_INDEX) == FALSE) {
+        response.error_message = "Failed to read HTTP status.";
+        WinHttpCloseHandle(request);
+        WinHttpCloseHandle(connection);
+        WinHttpCloseHandle(session);
+        return response;
+    }
+    response.status_code = static_cast<int>(status_code);
+
+    DWORD available_size = 0;
+    while (WinHttpQueryDataAvailable(request, &available_size) == TRUE && available_size > 0) {
+        std::string chunk(static_cast<size_t>(available_size), '\0');
+        DWORD bytes_read = 0;
+        if (WinHttpReadData(request, chunk.data(), available_size, &bytes_read) == FALSE) {
+            response.error_message = "Failed to read HTTP response.";
+            WinHttpCloseHandle(request);
+            WinHttpCloseHandle(connection);
+            WinHttpCloseHandle(session);
+            return response;
+        }
+        chunk.resize(static_cast<size_t>(bytes_read));
+        response.body += chunk;
+    }
+
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connection);
+    WinHttpCloseHandle(session);
+    return response;
+}
+#else
+http_response send_request(const std::string&,
+                           const std::string&,
+                           const std::string&,
+                           const std::vector<std::pair<std::string, std::string>>&) {
+    return {
+        0,
+        {},
+        "Community upload is only supported on Windows builds right now.",
+    };
+}
+#endif
+
+upload_request_result parse_song_upload_response(const http_response& response,
+                                                 bool updated_existing) {
+    upload_request_result result;
+    result.updated_existing = updated_existing;
+
+    if (!response.error_message.empty()) {
+        result.message = response.error_message;
+        return result;
+    }
+
+    if (response.status_code == 404) {
+        result.not_found = true;
+        result.message = parse_error_message(response, "Song not found.");
+        return result;
+    }
+    if (response.status_code < 200 || response.status_code >= 300) {
+        result.message = parse_error_message(response, "Song upload failed.");
+        return result;
+    }
+
+    const std::optional<std::string> song_object = extract_json_object(response.body, "song");
+    if (!song_object.has_value()) {
+        result.message = "Song upload succeeded, but the response was invalid.";
+        return result;
+    }
+
+    const std::optional<std::string> song_id = extract_json_string(*song_object, "id");
+    if (!song_id.has_value() || song_id->empty()) {
+        result.message = "Song upload succeeded, but the server did not return a song ID.";
+        return result;
+    }
+
+    result.success = true;
+    result.remote_song_id = *song_id;
+    result.message = updated_existing ? "Song upload updated." : "Song uploaded.";
+    return result;
+}
+
+upload_request_result parse_chart_upload_response(const http_response& response,
+                                                  bool updated_existing) {
+    upload_request_result result;
+    result.updated_existing = updated_existing;
+
+    if (!response.error_message.empty()) {
+        result.message = response.error_message;
+        return result;
+    }
+
+    if (response.status_code == 404) {
+        result.not_found = true;
+        result.message = parse_error_message(response, "Chart target was not found.");
+        return result;
+    }
+    if (response.status_code < 200 || response.status_code >= 300) {
+        result.message = parse_error_message(response, "Chart upload failed.");
+        return result;
+    }
+
+    const std::optional<std::string> chart_object = extract_json_object(response.body, "chart");
+    if (!chart_object.has_value()) {
+        result.message = "Chart upload succeeded, but the response was invalid.";
+        return result;
+    }
+
+    const std::optional<std::string> chart_id = extract_json_string(*chart_object, "id");
+    if (!chart_id.has_value() || chart_id->empty()) {
+        result.message = "Chart upload succeeded, but the server did not return a chart ID.";
+        return result;
+    }
+
+    result.success = true;
+    result.remote_chart_id = *chart_id;
+    result.message = updated_existing ? "Chart upload updated." : "Chart uploaded.";
+    return result;
+}
+
+std::optional<auth::session> require_saved_session(std::string& error_message) {
+    const std::optional<auth::session> session = auth::load_saved_session();
+    if (!session.has_value() || session->access_token.empty()) {
+        error_message = "Log in before uploading community content.";
+        return std::nullopt;
+    }
+
+    return auth::session{
+        .server_url = auth::normalize_server_url(session->server_url),
+        .access_token = session->access_token,
+        .refresh_token = session->refresh_token,
+        .user = session->user,
+    };
+}
+
+upload_request_result send_song_upload_request(const auth::session& session,
+                                               const song_select::song_entry& song,
+                                               const std::optional<std::string>& remote_song_id) {
+    upload_request_result result;
+
+    const song_meta& meta = song.song.meta;
+    if (meta.title.empty() || meta.artist.empty() || meta.base_bpm <= 0.0f) {
+        result.message = "Selected song is missing required metadata for upload.";
+        return result;
+    }
+    if (meta.audio_file.empty() || meta.jacket_file.empty()) {
+        result.message = "Selected song needs both audio and jacket files to upload.";
+        return result;
+    }
+
+    const fs::path song_dir = path_utils::from_utf8(song.song.directory);
+    const fs::path audio_path = song_dir / path_utils::from_utf8(meta.audio_file);
+    const fs::path jacket_path = song_dir / path_utils::from_utf8(meta.jacket_file);
+    if (!fs::exists(audio_path) || !fs::is_regular_file(audio_path)) {
+        result.message = "Selected song audio file was not found.";
+        return result;
+    }
+    if (!fs::exists(jacket_path) || !fs::is_regular_file(jacket_path)) {
+        result.message = "Selected song jacket file was not found.";
+        return result;
+    }
+
+    std::vector<unsigned char> audio_bytes;
+    std::vector<unsigned char> jacket_bytes;
+    if (!read_binary_file(audio_path, audio_bytes, result.message) ||
+        !read_binary_file(jacket_path, jacket_bytes, result.message)) {
+        return result;
+    }
+
+    std::vector<multipart_field> fields;
+    fields.push_back({"title", meta.title});
+    fields.push_back({"artist", meta.artist});
+    {
+        std::ostringstream bpm_stream;
+        bpm_stream << meta.base_bpm;
+        fields.push_back({"baseBpm", bpm_stream.str()});
+    }
+    if (meta.duration_seconds > 0.0f) {
+        fields.push_back({"durationSec", std::to_string(static_cast<int>(meta.duration_seconds + 0.5f))});
+    }
+    fields.push_back({"previewStartMs", std::to_string(std::max(0, meta.preview_start_ms))});
+    fields.push_back({"visibility", "public"});
+    const std::string external_links_json = build_external_links_json(meta);
+    if (external_links_json != "[]") {
+        fields.push_back({"externalLinks", external_links_json});
+    }
+
+    std::vector<multipart_file> files;
+    files.push_back({
+        .name = "audio",
+        .filename = audio_path.filename().string(),
+        .content_type = detect_audio_content_type(audio_path),
+        .bytes = std::move(audio_bytes),
+    });
+    files.push_back({
+        .name = "jacket",
+        .filename = jacket_path.filename().string(),
+        .content_type = detect_image_content_type(jacket_path),
+        .bytes = std::move(jacket_bytes),
+    });
+
+    const std::string boundary = make_multipart_boundary();
+    const std::string body = build_multipart_body(fields, files, boundary);
+    const std::string method = remote_song_id.has_value() ? "PUT" : "POST";
+    const std::string url = remote_song_id.has_value()
+        ? session.server_url + "/songs/" + *remote_song_id
+        : session.server_url + "/songs";
+    const http_response response = send_request(method, url, body, {
+        {"Authorization", "Bearer " + session.access_token},
+        {"Accept", "application/json"},
+        {"Content-Type", "multipart/form-data; boundary=" + boundary},
+    });
+    return parse_song_upload_response(response, remote_song_id.has_value());
+}
+
+std::optional<std::string> find_remote_song_id(const auth::session& session,
+                                               upload_mapping_store& store,
+                                               const song_select::song_entry& song) {
+    if (const std::optional<std::string> mapped = find_song_mapping(
+            store, session.server_url, song.song.meta.song_id);
+        mapped.has_value()) {
+        return mapped;
+    }
+
+    if (song.song.meta.song_id.empty()) {
+        return std::nullopt;
+    }
+
+    const title_online_view::remote_song_lookup_result lookup =
+        title_online_view::fetch_remote_song_by_id(song.song.meta.song_id, session.server_url);
+    if (!lookup.success || lookup.not_found || lookup.song.id.empty()) {
+        return std::nullopt;
+    }
+
+    store_song_mapping(store, session.server_url, song.song.meta.song_id, lookup.song.id);
+    return lookup.song.id;
+}
+
+std::optional<std::string> rewrite_chart_song_id(const std::string& content,
+                                                 const std::string& remote_song_id,
+                                                 std::string& error_message) {
+    if (remote_song_id.empty()) {
+        error_message = "Chart upload is missing a remote song ID.";
+        return std::nullopt;
+    }
+
+    std::vector<std::string> lines;
+    {
+        std::string normalized = content;
+        size_t position = 0;
+        while ((position = normalized.find("\r\n", position)) != std::string::npos) {
+            normalized.replace(position, 2, "\n");
+        }
+
+        std::istringstream stream(normalized);
+        std::string line;
+        while (std::getline(stream, line)) {
+            lines.push_back(line);
+        }
+    }
+
+    int metadata_header_index = -1;
+    int metadata_end_index = static_cast<int>(lines.size());
+    for (int index = 0; index < static_cast<int>(lines.size()); ++index) {
+        const std::string trimmed = trim_ascii(lines[static_cast<size_t>(index)]);
+        if (metadata_header_index < 0) {
+            if (trimmed == "[Metadata]") {
+                metadata_header_index = index;
+            }
+            continue;
+        }
+        if (!trimmed.empty() && trimmed.front() == '[' && trimmed.back() == ']') {
+            metadata_end_index = index;
+            break;
+        }
+    }
+
+    if (metadata_header_index < 0) {
+        error_message = "Selected chart does not contain a [Metadata] section.";
+        return std::nullopt;
+    }
+
+    std::vector<std::string> ordered_keys;
+    std::vector<std::pair<std::string, std::string>> metadata_values;
+    auto find_metadata = [&](const std::string& key) {
+        return std::find_if(metadata_values.begin(), metadata_values.end(), [&](const auto& entry) {
+            return entry.first == key;
+        });
+    };
+
+    for (int index = metadata_header_index + 1; index < metadata_end_index; ++index) {
+        const std::string& line = lines[static_cast<size_t>(index)];
+        const size_t separator = line.find('=');
+        if (separator == std::string::npos) {
+            continue;
+        }
+
+        const std::string key = trim_ascii(line.substr(0, separator));
+        const std::string value = trim_ascii(line.substr(separator + 1));
+        if (key.empty()) {
+            continue;
+        }
+
+        if (find_metadata(key) == metadata_values.end()) {
+            ordered_keys.push_back(key);
+            metadata_values.emplace_back(key, value);
+        }
+    }
+
+    auto song_id_entry = find_metadata("songId");
+    if (song_id_entry == metadata_values.end()) {
+        ordered_keys.push_back("songId");
+        metadata_values.emplace_back("songId", remote_song_id);
+    } else {
+        song_id_entry->second = remote_song_id;
+    }
+
+    std::ostringstream rebuilt;
+    for (int index = 0; index <= metadata_header_index; ++index) {
+        rebuilt << lines[static_cast<size_t>(index)] << '\n';
+    }
+    for (const std::string& key : ordered_keys) {
+        const auto entry = find_metadata(key);
+        if (entry == metadata_values.end()) {
+            continue;
+        }
+        rebuilt << entry->first << '=' << entry->second << '\n';
+    }
+    for (int index = metadata_end_index; index < static_cast<int>(lines.size()); ++index) {
+        rebuilt << lines[static_cast<size_t>(index)];
+        if (index + 1 < static_cast<int>(lines.size())) {
+            rebuilt << '\n';
+        }
+    }
+
+    return rebuilt.str();
+}
+
+upload_request_result send_chart_upload_request(const auth::session& session,
+                                                const song_select::song_entry& song,
+                                                const song_select::chart_option& chart,
+                                                const std::string& remote_song_id,
+                                                const std::optional<std::string>& remote_chart_id) {
+    upload_request_result result;
+
+    const fs::path chart_path = path_utils::from_utf8(chart.path);
+    if (!fs::exists(chart_path) || !fs::is_regular_file(chart_path)) {
+        result.message = "Selected chart file was not found.";
+        return result;
+    }
+
+    std::string chart_content;
+    if (!read_text_file(chart_path, chart_content, result.message)) {
+        return result;
+    }
+
+    std::optional<std::string> rewritten_chart = rewrite_chart_song_id(chart_content, remote_song_id, result.message);
+    if (!rewritten_chart.has_value()) {
+        return result;
+    }
+
+    std::vector<multipart_field> fields;
+    fields.push_back({"visibility", chart.meta.is_public ? "public" : "private"});
+
+    std::vector<unsigned char> chart_bytes(rewritten_chart->begin(), rewritten_chart->end());
+    std::vector<multipart_file> files;
+    files.push_back({
+        .name = "chart",
+        .filename = chart_path.filename().string(),
+        .content_type = "text/plain; charset=utf-8",
+        .bytes = std::move(chart_bytes),
+    });
+
+    const std::string boundary = make_multipart_boundary();
+    const std::string body = build_multipart_body(fields, files, boundary);
+    const std::string method = remote_chart_id.has_value() ? "PUT" : "POST";
+    const std::string url = remote_chart_id.has_value()
+        ? session.server_url + "/charts/" + *remote_chart_id
+        : session.server_url + "/charts";
+    const http_response response = send_request(method, url, body, {
+        {"Authorization", "Bearer " + session.access_token},
+        {"Accept", "application/json"},
+        {"Content-Type", "multipart/form-data; boundary=" + boundary},
+    });
+    return parse_chart_upload_response(response, remote_chart_id.has_value());
+}
+
+}  // namespace
+
+upload_result upload_song(const song_select::song_entry& song) {
+    upload_result result;
+
+    std::string error_message;
+    const std::optional<auth::session> session_opt = require_saved_session(error_message);
+    if (!session_opt.has_value()) {
+        result.message = std::move(error_message);
+        return result;
+    }
+    const auth::session& session = *session_opt;
+
+    upload_mapping_store store = load_upload_mappings();
+    const std::optional<std::string> existing_remote_song_id =
+        find_song_mapping(store, session.server_url, song.song.meta.song_id);
+
+    upload_request_result request_result =
+        send_song_upload_request(session, song, existing_remote_song_id);
+    if (request_result.not_found && existing_remote_song_id.has_value()) {
+        remove_song_mapping(store, session.server_url, song.song.meta.song_id);
+        save_upload_mappings(store);
+        request_result = send_song_upload_request(session, song, std::nullopt);
+    }
+
+    result.success = request_result.success;
+    result.message = request_result.message;
+    result.should_refresh_online_catalog = request_result.success;
+    if (!request_result.success) {
+        return result;
+    }
+
+    store_song_mapping(store, session.server_url, song.song.meta.song_id, request_result.remote_song_id);
+    if (!save_upload_mappings(store)) {
+        result.message += " Local upload mapping was not saved.";
+    } else if (!request_result.updated_existing) {
+        result.message += " Charts for this song can now be uploaded.";
+    }
+
+    return result;
+}
+
+upload_result upload_chart(const song_select::song_entry& song,
+                           const song_select::chart_option& chart) {
+    upload_result result;
+
+    std::string error_message;
+    const std::optional<auth::session> session_opt = require_saved_session(error_message);
+    if (!session_opt.has_value()) {
+        result.message = std::move(error_message);
+        return result;
+    }
+    const auth::session& session = *session_opt;
+
+    upload_mapping_store store = load_upload_mappings();
+    const std::optional<std::string> remote_song_id = find_remote_song_id(session, store, song);
+    if (!remote_song_id.has_value()) {
+        result.message = "Upload the song first so the server can assign a song ID.";
+        return result;
+    }
+
+    const std::optional<std::string> existing_remote_chart_id =
+        find_chart_mapping(store, session.server_url, chart.meta.chart_id);
+    upload_request_result request_result =
+        send_chart_upload_request(session, song, chart, *remote_song_id, existing_remote_chart_id);
+    if (request_result.not_found && existing_remote_chart_id.has_value()) {
+        remove_chart_mapping(store, session.server_url, chart.meta.chart_id);
+        save_upload_mappings(store);
+        request_result =
+            send_chart_upload_request(session, song, chart, *remote_song_id, std::nullopt);
+    }
+
+    result.success = request_result.success;
+    result.message = request_result.message;
+    result.should_refresh_online_catalog = request_result.success;
+    if (!request_result.success) {
+        return result;
+    }
+
+    store_song_mapping(store, session.server_url, song.song.meta.song_id, *remote_song_id);
+    store_chart_mapping(store, session.server_url, chart.meta.chart_id, song.song.meta.song_id,
+                        request_result.remote_chart_id, *remote_song_id);
+    if (!save_upload_mappings(store)) {
+        result.message += " Local upload mapping was not saved.";
+    }
+
+    return result;
+}
+
+}  // namespace title_create_upload

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -13,6 +13,7 @@
 
 #include "app_paths.h"
 #include "network/auth_client.h"
+#include "network/json_helpers.h"
 #include "path_utils.h"
 #include "title/online_download_remote_client.h"
 
@@ -36,6 +37,7 @@
 namespace title_create_upload {
 namespace {
 namespace fs = std::filesystem;
+namespace json = network::json;
 
 struct http_response {
     int status_code = 0;
@@ -134,22 +136,6 @@ std::vector<std::string> split_tab_fields(const std::string& line) {
     return fields;
 }
 
-std::string escape_json_string(const std::string& value) {
-    std::string result;
-    result.reserve(value.size() + 8);
-    for (const char ch : value) {
-        switch (ch) {
-            case '\\': result += "\\\\"; break;
-            case '"': result += "\\\""; break;
-            case '\n': result += "\\n"; break;
-            case '\r': result += "\\r"; break;
-            case '\t': result += "\\t"; break;
-            default: result += ch; break;
-        }
-    }
-    return result;
-}
-
 std::string escape_multipart_header_value(const std::string& value) {
     std::string result;
     result.reserve(value.size());
@@ -162,118 +148,8 @@ std::string escape_multipart_header_value(const std::string& value) {
     return result;
 }
 
-std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
-    const std::string token = "\"" + key + "\"";
-    const size_t key_pos = content.find(token);
-    if (key_pos == std::string::npos) {
-        return std::nullopt;
-    }
-    return key_pos + token.size();
-}
-
-std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
-    const auto key_end = find_json_key(content, key);
-    if (!key_end.has_value()) {
-        return std::nullopt;
-    }
-
-    const size_t colon_pos = content.find(':', *key_end);
-    if (colon_pos == std::string::npos) {
-        return std::nullopt;
-    }
-
-    size_t start = colon_pos + 1;
-    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start])) != 0) {
-        ++start;
-    }
-
-    if (start >= content.size()) {
-        return std::nullopt;
-    }
-
-    return start;
-}
-
-std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '"') {
-        return std::nullopt;
-    }
-
-    std::string result;
-    bool escaping = false;
-    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (escaping) {
-            switch (ch) {
-                case 'n': result += '\n'; break;
-                case 'r': result += '\r'; break;
-                case 't': result += '\t'; break;
-                default: result += ch; break;
-            }
-            escaping = false;
-            continue;
-        }
-
-        if (ch == '\\') {
-            escaping = true;
-            continue;
-        }
-
-        if (ch == '"') {
-            return result;
-        }
-
-        result += ch;
-    }
-
-    return std::nullopt;
-}
-
-std::optional<std::string> extract_json_object(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '{') {
-        return std::nullopt;
-    }
-
-    size_t depth = 0;
-    bool in_string = false;
-    bool escaping = false;
-    for (size_t index = *start_opt; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-
-        if (ch == '{') {
-            ++depth;
-        } else if (ch == '}') {
-            --depth;
-            if (depth == 0) {
-                return content.substr(*start_opt, index - *start_opt + 1);
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
 std::string parse_error_message(const http_response& response, std::string fallback) {
-    if (const std::optional<std::string> message = extract_json_string(response.body, "message");
+    if (const std::optional<std::string> message = json::extract_string(response.body, "message");
         message.has_value() && !message->empty()) {
         return *message;
     }
@@ -550,8 +426,8 @@ std::string build_external_links_json(const song_meta& meta) {
             stream << ',';
         }
         first = false;
-        stream << "{\"url\":\"" << escape_json_string(*link.url)
-               << "\",\"label\":\"" << escape_json_string(link.label) << "\"}";
+        stream << "{\"url\":\"" << json::escape_string(*link.url)
+               << "\",\"label\":\"" << json::escape_string(link.label) << "\"}";
     }
     stream << ']';
     return stream.str();
@@ -812,13 +688,13 @@ upload_request_result parse_song_upload_response(const http_response& response,
         return result;
     }
 
-    const std::optional<std::string> song_object = extract_json_object(response.body, "song");
+    const std::optional<std::string> song_object = json::extract_object(response.body, "song");
     if (!song_object.has_value()) {
         result.message = "Song upload succeeded, but the response was invalid.";
         return result;
     }
 
-    const std::optional<std::string> song_id = extract_json_string(*song_object, "id");
+    const std::optional<std::string> song_id = json::extract_string(*song_object, "id");
     if (!song_id.has_value() || song_id->empty()) {
         result.message = "Song upload succeeded, but the server did not return a song ID.";
         return result;
@@ -855,13 +731,13 @@ upload_request_result parse_chart_upload_response(const http_response& response,
         return result;
     }
 
-    const std::optional<std::string> chart_object = extract_json_object(response.body, "chart");
+    const std::optional<std::string> chart_object = json::extract_object(response.body, "chart");
     if (!chart_object.has_value()) {
         result.message = "Chart upload succeeded, but the response was invalid.";
         return result;
     }
 
-    const std::optional<std::string> chart_id = extract_json_string(*chart_object, "id");
+    const std::optional<std::string> chart_id = json::extract_string(*chart_object, "id");
     if (!chart_id.has_value() || chart_id->empty()) {
         result.message = "Chart upload succeeded, but the server did not return a chart ID.";
         return result;

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -77,6 +77,7 @@ struct multipart_file {
 struct upload_request_result {
     bool success = false;
     bool not_found = false;
+    bool unauthorized = false;
     bool updated_existing = false;
     std::string message;
     std::string remote_song_id;
@@ -801,6 +802,11 @@ upload_request_result parse_song_upload_response(const http_response& response,
         result.message = parse_error_message(response, "Song not found.");
         return result;
     }
+    if (response.status_code == 401) {
+        result.unauthorized = true;
+        result.message = parse_error_message(response, "Log in before uploading community content.");
+        return result;
+    }
     if (response.status_code < 200 || response.status_code >= 300) {
         result.message = parse_error_message(response, "Song upload failed.");
         return result;
@@ -839,6 +845,11 @@ upload_request_result parse_chart_upload_response(const http_response& response,
         result.message = parse_error_message(response, "Chart target was not found.");
         return result;
     }
+    if (response.status_code == 401) {
+        result.unauthorized = true;
+        result.message = parse_error_message(response, "Log in before uploading community content.");
+        return result;
+    }
     if (response.status_code < 200 || response.status_code >= 300) {
         result.message = parse_error_message(response, "Chart upload failed.");
         return result;
@@ -874,6 +885,23 @@ std::optional<auth::session> require_saved_session(std::string& error_message) {
         .access_token = session->access_token,
         .refresh_token = session->refresh_token,
         .user = session->user,
+    };
+}
+
+std::optional<auth::session> restore_upload_session(std::string& error_message) {
+    const auth::operation_result restored = auth::restore_saved_session();
+    if (!restored.success || !restored.session_data.has_value()) {
+        error_message = restored.message.empty()
+            ? "Log in before uploading community content."
+            : restored.message;
+        return std::nullopt;
+    }
+
+    return auth::session{
+        .server_url = auth::normalize_server_url(restored.session_data->server_url),
+        .access_token = restored.session_data->access_token,
+        .refresh_token = restored.session_data->refresh_token,
+        .user = restored.session_data->user,
     };
 }
 
@@ -1140,7 +1168,7 @@ upload_result upload_song(const song_select::song_entry& song) {
         result.message = std::move(error_message);
         return result;
     }
-    const auth::session& session = *session_opt;
+    auth::session session = *session_opt;
 
     upload_mapping_store store = load_upload_mappings();
     const std::optional<std::string> existing_remote_song_id =
@@ -1148,10 +1176,30 @@ upload_result upload_song(const song_select::song_entry& song) {
 
     upload_request_result request_result =
         send_song_upload_request(session, song, existing_remote_song_id);
+    if (request_result.unauthorized) {
+        std::string restore_error;
+        const std::optional<auth::session> restored = restore_upload_session(restore_error);
+        if (!restored.has_value()) {
+            result.message = std::move(restore_error);
+            return result;
+        }
+        session = *restored;
+        request_result = send_song_upload_request(session, song, existing_remote_song_id);
+    }
     if (request_result.not_found && existing_remote_song_id.has_value()) {
         remove_song_mapping(store, session.server_url, song.song.meta.song_id);
         save_upload_mappings(store);
         request_result = send_song_upload_request(session, song, std::nullopt);
+        if (request_result.unauthorized) {
+            std::string restore_error;
+            const std::optional<auth::session> restored = restore_upload_session(restore_error);
+            if (!restored.has_value()) {
+                result.message = std::move(restore_error);
+                return result;
+            }
+            session = *restored;
+            request_result = send_song_upload_request(session, song, std::nullopt);
+        }
     }
 
     result.success = request_result.success;
@@ -1181,7 +1229,7 @@ upload_result upload_chart(const song_select::song_entry& song,
         result.message = std::move(error_message);
         return result;
     }
-    const auth::session& session = *session_opt;
+    auth::session session = *session_opt;
 
     upload_mapping_store store = load_upload_mappings();
     const std::optional<std::string> remote_song_id = find_remote_song_id(session, store, song);
@@ -1194,11 +1242,32 @@ upload_result upload_chart(const song_select::song_entry& song,
         find_chart_mapping(store, session.server_url, chart.meta.chart_id);
     upload_request_result request_result =
         send_chart_upload_request(session, song, chart, *remote_song_id, existing_remote_chart_id);
+    if (request_result.unauthorized) {
+        std::string restore_error;
+        const std::optional<auth::session> restored = restore_upload_session(restore_error);
+        if (!restored.has_value()) {
+            result.message = std::move(restore_error);
+            return result;
+        }
+        session = *restored;
+        request_result = send_chart_upload_request(session, song, chart, *remote_song_id, existing_remote_chart_id);
+    }
     if (request_result.not_found && existing_remote_chart_id.has_value()) {
         remove_chart_mapping(store, session.server_url, chart.meta.chart_id);
         save_upload_mappings(store);
         request_result =
             send_chart_upload_request(session, song, chart, *remote_song_id, std::nullopt);
+        if (request_result.unauthorized) {
+            std::string restore_error;
+            const std::optional<auth::session> restored = restore_upload_session(restore_error);
+            if (!restored.has_value()) {
+                result.message = std::move(restore_error);
+                return result;
+            }
+            session = *restored;
+            request_result =
+                send_chart_upload_request(session, song, chart, *remote_song_id, std::nullopt);
+        }
     }
 
     result.success = request_result.success;

--- a/src/scenes/title/create_upload_client.h
+++ b/src/scenes/title/create_upload_client.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+#include "song_select/song_select_state.h"
+
+namespace title_create_upload {
+
+struct upload_result {
+    bool success = false;
+    bool should_refresh_online_catalog = false;
+    std::string message;
+};
+
+upload_result upload_song(const song_select::song_entry& song);
+upload_result upload_chart(const song_select::song_entry& song,
+                           const song_select::chart_option& chart);
+
+}  // namespace title_create_upload

--- a/src/scenes/title/online_download_catalog.cpp
+++ b/src/scenes/title/online_download_catalog.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <future>
@@ -462,9 +463,15 @@ void reload_catalog(state& state) {
     state.owned_loading = false;
     state.owned_loaded_once = false;
     state.jackets.clear();
-    state.catalog_future = std::async(std::launch::async, []() {
-        return load_catalog_result();
-    });
+    std::promise<catalog_load_result> promise;
+    state.catalog_future = promise.get_future();
+    std::thread([promise = std::move(promise)]() mutable {
+        try {
+            promise.set_value(load_catalog_result());
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 bool poll_catalog(state& state) {
@@ -475,7 +482,16 @@ bool poll_catalog(state& state) {
         return false;
     }
 
-    catalog_load_result result = state.catalog_future.get();
+    catalog_load_result result;
+    try {
+        result = state.catalog_future.get();
+    } catch (const std::exception& ex) {
+        result.catalog_request_failed = true;
+        result.catalog_status_message = ex.what();
+    } catch (...) {
+        result.catalog_request_failed = true;
+        result.catalog_status_message = "Failed to load online catalog.";
+    }
     state.catalog_loading = false;
     state.catalog_loaded_once = true;
     state.catalog_server_url = std::move(result.catalog_server_url);
@@ -511,9 +527,15 @@ void request_next_song_page(state& state, catalog_mode mode) {
     state.song_page_mode = mode;
     const int page = next_page_ref(state, mode);
     const std::string server_url = state.catalog_server_url;
-    state.song_page_future = std::async(std::launch::async, [mode, page, server_url]() {
-        return fetch_remote_song_page(mode, page, kSongPageSize, server_url);
-    });
+    std::promise<remote_song_page_fetch_result> promise;
+    state.song_page_future = promise.get_future();
+    std::thread([promise = std::move(promise), mode, page, server_url]() mutable {
+        try {
+            promise.set_value(fetch_remote_song_page(mode, page, kSongPageSize, server_url));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 bool poll_song_page(state& state) {
@@ -524,7 +546,16 @@ bool poll_song_page(state& state) {
         return false;
     }
 
-    const remote_song_page_fetch_result page_result = state.song_page_future.get();
+    remote_song_page_fetch_result page_result;
+    try {
+        page_result = state.song_page_future.get();
+    } catch (const std::exception& ex) {
+        page_result.success = false;
+        page_result.error_message = ex.what();
+    } catch (...) {
+        page_result.success = false;
+        page_result.error_message = "Failed to load more songs.";
+    }
     state.song_page_loading = false;
     if (!page_result.success) {
         state.catalog_status_message = page_result.error_message;
@@ -569,9 +600,16 @@ void request_charts_for_selected_song(state& state) {
     state.chart_page_song_id = song->song.song.meta.song_id;
     const std::string server_url = state.catalog_server_url;
     const int page = song->next_chart_page;
-    state.chart_page_future = std::async(std::launch::async, [server_url, page, song_id = state.chart_page_song_id]() {
-        return fetch_remote_chart_page(server_url, song_id, page, kChartPageSize);
-    });
+    std::promise<remote_chart_page_fetch_result> promise;
+    state.chart_page_future = promise.get_future();
+    const std::string song_id = state.chart_page_song_id;
+    std::thread([promise = std::move(promise), server_url, page, song_id]() mutable {
+        try {
+            promise.set_value(fetch_remote_chart_page(server_url, song_id, page, kChartPageSize));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 bool poll_chart_page(state& state) {
@@ -582,7 +620,12 @@ bool poll_chart_page(state& state) {
         return false;
     }
 
-    const remote_chart_page_fetch_result page_result = state.chart_page_future.get();
+    remote_chart_page_fetch_result page_result;
+    try {
+        page_result = state.chart_page_future.get();
+    } catch (...) {
+        page_result.success = false;
+    }
     state.chart_page_loading = false;
     song_entry_state* song = find_song_state(songs_for_mode(state, state.chart_page_mode), state.chart_page_song_id);
     if (song == nullptr) {

--- a/src/scenes/title/online_download_remote_client.cpp
+++ b/src/scenes/title/online_download_remote_client.cpp
@@ -1,6 +1,5 @@
 #include "title/online_download_remote_client.h"
 
-#include <cctype>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -8,6 +7,7 @@
 #include <vector>
 
 #include "network/auth_client.h"
+#include "network/json_helpers.h"
 #include "title/online_download_view.h"
 
 #ifdef _WIN32
@@ -29,6 +29,7 @@
 
 namespace title_online_view {
 namespace {
+namespace json = network::json;
 
 struct http_response {
     int status_code = 0;
@@ -66,236 +67,12 @@ constexpr int kSendTimeoutMs = 5000;
 constexpr int kReceiveTimeoutMs = 5000;
 #endif
 
-std::string trim(std::string_view value) {
-    size_t start = 0;
-    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
-        ++start;
-    }
-
-    size_t end = value.size();
-    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
-        --end;
-    }
-
-    return std::string(value.substr(start, end - start));
-}
-
-std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
-    const std::string token = "\"" + key + "\"";
-    const size_t key_pos = content.find(token);
-    if (key_pos == std::string::npos) {
-        return std::nullopt;
-    }
-    return key_pos + token.size();
-}
-
-std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
-    const auto key_end = find_json_key(content, key);
-    if (!key_end.has_value()) {
-        return std::nullopt;
-    }
-
-    const size_t colon_pos = content.find(':', *key_end);
-    if (colon_pos == std::string::npos) {
-        return std::nullopt;
-    }
-
-    size_t start = colon_pos + 1;
-    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
-        ++start;
-    }
-
-    if (start >= content.size()) {
-        return std::nullopt;
-    }
-
-    return start;
-}
-
-std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '"') {
-        return std::nullopt;
-    }
-
-    std::string result;
-    bool escaping = false;
-    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (escaping) {
-            switch (ch) {
-                case 'n': result += '\n'; break;
-                case 'r': result += '\r'; break;
-                case 't': result += '\t'; break;
-                default: result += ch; break;
-            }
-            escaping = false;
-            continue;
-        }
-
-        if (ch == '\\') {
-            escaping = true;
-            continue;
-        }
-
-        if (ch == '"') {
-            return result;
-        }
-
-        result += ch;
-    }
-
-    return std::nullopt;
-}
-
-std::optional<int> extract_json_int(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value()) {
-        return std::nullopt;
-    }
-
-    size_t end = *start_opt;
-    if (content[end] == '-') {
-        ++end;
-    }
-    while (end < content.size() && std::isdigit(static_cast<unsigned char>(content[end]))) {
-        ++end;
-    }
-    if (end == *start_opt) {
-        return std::nullopt;
-    }
-
-    try {
-        return std::stoi(content.substr(*start_opt, end - *start_opt));
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-std::optional<float> extract_json_float(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value()) {
-        return std::nullopt;
-    }
-
-    size_t end = *start_opt;
-    if (content[end] == '-') {
-        ++end;
-    }
-    while (end < content.size()) {
-        const char ch = content[end];
-        if (!(std::isdigit(static_cast<unsigned char>(ch)) || ch == '.')) {
-            break;
-        }
-        ++end;
-    }
-    if (end == *start_opt) {
-        return std::nullopt;
-    }
-
-    try {
-        return std::stof(content.substr(*start_opt, end - *start_opt));
-    } catch (...) {
-        return std::nullopt;
-    }
-}
-
-std::optional<std::string> extract_json_array(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '[') {
-        return std::nullopt;
-    }
-
-    size_t depth = 0;
-    bool in_string = false;
-    bool escaping = false;
-    for (size_t index = *start_opt; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-
-        if (ch == '[') {
-            ++depth;
-        } else if (ch == ']') {
-            --depth;
-            if (depth == 0) {
-                return content.substr(*start_opt, index - *start_opt + 1);
-            }
-        }
-    }
-
-    return std::nullopt;
-}
-
-std::vector<std::string> extract_json_objects_from_array(const std::string& array_content) {
-    std::vector<std::string> objects;
-    size_t index = 0;
-    while (index < array_content.size()) {
-        index = array_content.find('{', index);
-        if (index == std::string::npos) {
-            break;
-        }
-
-        const size_t start = index;
-        size_t depth = 0;
-        bool in_string = false;
-        bool escaping = false;
-        for (; index < array_content.size(); ++index) {
-            const char ch = array_content[index];
-            if (in_string) {
-                if (escaping) {
-                    escaping = false;
-                    continue;
-                }
-                if (ch == '\\') {
-                    escaping = true;
-                } else if (ch == '"') {
-                    in_string = false;
-                }
-                continue;
-            }
-
-            if (ch == '"') {
-                in_string = true;
-                continue;
-            }
-
-            if (ch == '{') {
-                ++depth;
-            } else if (ch == '}') {
-                --depth;
-                if (depth == 0) {
-                    objects.push_back(array_content.substr(start, index - start + 1));
-                    ++index;
-                    break;
-                }
-            }
-        }
-    }
-    return objects;
-}
-
 bool is_absolute_remote_url(std::string_view value) {
     return value.rfind("http://", 0) == 0 || value.rfind("https://", 0) == 0;
 }
 
 void push_candidate_server_url(std::vector<std::string>& urls, std::string url) {
-    url = auth::normalize_server_url(trim(url));
+    url = auth::normalize_server_url(json::trim(url));
     if (url.empty()) {
         return;
     }
@@ -582,9 +359,9 @@ http_response send_request(const std::string&, const std::string&) {
 #endif
 
 std::optional<remote_song_payload> parse_remote_song(const std::string& object) {
-    const auto id = extract_json_string(object, "id");
-    const auto title = extract_json_string(object, "title");
-    const auto artist = extract_json_string(object, "artist");
+    const auto id = json::extract_string(object, "id");
+    const auto title = json::extract_string(object, "title");
+    const auto artist = json::extract_string(object, "artist");
     if (!id.has_value() || !title.has_value() || !artist.has_value()) {
         return std::nullopt;
     }
@@ -593,20 +370,20 @@ std::optional<remote_song_payload> parse_remote_song(const std::string& object) 
         .id = *id,
         .title = *title,
         .artist = *artist,
-        .base_bpm = extract_json_float(object, "baseBpm").value_or(0.0f),
-        .duration_seconds = extract_json_float(object, "durationSec").value_or(0.0f),
-        .preview_start_ms = extract_json_int(object, "previewStartMs").value_or(0),
-        .song_version = extract_json_int(object, "songVersion").value_or(0),
-        .content_source = extract_json_string(object, "contentSource").value_or("community"),
-        .audio_url = extract_json_string(object, "audioUrl").value_or(""),
-        .jacket_url = extract_json_string(object, "jacketUrl").value_or(""),
+        .base_bpm = json::extract_float(object, "baseBpm").value_or(0.0f),
+        .duration_seconds = json::extract_float(object, "durationSec").value_or(0.0f),
+        .preview_start_ms = json::extract_int(object, "previewStartMs").value_or(0),
+        .song_version = json::extract_int(object, "songVersion").value_or(0),
+        .content_source = json::extract_string(object, "contentSource").value_or("community"),
+        .audio_url = json::extract_string(object, "audioUrl").value_or(""),
+        .jacket_url = json::extract_string(object, "jacketUrl").value_or(""),
     };
 }
 
 std::optional<remote_chart_payload> parse_remote_chart(const std::string& object) {
-    const auto id = extract_json_string(object, "id");
-    const auto song_id = extract_json_string(object, "songId");
-    const auto difficulty_name = extract_json_string(object, "difficultyName");
+    const auto id = json::extract_string(object, "id");
+    const auto song_id = json::extract_string(object, "songId");
+    const auto difficulty_name = json::extract_string(object, "difficultyName");
     if (!id.has_value() || !song_id.has_value() || !difficulty_name.has_value()) {
         return std::nullopt;
     }
@@ -614,14 +391,14 @@ std::optional<remote_chart_payload> parse_remote_chart(const std::string& object
     return remote_chart_payload{
         .id = *id,
         .song_id = *song_id,
-        .key_count = extract_json_int(object, "keyCount").value_or(4),
+        .key_count = json::extract_int(object, "keyCount").value_or(4),
         .difficulty_name = *difficulty_name,
-        .level = extract_json_float(object, "level").value_or(0.0f),
-        .chart_author = extract_json_string(object, "chartAuthor").value_or(""),
-        .format_version = extract_json_int(object, "formatVersion").value_or(0),
-        .resolution = extract_json_int(object, "resolution").value_or(0),
-        .offset = extract_json_int(object, "offset").value_or(0),
-        .content_source = extract_json_string(object, "contentSource").value_or("community"),
+        .level = json::extract_float(object, "level").value_or(0.0f),
+        .chart_author = json::extract_string(object, "chartAuthor").value_or(""),
+        .format_version = json::extract_int(object, "formatVersion").value_or(0),
+        .resolution = json::extract_int(object, "resolution").value_or(0),
+        .offset = json::extract_int(object, "offset").value_or(0),
+        .content_source = json::extract_string(object, "contentSource").value_or("community"),
     };
 }
 
@@ -642,13 +419,13 @@ remote_song_fetch_result fetch_remote_songs(const std::string& server_url) {
             return result;
         }
 
-        const std::optional<std::string> items_array = extract_json_array(response.body, "items");
+        const std::optional<std::string> items_array = json::extract_array(response.body, "items");
         if (!items_array.has_value()) {
             result.error_message = "raythm-Server returned an unexpected song catalog response.";
             return result;
         }
 
-        const std::vector<std::string> objects = extract_json_objects_from_array(*items_array);
+        const std::vector<std::string> objects = json::extract_objects_from_array(*items_array);
         for (const std::string& object : objects) {
             const auto song = parse_remote_song(object);
             if (song.has_value()) {
@@ -656,7 +433,7 @@ remote_song_fetch_result fetch_remote_songs(const std::string& server_url) {
             }
         }
 
-        total = extract_json_int(response.body, "total").value_or(static_cast<int>(result.songs.size()));
+        total = json::extract_int(response.body, "total").value_or(static_cast<int>(result.songs.size()));
         if (result.songs.empty() || static_cast<int>(result.songs.size()) >= total ||
             static_cast<int>(objects.size()) < kRemotePageSize) {
             break;
@@ -688,13 +465,13 @@ remote_song_page_fetch_result fetch_remote_song_page_from_server(const std::stri
         return result;
     }
 
-    const std::optional<std::string> items_array = extract_json_array(response.body, "items");
+    const std::optional<std::string> items_array = json::extract_array(response.body, "items");
     if (!items_array.has_value()) {
         result.error_message = "raythm-Server returned an unexpected song catalog response.";
         return result;
     }
 
-    const std::vector<std::string> objects = extract_json_objects_from_array(*items_array);
+    const std::vector<std::string> objects = json::extract_objects_from_array(*items_array);
     for (const std::string& object : objects) {
         const auto song = parse_remote_song(object);
         if (song.has_value()) {
@@ -702,7 +479,7 @@ remote_song_page_fetch_result fetch_remote_song_page_from_server(const std::stri
         }
     }
 
-    result.total = extract_json_int(response.body, "total").value_or(static_cast<int>(result.songs.size()));
+    result.total = json::extract_int(response.body, "total").value_or(static_cast<int>(result.songs.size()));
     result.success = true;
     return result;
 }
@@ -724,13 +501,13 @@ remote_chart_fetch_result fetch_remote_charts(const std::string& server_url) {
             return result;
         }
 
-        const std::optional<std::string> items_array = extract_json_array(response.body, "items");
+        const std::optional<std::string> items_array = json::extract_array(response.body, "items");
         if (!items_array.has_value()) {
             result.error_message = "raythm-Server returned an unexpected chart catalog response.";
             return result;
         }
 
-        const std::vector<std::string> objects = extract_json_objects_from_array(*items_array);
+        const std::vector<std::string> objects = json::extract_objects_from_array(*items_array);
         for (const std::string& object : objects) {
             const auto chart = parse_remote_chart(object);
             if (chart.has_value()) {
@@ -738,7 +515,7 @@ remote_chart_fetch_result fetch_remote_charts(const std::string& server_url) {
             }
         }
 
-        total = extract_json_int(response.body, "total").value_or(static_cast<int>(result.charts.size()));
+        total = json::extract_int(response.body, "total").value_or(static_cast<int>(result.charts.size()));
         if (result.charts.empty() || static_cast<int>(result.charts.size()) >= total ||
             static_cast<int>(objects.size()) < kRemotePageSize) {
             break;
@@ -771,13 +548,13 @@ remote_chart_page_fetch_result fetch_remote_chart_page_from_server(const std::st
         return result;
     }
 
-    const std::optional<std::string> items_array = extract_json_array(response.body, "items");
+    const std::optional<std::string> items_array = json::extract_array(response.body, "items");
     if (!items_array.has_value()) {
         result.error_message = "raythm-Server returned an unexpected chart catalog response.";
         return result;
     }
 
-    const std::vector<std::string> objects = extract_json_objects_from_array(*items_array);
+    const std::vector<std::string> objects = json::extract_objects_from_array(*items_array);
     for (const std::string& object : objects) {
         const auto chart = parse_remote_chart(object);
         if (chart.has_value()) {
@@ -785,7 +562,7 @@ remote_chart_page_fetch_result fetch_remote_chart_page_from_server(const std::st
         }
     }
 
-    result.total = extract_json_int(response.body, "total").value_or(static_cast<int>(result.charts.size()));
+    result.total = json::extract_int(response.body, "total").value_or(static_cast<int>(result.charts.size()));
     result.success = true;
     return result;
 }
@@ -810,52 +587,20 @@ remote_song_lookup_result fetch_remote_song_by_id_from_server(const std::string&
         return result;
     }
 
-    const auto start = find_value_start(response.body, "song");
-    if (!start.has_value() || response.body[*start] != '{') {
+    const auto song_object = json::extract_object(response.body, "song");
+    if (!song_object.has_value()) {
         result.error_message = "raythm-Server returned an unexpected song detail response.";
         return result;
     }
 
-    size_t depth = 0;
-    bool in_string = false;
-    bool escaping = false;
-    for (size_t index = *start; index < response.body.size(); ++index) {
-        const char ch = response.body[index];
-        if (in_string) {
-            if (escaping) {
-                escaping = false;
-                continue;
-            }
-            if (ch == '\\') {
-                escaping = true;
-            } else if (ch == '"') {
-                in_string = false;
-            }
-            continue;
-        }
-
-        if (ch == '"') {
-            in_string = true;
-            continue;
-        }
-        if (ch == '{') {
-            ++depth;
-        } else if (ch == '}') {
-            --depth;
-            if (depth == 0) {
-                const auto song = parse_remote_song(response.body.substr(*start, index - *start + 1));
-                if (!song.has_value()) {
-                    result.error_message = "raythm-Server returned an unexpected song detail response.";
-                    return result;
-                }
-                result.song = *song;
-                result.success = true;
-                return result;
-            }
-        }
+    const auto song = parse_remote_song(*song_object);
+    if (!song.has_value()) {
+        result.error_message = "raythm-Server returned an unexpected song detail response.";
+        return result;
     }
 
-    result.error_message = "raythm-Server returned an unexpected song detail response.";
+    result.song = *song;
+    result.success = true;
     return result;
 }
 

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -7,7 +7,6 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
-#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -16,6 +15,7 @@
 #include <vector>
 
 #include "app_paths.h"
+#include "network/json_helpers.h"
 #include "path_utils.h"
 #include "song_loader.h"
 #include "title/online_download_remote_client.h"
@@ -23,6 +23,7 @@
 
 namespace title_online_view {
 namespace {
+namespace json = network::json;
 
 struct staged_chart_file {
     std::string chart_id;
@@ -41,74 +42,6 @@ std::string trim_ascii(std::string_view value) {
     }
 
     return std::string(value.substr(start, end - start));
-}
-
-std::optional<size_t> find_json_key(const std::string& content, const std::string& key) {
-    const std::string token = "\"" + key + "\"";
-    const size_t key_pos = content.find(token);
-    if (key_pos == std::string::npos) {
-        return std::nullopt;
-    }
-    return key_pos + token.size();
-}
-
-std::optional<size_t> find_value_start(const std::string& content, const std::string& key) {
-    const auto key_end = find_json_key(content, key);
-    if (!key_end.has_value()) {
-        return std::nullopt;
-    }
-
-    const size_t colon_pos = content.find(':', *key_end);
-    if (colon_pos == std::string::npos) {
-        return std::nullopt;
-    }
-
-    size_t start = colon_pos + 1;
-    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
-        ++start;
-    }
-
-    if (start >= content.size()) {
-        return std::nullopt;
-    }
-
-    return start;
-}
-
-std::optional<std::string> extract_json_string(const std::string& content, const std::string& key) {
-    const auto start_opt = find_value_start(content, key);
-    if (!start_opt.has_value() || content[*start_opt] != '"') {
-        return std::nullopt;
-    }
-
-    std::string result;
-    bool escaping = false;
-    for (size_t index = *start_opt + 1; index < content.size(); ++index) {
-        const char ch = content[index];
-        if (escaping) {
-            switch (ch) {
-                case 'n': result += '\n'; break;
-                case 'r': result += '\r'; break;
-                case 't': result += '\t'; break;
-                default: result += ch; break;
-            }
-            escaping = false;
-            continue;
-        }
-
-        if (ch == '\\') {
-            escaping = true;
-            continue;
-        }
-
-        if (ch == '"') {
-            return result;
-        }
-
-        result += ch;
-    }
-
-    return std::nullopt;
 }
 
 bool write_binary_file(const std::filesystem::path& path,
@@ -242,8 +175,8 @@ download_song_result download_song_package(const song_entry_state song,
     finish_step();
 
     const std::string metadata_json(metadata_fetch.bytes.begin(), metadata_fetch.bytes.end());
-    const std::string audio_file = trim_ascii(extract_json_string(metadata_json, "audioFile").value_or(""));
-    const std::string jacket_file = trim_ascii(extract_json_string(metadata_json, "jacketFile").value_or(""));
+    const std::string audio_file = trim_ascii(json::extract_string(metadata_json, "audioFile").value_or(""));
+    const std::string jacket_file = trim_ascii(json::extract_string(metadata_json, "jacketFile").value_or(""));
     if (audio_file.empty()) {
         result.message = "Downloaded song metadata did not include audioFile.";
         return result;

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -3,12 +3,15 @@
 #include <algorithm>
 #include <chrono>
 #include <cctype>
+#include <exception>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -366,9 +369,15 @@ void start_download(state& state) {
     state.download_progress = std::make_shared<download_progress_state>();
     ui::push_notice(state.notices, "Downloading song...", ui::notice_tone::info, 1.8f);
     const std::shared_ptr<download_progress_state> progress = state.download_progress;
-    state.download_future = std::async(std::launch::async, [selected, server_url, progress]() {
-        return download_song_package(selected, server_url, progress);
-    });
+    std::promise<download_song_result> promise;
+    state.download_future = promise.get_future();
+    std::thread([promise = std::move(promise), selected, server_url, progress]() mutable {
+        try {
+            promise.set_value(download_song_package(selected, server_url, progress));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 bool poll_download(state& state) {
@@ -379,7 +388,16 @@ bool poll_download(state& state) {
         return false;
     }
 
-    download_song_result result = state.download_future.get();
+    download_song_result result;
+    try {
+        result = state.download_future.get();
+    } catch (const std::exception& ex) {
+        result.success = false;
+        result.message = ex.what();
+    } catch (...) {
+        result.success = false;
+        result.message = "Song download failed.";
+    }
     state.download_in_progress = false;
     state.download_progress.reset();
 

--- a/src/scenes/title/play_session_controller.cpp
+++ b/src/scenes/title/play_session_controller.cpp
@@ -1,42 +1,11 @@
 #include "title/play_session_controller.h"
 
-#include <string>
-
-#include "ranking_service.h"
-#include "song_select/song_catalog_service.h"
 #include "song_select/song_select_navigation.h"
 
 namespace title_play_session {
 
-void warm_scoring_ruleset() {
-    ranking_service::warm_scoring_ruleset_cache(false);
-}
-
-void reload_catalog(song_select::state& state,
-                    song_select::preview_controller& preview_controller,
-                    const std::string& preferred_song_id,
-                    const std::string& preferred_chart_id,
-                    bool sync_media_now) {
-    song_select::apply_catalog(state, song_select::load_catalog(), preferred_song_id, preferred_chart_id);
-    if (sync_media_now) {
-        sync_media(state, preview_controller);
-    }
-}
-
-void sync_media(song_select::state& state, song_select::preview_controller& preview_controller) {
+void sync_preview(song_select::state& state, song_select::preview_controller& preview_controller) {
     preview_controller.select_song(song_select::selected_song(state));
-    reload_ranking(state);
-}
-
-void reload_ranking(song_select::state& state) {
-    const auto filtered = song_select::filtered_charts_for_selected_song(state);
-    const song_select::chart_option* chart = song_select::selected_chart_for(state, filtered);
-    const std::string chart_id = chart != nullptr ? chart->meta.chart_id : "";
-    state.ranking_panel.listing =
-        ranking_service::load_chart_ranking(chart_id, state.ranking_panel.selected_source, 50);
-    state.ranking_panel.scroll_y = 0.0f;
-    state.ranking_panel.scroll_y_target = 0.0f;
-    state.ranking_panel.reveal_anim = 0.0f;
 }
 
 bool start_selected_chart(scene_manager& manager,
@@ -48,7 +17,6 @@ bool start_selected_chart(scene_manager& manager,
     if (song == nullptr || chart == nullptr) {
         return false;
     }
-    ranking_service::refresh_scoring_ruleset_cache_for_chart_start(chart->meta, true);
     preview_controller.stop();
     manager.change_scene(song_select::make_play_scene(manager, *song, *chart));
     return true;

--- a/src/scenes/title/play_session_controller.h
+++ b/src/scenes/title/play_session_controller.h
@@ -1,23 +1,12 @@
 #pragma once
 
-#include <optional>
-#include <string>
-
 #include "scene_manager.h"
 #include "song_select/song_preview_controller.h"
 #include "song_select/song_select_state.h"
 
 namespace title_play_session {
 
-void reload_catalog(song_select::state& state,
-                    song_select::preview_controller& preview_controller,
-                    const std::string& preferred_song_id = "",
-                    const std::string& preferred_chart_id = "",
-                    bool sync_media_now = false);
-void warm_scoring_ruleset();
-
-void sync_media(song_select::state& state, song_select::preview_controller& preview_controller);
-void reload_ranking(song_select::state& state);
+void sync_preview(song_select::state& state, song_select::preview_controller& preview_controller);
 bool start_selected_chart(scene_manager& manager,
                           song_select::state& state,
                           song_select::preview_controller& preview_controller);

--- a/src/scenes/title/seamless_song_select_view.cpp
+++ b/src/scenes/title/seamless_song_select_view.cpp
@@ -31,8 +31,8 @@ constexpr Rectangle kPlayRankingHeaderRect = {878.0f, 102.0f, 338.0f, 36.0f};
 constexpr Rectangle kPlayRankingSourceLocalRect = {1034.0f, 98.0f, 86.0f, 34.0f};
 constexpr Rectangle kPlayRankingSourceOnlineRect = {1126.0f, 98.0f, 90.0f, 34.0f};
 constexpr Rectangle kPlayRankingListRect = {878.0f, 150.0f, 338.0f, 468.0f};
-constexpr float kCreateToolButtonHeight = 54.0f;
-constexpr float kCreateToolButtonGap = 12.0f;
+constexpr float kCreateToolButtonHeight = 48.0f;
+constexpr float kCreateToolButtonGap = 8.0f;
 constexpr int kPlaySongContextMenuItemCount = 1;
 
 Rectangle delete_song_menu_item_rect(Rectangle menu_rect) {
@@ -182,13 +182,17 @@ update_result update(song_select::state& state, mode view_mode, float anim_t, Re
             {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 3.0f, list_rect.width, kCreateToolButtonHeight},
             {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 4.0f, list_rect.width, kCreateToolButtonHeight},
             {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 5.0f, list_rect.width, kCreateToolButtonHeight},
+            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 6.0f, list_rect.width, kCreateToolButtonHeight},
+            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 7.0f, list_rect.width, kCreateToolButtonHeight},
         };
         if (CheckCollisionPointRec(mouse, tools[0])) { result.create_song_requested = true; return result; }
         if (CheckCollisionPointRec(mouse, tools[1])) { result.edit_song_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[2])) { result.create_chart_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[3])) { result.edit_chart_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[4])) { result.edit_mv_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[5])) { result.manage_library_requested = true; return result; }
+        if (CheckCollisionPointRec(mouse, tools[2])) { result.upload_song_requested = true; return result; }
+        if (CheckCollisionPointRec(mouse, tools[3])) { result.create_chart_requested = true; return result; }
+        if (CheckCollisionPointRec(mouse, tools[4])) { result.edit_chart_requested = true; return result; }
+        if (CheckCollisionPointRec(mouse, tools[5])) { result.upload_chart_requested = true; return result; }
+        if (CheckCollisionPointRec(mouse, tools[6])) { result.edit_mv_requested = true; return result; }
+        if (CheckCollisionPointRec(mouse, tools[7])) { result.manage_library_requested = true; return result; }
     }
 
     if (left_pressed) {
@@ -394,12 +398,14 @@ void draw(const song_select::state& state,
         const struct tool_entry { const char* title; const char* detail; } entries[] = {
             {"NEW SONG", "Start a new song package."},
             {"EDIT SONG", "Edit selected song metadata."},
+            {"UPLOAD SONG", "Publish selected song to Community."},
             {"NEW CHART", "Open editor for a new chart."},
             {"EDIT CHART", "Open selected chart in editor."},
+            {"UPLOAD CHART", "Publish selected chart to Community."},
             {"MV EDITOR", "Open MV editor for song."},
             {"MANAGE", "Import / export with legacy tools."},
         };
-        for (int i = 0; i < 6; ++i) {
+        for (int i = 0; i < 8; ++i) {
             const Rectangle rect = {
                 current.ranking_list_rect.x,
                 current.ranking_list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * static_cast<float>(i),
@@ -411,10 +417,10 @@ void draw(const song_select::state& state,
             DrawRectangleRec(rect, with_alpha(button_base, row_alpha));
             DrawRectangleLinesEx(rect, 1.2f, with_alpha(t.border, row_alpha));
             ui::draw_text_in_rect(entries[i].title, 18,
-                                  {rect.x + 14.0f, rect.y + 8.0f, rect.width - 28.0f, 20.0f},
+                                  {rect.x + 14.0f, rect.y + 6.0f, rect.width - 28.0f, 20.0f},
                                   with_alpha(t.text, alpha), ui::text_align::left);
             ui::draw_text_in_rect(entries[i].detail, 12,
-                                  {rect.x + 14.0f, rect.y + 30.0f, rect.width - 28.0f, 16.0f},
+                                  {rect.x + 14.0f, rect.y + 26.0f, rect.width - 28.0f, 16.0f},
                                   with_alpha(t.text_muted, alpha), ui::text_align::left);
         }
     }

--- a/src/scenes/title/seamless_song_select_view.h
+++ b/src/scenes/title/seamless_song_select_view.h
@@ -35,8 +35,10 @@ struct update_result {
     bool delete_song_requested = false;
     bool create_song_requested = false;
     bool edit_song_requested = false;
+    bool upload_song_requested = false;
     bool create_chart_requested = false;
     bool edit_chart_requested = false;
+    bool upload_chart_requested = false;
     bool edit_mv_requested = false;
     bool manage_library_requested = false;
 };

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -5,6 +5,7 @@
 #include <chrono>
 #include <cstdio>
 #include <ctime>
+#include <exception>
 #include <future>
 #include <memory>
 #include <string>
@@ -150,7 +151,7 @@ void title_scene::enter_play_mode() {
     mode_ = hub_mode::play;
     home_status_message_.clear();
     play_entry_origin_rect_ = title_home_view::button_rect(home_menu_selected_index_, home_menu_anim_);
-    title_play_session::sync_media(play_state_, audio_controller_.preview());
+    sync_play_media();
     audio_controller_.update(current_audio_mode(), selected_audio_song(mode_, play_state_, online_state_), 0.0f);
 }
 
@@ -166,7 +167,7 @@ void title_scene::enter_create_mode() {
     mode_ = hub_mode::create;
     home_status_message_.clear();
     play_entry_origin_rect_ = title_home_view::button_rect(home_menu_selected_index_, home_menu_anim_);
-    title_play_session::sync_media(play_state_, audio_controller_.preview());
+    title_play_session::sync_preview(play_state_, audio_controller_.preview());
     audio_controller_.update(current_audio_mode(), selected_audio_song(mode_, play_state_, online_state_), 0.0f);
 }
 
@@ -215,10 +216,11 @@ void title_scene::poll_play_catalog_reload() {
         play_state_.load_errors = {ex.what()};
     }
     play_catalog_loading_ = false;
-    const bool should_sync_media =
-        play_catalog_sync_media_on_apply_ || mode_ == hub_mode::play || mode_ == hub_mode::create;
+    const bool should_sync_media = play_catalog_sync_media_on_apply_ || mode_ == hub_mode::play;
     if (should_sync_media) {
-        title_play_session::sync_media(play_state_, audio_controller_.preview());
+        sync_play_media();
+    } else if (mode_ == hub_mode::create) {
+        title_play_session::sync_preview(play_state_, audio_controller_.preview());
     }
     play_catalog_sync_media_on_apply_ = false;
 
@@ -235,6 +237,118 @@ void title_scene::poll_play_catalog_reload() {
     queued_play_catalog_sync_media_on_apply_ = false;
 }
 
+void title_scene::sync_play_media() {
+    title_play_session::sync_preview(play_state_, audio_controller_.preview());
+    request_play_ranking_reload();
+}
+
+void title_scene::request_play_ranking_reload() {
+    if (play_ranking_loading_) {
+        ++play_ranking_generation_;
+        play_ranking_reload_pending_ = true;
+        if (play_state_.ranking_panel.selected_source == ranking_service::source::online) {
+            play_state_.ranking_panel.listing = {};
+            play_state_.ranking_panel.listing.ranking_source = play_state_.ranking_panel.selected_source;
+            play_state_.ranking_panel.listing.available = false;
+            play_state_.ranking_panel.listing.message = "Loading online rankings...";
+        }
+        return;
+    }
+
+    const auto filtered = song_select::filtered_charts_for_selected_song(play_state_);
+    const song_select::chart_option* chart = song_select::selected_chart_for(play_state_, filtered);
+    const std::string chart_id = chart != nullptr ? chart->meta.chart_id : "";
+    const ranking_service::source source = play_state_.ranking_panel.selected_source;
+
+    ++play_ranking_generation_;
+    play_ranking_pending_generation_ = play_ranking_generation_;
+    play_state_.ranking_panel.source_dropdown_open = false;
+    play_state_.ranking_panel.scroll_y = 0.0f;
+    play_state_.ranking_panel.scroll_y_target = 0.0f;
+    play_state_.ranking_panel.scrollbar_dragging = false;
+    play_state_.ranking_panel.scrollbar_drag_offset = 0.0f;
+
+    if (source == ranking_service::source::online) {
+        play_state_.ranking_panel.listing = {};
+        play_state_.ranking_panel.listing.ranking_source = source;
+        play_state_.ranking_panel.listing.available = false;
+        play_state_.ranking_panel.listing.message = "Loading online rankings...";
+    }
+
+    play_ranking_loading_ = true;
+    std::promise<ranking_service::listing> promise;
+    play_ranking_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), chart_id, source]() mutable {
+        try {
+            promise.set_value(ranking_service::load_chart_ranking(chart_id, source, 50));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+void title_scene::poll_play_ranking_reload() {
+    if (!play_ranking_loading_) {
+        return;
+    }
+    if (play_ranking_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    ranking_service::listing listing;
+    try {
+        listing = play_ranking_future_.get();
+    } catch (const std::exception& ex) {
+        listing.available = false;
+        listing.message = ex.what();
+        listing.ranking_source = play_state_.ranking_panel.selected_source;
+    }
+    play_ranking_loading_ = false;
+    const bool stale = play_ranking_pending_generation_ != play_ranking_generation_;
+    if (!stale) {
+        play_state_.ranking_panel.listing = std::move(listing);
+        play_state_.ranking_panel.reveal_anim = 0.0f;
+    }
+
+    if (play_ranking_reload_pending_) {
+        play_ranking_reload_pending_ = false;
+        request_play_ranking_reload();
+        return;
+    }
+}
+
+void title_scene::request_scoring_ruleset_warm(bool force_refresh) {
+    if (scoring_ruleset_loading_) {
+        return;
+    }
+
+    scoring_ruleset_loading_ = true;
+    std::promise<bool> promise;
+    scoring_ruleset_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), force_refresh]() mutable {
+        try {
+            promise.set_value(ranking_service::warm_scoring_ruleset_cache(force_refresh));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+void title_scene::poll_scoring_ruleset_warm() {
+    if (!scoring_ruleset_loading_) {
+        return;
+    }
+    if (scoring_ruleset_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    try {
+        scoring_ruleset_future_.get();
+    } catch (...) {
+    }
+    scoring_ruleset_loading_ = false;
+}
+
 void title_scene::start_song_upload(const song_select::song_entry& song) {
     if (create_upload_in_progress_) {
         ui::push_notice(play_state_.notices, "Upload already in progress.", ui::notice_tone::info, 1.8f);
@@ -243,9 +357,15 @@ void title_scene::start_song_upload(const song_select::song_entry& song) {
 
     create_upload_in_progress_ = true;
     ui::push_notice(play_state_.notices, "Uploading song...", ui::notice_tone::info, 1.8f);
-    create_upload_future_ = std::async(std::launch::async, [song]() {
-        return title_create_upload::upload_song(song);
-    });
+    std::promise<title_create_upload::upload_result> promise;
+    create_upload_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), song]() mutable {
+        try {
+            promise.set_value(title_create_upload::upload_song(song));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 void title_scene::start_chart_upload(const song_select::song_entry& song,
@@ -257,9 +377,15 @@ void title_scene::start_chart_upload(const song_select::song_entry& song,
 
     create_upload_in_progress_ = true;
     ui::push_notice(play_state_.notices, "Uploading chart...", ui::notice_tone::info, 1.8f);
-    create_upload_future_ = std::async(std::launch::async, [song, chart]() {
-        return title_create_upload::upload_chart(song, chart);
-    });
+    std::promise<title_create_upload::upload_result> promise;
+    create_upload_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), song, chart]() mutable {
+        try {
+            promise.set_value(title_create_upload::upload_chart(song, chart));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
 }
 
 void title_scene::poll_create_upload() {
@@ -270,7 +396,16 @@ void title_scene::poll_create_upload() {
         return;
     }
 
-    const title_create_upload::upload_result result = create_upload_future_.get();
+    title_create_upload::upload_result result;
+    try {
+        result = create_upload_future_.get();
+    } catch (const std::exception& ex) {
+        result.success = false;
+        result.message = ex.what();
+    } catch (...) {
+        result.success = false;
+        result.message = "Upload failed.";
+    }
     create_upload_in_progress_ = false;
     song_select::queue_status_message(play_state_, result.message, !result.success);
     if (result.success && result.should_refresh_online_catalog) {
@@ -313,11 +448,11 @@ void title_scene::update_play_mode(float dt) {
         return;
     }
     if (result.song_selection_changed) {
-        title_play_session::sync_media(play_state_, audio_controller_.preview());
+        sync_play_media();
         return;
     }
     if (result.chart_selection_changed || result.ranking_source_changed) {
-        title_play_session::reload_ranking(play_state_);
+        request_play_ranking_reload();
         return;
     }
 }
@@ -340,7 +475,7 @@ void title_scene::update_create_mode(float dt) {
         return;
     }
     if (result.song_selection_changed) {
-        title_play_session::sync_media(play_state_, audio_controller_.preview());
+        title_play_session::sync_preview(play_state_, audio_controller_.preview());
         return;
     }
     if (result.chart_selection_changed) {
@@ -441,6 +576,8 @@ void title_scene::update_common_animation(float dt) {
     auth_overlay::poll_restore(auth_controller_, play_state_.auth, play_state_.login_dialog);
     auth_overlay::poll_request(auth_controller_, play_state_.auth, play_state_.login_dialog);
     poll_play_catalog_reload();
+    poll_play_ranking_reload();
+    poll_scoring_ruleset_warm();
     poll_create_upload();
     title_online_view::poll_song_page(online_state_);
     title_online_view::poll_chart_page(online_state_);
@@ -631,6 +768,10 @@ void title_scene::on_enter() {
     audio_controller_.on_enter();
     song_select::reset_for_enter(play_state_);
     play_catalog_loading_ = false;
+    play_ranking_loading_ = false;
+    play_ranking_reload_pending_ = false;
+    play_ranking_generation_ = 0;
+    play_ranking_pending_generation_ = 0;
     play_catalog_reload_pending_ = false;
     play_catalog_sync_media_on_apply_ = false;
     queued_play_catalog_sync_media_on_apply_ = false;
@@ -640,7 +781,8 @@ void title_scene::on_enter() {
     queued_play_catalog_chart_id_.clear();
     play_state_.ranking_panel.selected_source = ranking_service::source::local;
     auth_overlay::refresh_auth_state(play_state_.auth);
-    title_play_session::warm_scoring_ruleset();
+    scoring_ruleset_loading_ = false;
+    request_scoring_ruleset_warm(false);
     play_state_.recent_result_offset = recent_result_offset_;
     if (play_intro_fade_) {
         intro_fade_.restart(scene_fade::direction::in, 1.0f, 1.0f);

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -26,6 +26,7 @@
 #include "title/title_layout.h"
 #include "title/seamless_song_select_view.h"
 #include "theme.h"
+#include "ui_notice.h"
 #include "ui_clip.h"
 #include "ui_draw.h"
 #include "virtual_screen.h"
@@ -234,6 +235,49 @@ void title_scene::poll_play_catalog_reload() {
     queued_play_catalog_sync_media_on_apply_ = false;
 }
 
+void title_scene::start_song_upload(const song_select::song_entry& song) {
+    if (create_upload_in_progress_) {
+        ui::push_notice(play_state_.notices, "Upload already in progress.", ui::notice_tone::info, 1.8f);
+        return;
+    }
+
+    create_upload_in_progress_ = true;
+    ui::push_notice(play_state_.notices, "Uploading song...", ui::notice_tone::info, 1.8f);
+    create_upload_future_ = std::async(std::launch::async, [song]() {
+        return title_create_upload::upload_song(song);
+    });
+}
+
+void title_scene::start_chart_upload(const song_select::song_entry& song,
+                                     const song_select::chart_option& chart) {
+    if (create_upload_in_progress_) {
+        ui::push_notice(play_state_.notices, "Upload already in progress.", ui::notice_tone::info, 1.8f);
+        return;
+    }
+
+    create_upload_in_progress_ = true;
+    ui::push_notice(play_state_.notices, "Uploading chart...", ui::notice_tone::info, 1.8f);
+    create_upload_future_ = std::async(std::launch::async, [song, chart]() {
+        return title_create_upload::upload_chart(song, chart);
+    });
+}
+
+void title_scene::poll_create_upload() {
+    if (!create_upload_in_progress_) {
+        return;
+    }
+    if (create_upload_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    const title_create_upload::upload_result result = create_upload_future_.get();
+    create_upload_in_progress_ = false;
+    song_select::queue_status_message(play_state_, result.message, !result.success);
+    if (result.success && result.should_refresh_online_catalog) {
+        title_online_view::reload_catalog(online_state_);
+    }
+}
+
 void title_scene::apply_play_delete_result(const song_select::delete_result& result) {
     play_state_.confirmation_dialog = {};
     if (!result.success) {
@@ -281,6 +325,15 @@ void title_scene::update_play_mode(float dt) {
 void title_scene::update_create_mode(float dt) {
     const title_play_view::update_result result =
         title_play_view::update(play_state_, title_play_view::mode::create, play_view_anim_, play_entry_origin_rect_, dt);
+    const bool create_action_requested =
+        result.create_song_requested ||
+        result.edit_song_requested ||
+        result.upload_song_requested ||
+        result.create_chart_requested ||
+        result.edit_chart_requested ||
+        result.upload_chart_requested ||
+        result.edit_mv_requested ||
+        result.manage_library_requested;
 
     if (result.back_requested) {
         enter_home_mode(false);
@@ -291,6 +344,10 @@ void title_scene::update_create_mode(float dt) {
         return;
     }
     if (result.chart_selection_changed) {
+        return;
+    }
+    if (create_upload_in_progress_ && create_action_requested) {
+        ui::push_notice(play_state_.notices, "Wait for the current upload to finish.", ui::notice_tone::info, 1.8f);
         return;
     }
 
@@ -306,12 +363,28 @@ void title_scene::update_create_mode(float dt) {
         manager_.change_scene(song_select::make_edit_song_scene(manager_, *song));
         return;
     }
+    if (result.upload_song_requested) {
+        if (song == nullptr) {
+            song_select::queue_status_message(play_state_, "Select a song to upload.", true);
+        } else {
+            start_song_upload(*song);
+        }
+        return;
+    }
     if (result.create_chart_requested && song != nullptr) {
         manager_.change_scene(song_select::make_new_chart_scene(manager_, *song, play_state_.difficulty_index));
         return;
     }
     if (result.edit_chart_requested && song != nullptr && chart != nullptr) {
         manager_.change_scene(song_select::make_edit_chart_scene(manager_, *song, *chart));
+        return;
+    }
+    if (result.upload_chart_requested) {
+        if (song == nullptr || chart == nullptr) {
+            song_select::queue_status_message(play_state_, "Select a chart to upload.", true);
+        } else {
+            start_chart_upload(*song, *chart);
+        }
         return;
     }
     if (result.edit_mv_requested && song != nullptr) {
@@ -368,6 +441,7 @@ void title_scene::update_common_animation(float dt) {
     auth_overlay::poll_restore(auth_controller_, play_state_.auth, play_state_.login_dialog);
     auth_overlay::poll_request(auth_controller_, play_state_.auth, play_state_.login_dialog);
     poll_play_catalog_reload();
+    poll_create_upload();
     title_online_view::poll_song_page(online_state_);
     title_online_view::poll_chart_page(online_state_);
     title_online_view::poll_owned(online_state_);

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "scene.h"
+#include "ranking_service.h"
 #include "shared/auth_overlay_controller.h"
 #include "song_select/song_catalog_service.h"
 #include "shared/scene_fade.h"
@@ -61,6 +62,11 @@ private:
                                      std::string preferred_chart_id = "",
                                      bool sync_media_on_apply = false);
     void poll_play_catalog_reload();
+    void sync_play_media();
+    void request_play_ranking_reload();
+    void poll_play_ranking_reload();
+    void request_scoring_ruleset_warm(bool force_refresh = false);
+    void poll_scoring_ruleset_warm();
     void start_song_upload(const song_select::song_entry& song);
     void start_chart_upload(const song_select::song_entry& song,
                             const song_select::chart_option& chart);
@@ -98,6 +104,13 @@ private:
     bool play_catalog_loading_ = false;
     std::future<title_create_upload::upload_result> create_upload_future_;
     bool create_upload_in_progress_ = false;
+    std::future<ranking_service::listing> play_ranking_future_;
+    bool play_ranking_loading_ = false;
+    bool play_ranking_reload_pending_ = false;
+    int play_ranking_generation_ = 0;
+    int play_ranking_pending_generation_ = 0;
+    std::future<bool> scoring_ruleset_future_;
+    bool scoring_ruleset_loading_ = false;
     bool play_catalog_reload_pending_ = false;
     bool play_catalog_sync_media_on_apply_ = false;
     bool queued_play_catalog_sync_media_on_apply_ = false;

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -5,6 +5,7 @@
 #include "song_select/song_catalog_service.h"
 #include "shared/scene_fade.h"
 #include "song_select/song_select_state.h"
+#include "title/create_upload_client.h"
 #include "title/online_download_view.h"
 #include "title/title_audio_controller.h"
 #include <future>
@@ -60,6 +61,10 @@ private:
                                      std::string preferred_chart_id = "",
                                      bool sync_media_on_apply = false);
     void poll_play_catalog_reload();
+    void start_song_upload(const song_select::song_entry& song);
+    void start_chart_upload(const song_select::song_entry& song,
+                            const song_select::chart_option& chart);
+    void poll_create_upload();
     void update_home_pointer_suppression();
     bool handle_title_input(bool left_click_for_home, bool right_click_for_home);
     bool handle_home_input();
@@ -91,6 +96,8 @@ private:
     song_select::state play_state_;
     std::future<song_select::catalog_data> play_catalog_future_;
     bool play_catalog_loading_ = false;
+    std::future<title_create_upload::upload_result> create_upload_future_;
+    bool create_upload_in_progress_ = false;
     bool play_catalog_reload_pending_ = false;
     bool play_catalog_sync_media_on_apply_ = false;
     bool queued_play_catalog_sync_media_on_apply_ = false;


### PR DESCRIPTION
## 概要
- オンラインカタログの閲覧・ダウンロード、所有ライブラリ、作成アップロードのクライアント処理を追加
- 認証、オンラインランキング/スコアリング、タイトル画面/曲選択UIの連携と関連する smoke テストを追加
- 重複していた軽量JSONパース/エスケープ処理を `network::json` ヘルパに共通化

## 確認したこと
- `cmake --build cmake-build-release --target ranking_service_smoke raythm`
- `cmake-build-release\ranking_service_smoke.exe`

## 補足
- DebugビルドはローカルのMinGW環境で `as: unknown option -- gdwarf-5` により、コード診断前に停止します。Releaseビルドは通っています。