### PR TITLE
すぐ直せるゲームプレイ/エディタ周りのIssueを修正

### DIFF
--- a/src/audio/audio_manager.cpp
+++ b/src/audio/audio_manager.cpp
@@ -175,11 +175,16 @@ bool audio_manager::load_bgm(const std::string& file_path) {
 }
 
 void audio_manager::play_bgm(bool restart) {
+    apply_bgm_volume();
     play_voice(bgm_handle_, restart);
 }
 
 void audio_manager::pause_bgm() {
     pause_voice(bgm_handle_);
+}
+
+void audio_manager::fade_out_bgm(unsigned int duration_ms) {
+    fade_out_voice(bgm_handle_, duration_ms);
 }
 
 void audio_manager::stop_bgm() {
@@ -508,6 +513,12 @@ void audio_manager::play_voice(unsigned long handle, bool restart) {
 void audio_manager::pause_voice(unsigned long handle) {
     if (handle != 0) {
         BASS_ChannelPause(handle);
+    }
+}
+
+void audio_manager::fade_out_voice(unsigned long handle, unsigned int duration_ms) {
+    if (handle != 0) {
+        BASS_ChannelSlideAttribute(handle, BASS_ATTRIB_VOL, 0.0f, duration_ms);
     }
 }
 

--- a/src/audio/audio_manager.h
+++ b/src/audio/audio_manager.h
@@ -29,6 +29,7 @@ public:
     bool load_bgm(const std::string& file_path);
     void play_bgm(bool restart = true);
     void pause_bgm();
+    void fade_out_bgm(unsigned int duration_ms);
     void stop_bgm();
     void set_bgm_volume(float volume);
     void seek_bgm(double seconds);
@@ -82,6 +83,7 @@ private:
     static audio_clock_snapshot get_voice_clock(unsigned long handle);
     static void play_voice(unsigned long handle, bool restart);
     static void pause_voice(unsigned long handle);
+    static void fade_out_voice(unsigned long handle, unsigned int duration_ms);
     static void stop_voice(unsigned long handle);
     static void set_voice_position_seconds(unsigned long handle, double seconds);
     static void free_voice(unsigned long& handle);

--- a/src/scenes/editor/view/editor_layout.h
+++ b/src/scenes/editor/view/editor_layout.h
@@ -21,6 +21,9 @@ inline constexpr Rectangle kRightPanelRect = ui::place(kScreenRect, 248.0f, 620.
 inline constexpr Rectangle kBackButtonRect = ui::place(kHeaderRect, 120.0f, 34.0f,
                                                        ui::anchor::center_left, ui::anchor::center_left,
                                                        {16.0f, 0.0f});
+inline constexpr Rectangle kSettingsButtonRect = ui::place(kHeaderRect, 128.0f, 34.0f,
+                                                           ui::anchor::center_left, ui::anchor::center_left,
+                                                           {150.0f, 0.0f});
 
 inline constexpr Rectangle kHeaderToolsRect = ui::place(kHeaderRect, 168.0f, 34.0f,
                                                         ui::anchor::center_right, ui::anchor::center_right,

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -22,6 +22,7 @@
 #include "play_scene.h"
 #include "scene_common.h"
 #include "scene_manager.h"
+#include "settings_scene.h"
 #include "song_select/song_select_navigation.h"
 #include "theme.h"
 #include "ui_clip.h"
@@ -145,6 +146,11 @@ void editor_scene::update(float dt) {
         return;
     }
 
+    if (!has_blocking_modal() && ui::is_clicked(layout::kSettingsButtonRect)) {
+        manager_.change_scene(std::make_unique<settings_scene>(manager_, song_, build_resume_state()));
+        return;
+    }
+
     const editor_shortcut_result shortcut_result = editor_runtime_controller::handle_shortcuts({
         *state_,
         make_sync_context(),
@@ -236,6 +242,7 @@ void editor_scene::draw() {
     ui::draw_panel(layout::kHeaderRect);
 
     ui::draw_button_colored(layout::kBackButtonRect, "BACK", 20, t.row, t.row_hover, t.text);
+    ui::draw_button_colored(layout::kSettingsButtonRect, "SETTINGS", 18, t.row, t.row_hover, t.text);
 
     const editor_left_panel_view_result left_panel = editor_left_panel_view::draw({
         song_.meta.title.c_str(),

--- a/src/scenes/play/play_flow_controller.cpp
+++ b/src/scenes/play/play_flow_controller.cpp
@@ -98,7 +98,9 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
 
     if (state.intro_playing) {
         state.intro_timer = std::max(0.0f, state.intro_timer - context.dt);
-        state.input_handler.update(state.current_ms);
+        if (!context.input_already_updated) {
+            state.input_handler.update(state.current_ms);
+        }
         if (context.draw_window.has_value()) {
             draw_queue.update_visible_window(state.judge_system.note_states(), static_cast<float>(state.lane_speed),
                                              context.draw_window->judgement_z, context.draw_window->lane_start_z,
@@ -116,7 +118,9 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
 
     const double advanced_ms = state.current_ms + static_cast<double>(context.dt) * 1000.0;
     state.current_ms = context.bgm_audio_time_ms.value_or(advanced_ms);
-    state.input_handler.update(state.current_ms);
+    if (!context.input_already_updated) {
+        state.input_handler.update(state.current_ms);
+    }
     state.judge_system.update(state.current_ms, state.input_handler);
     const std::vector<judge_event>& judge_events = state.judge_system.get_judge_events();
     state.last_judge = state.judge_system.get_last_judge();
@@ -165,7 +169,7 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
         state.final_result = state.score_system.get_result_data();
         state.result_transition_playing = true;
         state.result_transition_timer = 0.0f;
-        result.request_pause_bgm = true;
+        result.request_fade_out_bgm = true;
         return result;
     }
 
@@ -173,6 +177,7 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
         state.final_result = state.score_system.get_result_data();
         state.result_transition_playing = true;
         state.result_transition_timer = 0.0f;
+        result.request_fade_out_bgm = true;
     } else if (context.backspace_pressed) {
         result.navigation = {play_navigation_target::song_select};
     }

--- a/src/scenes/play/play_flow_controller.h
+++ b/src/scenes/play/play_flow_controller.h
@@ -15,6 +15,7 @@ struct play_update_context {
     bool window_focused = true;
     bool bgm_loaded = false;
     std::optional<double> bgm_audio_time_ms;
+    bool input_already_updated = false;
     bool pause_resume_clicked = false;
     bool pause_restart_clicked = false;
     bool pause_song_select_clicked = false;
@@ -26,6 +27,7 @@ struct play_update_result {
     play_navigation_request navigation;
     bool request_play_bgm = false;
     bool request_pause_bgm = false;
+    bool request_fade_out_bgm = false;
     int hitsound_count = 0;
 };
 

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -237,6 +237,9 @@ void play_scene::update(float dt) {
     if (result.request_pause_bgm) {
         audio_manager::instance().pause_bgm();
     }
+    if (result.request_fade_out_bgm) {
+        audio_manager::instance().fade_out_bgm(180);
+    }
     if (result.request_play_bgm && audio_manager::instance().is_bgm_loaded()) {
         audio_manager::instance().play_bgm(false);
     }

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -89,10 +89,10 @@ result_scene::result_scene(scene_manager& manager, result_data result, bool rank
 }
 
 void result_scene::on_enter() {
-    if (ranking_enabled_) {
-        const ranking_service::local_submit_result local_result =
-            ranking_service::submit_local_result_detailed(chart_, result_);
+    const ranking_service::local_submit_result local_result =
+        ranking_service::submit_local_result_detailed(chart_, result_);
 
+    if (ranking_enabled_) {
         if (ranking_service::should_attempt_online_submit(local_result)) {
             online_submit_status_message_ = "Submitting online ranking...";
             online_submit_status_is_error_ = false;

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -1,7 +1,9 @@
 #include "settings_scene.h"
 
 #include <memory>
+#include <utility>
 
+#include "editor_scene.h"
 #include "raylib.h"
 #include "scene_manager.h"
 #include "settings_io.h"
@@ -18,6 +20,12 @@ settings_scene::settings_scene(scene_manager& manager, return_target target)
       audio_page_(g_settings, runtime_applier_),
       video_page_(g_settings, runtime_applier_),
       key_config_page_(g_settings) {
+}
+
+settings_scene::settings_scene(scene_manager& manager, song_data editor_song, editor_resume_state editor_resume)
+    : settings_scene(manager, return_target::editor) {
+    editor_song_ = std::move(editor_song);
+    editor_resume_ = std::make_shared<editor_resume_state>(std::move(editor_resume));
 }
 
 void settings_scene::on_enter() {
@@ -41,6 +49,9 @@ void settings_scene::update(float dt) {
         save_settings(g_settings);
         if (return_target_ == return_target::song_select) {
             manager_.change_scene(song_select::make_seamless_song_select_scene(manager_));
+        } else if (return_target_ == return_target::editor && editor_song_.has_value() && editor_resume_) {
+            manager_.change_scene(std::make_unique<editor_scene>(
+                manager_, std::move(*editor_song_), std::move(*editor_resume_)));
         } else {
             manager_.change_scene(song_select::make_title_scene(manager_));
         }

--- a/src/scenes/settings_scene.h
+++ b/src/scenes/settings_scene.h
@@ -1,15 +1,22 @@
 #pragma once
 
+#include <memory>
+#include <optional>
+
 #include "scene.h"
 #include "settings/settings_layout.h"
 #include "settings/settings_pages.h"
+#include "song_loader.h"
+
+struct editor_resume_state;
 
 // 設定画面。Gameplay / Audio / Video / Key Config の4ページ構成。
 class settings_scene final : public scene {
 public:
-    enum class return_target { title, song_select };
+    enum class return_target { title, song_select, editor };
 
     explicit settings_scene(scene_manager& manager, return_target target = return_target::title);
+    settings_scene(scene_manager& manager, song_data editor_song, editor_resume_state editor_resume);
 
     void on_enter() override;
     void update(float dt) override;
@@ -23,6 +30,8 @@ private:
 
     settings::page_id current_page_ = settings::page_id::gameplay;
     return_target return_target_ = return_target::title;
+    std::optional<song_data> editor_song_;
+    std::shared_ptr<editor_resume_state> editor_resume_;
     settings_runtime_applier runtime_applier_;
     settings_gameplay_page gameplay_page_;
     settings_audio_page audio_page_;

--- a/src/tests/play_flow_controller_smoke.cpp
+++ b/src/tests/play_flow_controller_smoke.cpp
@@ -117,7 +117,7 @@ int main() {
         context.bgm_audio_time_ms = 700.0;
 
         const play_update_result result = play_flow_controller::update(state, draw_queue, context);
-        if (!state.result_transition_playing || !result.request_pause_bgm || state.final_result.judge_counts[4] != 1) {
+        if (!state.result_transition_playing || !result.request_fade_out_bgm || state.final_result.judge_counts[4] != 1) {
             std::cerr << "Result skip flow failed\n";
             return EXIT_FAILURE;
         }
@@ -204,6 +204,7 @@ int main() {
         play_update_context context;
         context.dt = 0.0f;
         context.bgm_audio_time_ms = 500.0;
+        context.input_already_updated = true;
         context.play_hitsound_immediately = [&immediate_hitsound_count]() {
             ++immediate_hitsound_count;
         };


### PR DESCRIPTION
## 概要
- #257: ポーズ後でもリザルト画面でローカル結果を保存するよう修正
- #252: クリア後のリザルト遷移ではBGMを即時pauseせず、短いフェードアウトに変更
- #122: エディタ画面から設定画面へ移動し、BACKで編集中状態へ復帰できる導線を追加
- play flow smoke の疑似入力を安定させるため、入力更新済みフラグを追加

## 確認したこと
- `cmake --build cmake-build-release --target raythm play_flow_controller_smoke audio_manager_smoke editor_state_smoke`
- `cmake-build-release\play_flow_controller_smoke.exe`
- `cmake-build-release\audio_manager_smoke.exe`
- `cmake-build-release\editor_state_smoke.exe`
- `git diff --check`

## 補足
- `editor_flow_controller_smoke` は既存の `raylib.h` include パス不足で失敗します。今回の変更対象ではないため、このPRでは触っていません。