### PR TITLE
シームレス曲選択にインポート/エクスポートを追加

### DIFF
--- a/src/scenes/title/seamless_song_select_view.cpp
+++ b/src/scenes/title/seamless_song_select_view.cpp
@@ -33,7 +33,62 @@ constexpr Rectangle kPlayRankingSourceOnlineRect = {1126.0f, 98.0f, 90.0f, 34.0f
 constexpr Rectangle kPlayRankingListRect = {878.0f, 150.0f, 338.0f, 468.0f};
 constexpr float kCreateToolButtonHeight = 48.0f;
 constexpr float kCreateToolButtonGap = 8.0f;
+constexpr float kCreateToolColumnGap = 8.0f;
 constexpr int kPlaySongContextMenuItemCount = 1;
+
+enum class create_tool_action {
+    create_song,
+    edit_song,
+    import_song,
+    export_song,
+    upload_song,
+    create_chart,
+    edit_chart,
+    import_chart,
+    export_chart,
+    upload_chart,
+    edit_mv,
+    manage_library,
+};
+
+struct create_tool_entry {
+    const char* title;
+    const char* detail;
+    create_tool_action action;
+};
+
+constexpr create_tool_entry kCreateToolEntries[] = {
+    {"NEW SONG", "Create package.", create_tool_action::create_song},
+    {"EDIT SONG", "Edit metadata.", create_tool_action::edit_song},
+    {"IMPORT SONG", "Load .rpack.", create_tool_action::import_song},
+    {"EXPORT SONG", "Save .rpack.", create_tool_action::export_song},
+    {"UPLOAD SONG", "Publish song.", create_tool_action::upload_song},
+    {"NEW CHART", "Add chart.", create_tool_action::create_chart},
+    {"EDIT CHART", "Open editor.", create_tool_action::edit_chart},
+    {"IMPORT CHART", "Load .rchart.", create_tool_action::import_chart},
+    {"EXPORT CHART", "Save .rchart.", create_tool_action::export_chart},
+    {"UPLOAD CHART", "Publish chart.", create_tool_action::upload_chart},
+    {"MV EDITOR", "Edit MV.", create_tool_action::edit_mv},
+    {"LEGACY", "Classic tools.", create_tool_action::manage_library},
+};
+
+constexpr int kCreateToolColumnCount = 2;
+constexpr int kCreateToolEntryCount =
+    static_cast<int>(sizeof(kCreateToolEntries) / sizeof(kCreateToolEntries[0]));
+
+Rectangle create_tool_rect(Rectangle list_rect, int index) {
+    const int column = index % kCreateToolColumnCount;
+    const int row = index / kCreateToolColumnCount;
+    const float width =
+        (list_rect.width - kCreateToolColumnGap * static_cast<float>(kCreateToolColumnCount - 1)) /
+        static_cast<float>(kCreateToolColumnCount);
+    return {
+        list_rect.x + static_cast<float>(column) * (width + kCreateToolColumnGap),
+        list_rect.y + static_cast<float>(row) * (kCreateToolButtonHeight + kCreateToolButtonGap),
+        width,
+        kCreateToolButtonHeight,
+    };
+}
 
 Rectangle delete_song_menu_item_rect(Rectangle menu_rect) {
     return {
@@ -175,24 +230,26 @@ update_result update(song_select::state& state, mode view_mode, float anim_t, Re
         }
     } else if (left_pressed) {
         const Rectangle list_rect = current.ranking_list_rect;
-        const Rectangle tools[] = {
-            {list_rect.x, list_rect.y, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 1.0f, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 2.0f, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 3.0f, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 4.0f, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 5.0f, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 6.0f, list_rect.width, kCreateToolButtonHeight},
-            {list_rect.x, list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * 7.0f, list_rect.width, kCreateToolButtonHeight},
-        };
-        if (CheckCollisionPointRec(mouse, tools[0])) { result.create_song_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[1])) { result.edit_song_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[2])) { result.upload_song_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[3])) { result.create_chart_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[4])) { result.edit_chart_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[5])) { result.upload_chart_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[6])) { result.edit_mv_requested = true; return result; }
-        if (CheckCollisionPointRec(mouse, tools[7])) { result.manage_library_requested = true; return result; }
+        for (int i = 0; i < kCreateToolEntryCount; ++i) {
+            if (!CheckCollisionPointRec(mouse, create_tool_rect(list_rect, i))) {
+                continue;
+            }
+            switch (kCreateToolEntries[i].action) {
+            case create_tool_action::create_song: result.create_song_requested = true; break;
+            case create_tool_action::edit_song: result.edit_song_requested = true; break;
+            case create_tool_action::import_song: result.import_song_requested = true; break;
+            case create_tool_action::export_song: result.export_song_requested = true; break;
+            case create_tool_action::upload_song: result.upload_song_requested = true; break;
+            case create_tool_action::create_chart: result.create_chart_requested = true; break;
+            case create_tool_action::edit_chart: result.edit_chart_requested = true; break;
+            case create_tool_action::import_chart: result.import_chart_requested = true; break;
+            case create_tool_action::export_chart: result.export_chart_requested = true; break;
+            case create_tool_action::upload_chart: result.upload_chart_requested = true; break;
+            case create_tool_action::edit_mv: result.edit_mv_requested = true; break;
+            case create_tool_action::manage_library: result.manage_library_requested = true; break;
+            }
+            return result;
+        }
     }
 
     if (left_pressed) {
@@ -395,32 +452,17 @@ void draw(const song_select::state& state,
         });
     } else {
         ui::draw_text_in_rect("CREATE TOOLS", 18, current.ranking_header_rect, with_alpha(t.text, alpha), ui::text_align::left);
-        const struct tool_entry { const char* title; const char* detail; } entries[] = {
-            {"NEW SONG", "Start a new song package."},
-            {"EDIT SONG", "Edit selected song metadata."},
-            {"UPLOAD SONG", "Publish selected song to Community."},
-            {"NEW CHART", "Open editor for a new chart."},
-            {"EDIT CHART", "Open selected chart in editor."},
-            {"UPLOAD CHART", "Publish selected chart to Community."},
-            {"MV EDITOR", "Open MV editor for song."},
-            {"MANAGE", "Import / export with legacy tools."},
-        };
-        for (int i = 0; i < 8; ++i) {
-            const Rectangle rect = {
-                current.ranking_list_rect.x,
-                current.ranking_list_rect.y + (kCreateToolButtonHeight + kCreateToolButtonGap) * static_cast<float>(i),
-                current.ranking_list_rect.width,
-                kCreateToolButtonHeight
-            };
+        for (int i = 0; i < kCreateToolEntryCount; ++i) {
+            const Rectangle rect = create_tool_rect(current.ranking_list_rect, i);
             const bool hovered = CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), rect);
             const unsigned char row_alpha = hovered ? hover_row_alpha : normal_row_alpha;
             DrawRectangleRec(rect, with_alpha(button_base, row_alpha));
             DrawRectangleLinesEx(rect, 1.2f, with_alpha(t.border, row_alpha));
-            ui::draw_text_in_rect(entries[i].title, 18,
-                                  {rect.x + 14.0f, rect.y + 6.0f, rect.width - 28.0f, 20.0f},
+            ui::draw_text_in_rect(kCreateToolEntries[i].title, 14,
+                                  {rect.x + 10.0f, rect.y + 6.0f, rect.width - 20.0f, 18.0f},
                                   with_alpha(t.text, alpha), ui::text_align::left);
-            ui::draw_text_in_rect(entries[i].detail, 12,
-                                  {rect.x + 14.0f, rect.y + 26.0f, rect.width - 28.0f, 16.0f},
+            ui::draw_text_in_rect(kCreateToolEntries[i].detail, 11,
+                                  {rect.x + 10.0f, rect.y + 27.0f, rect.width - 20.0f, 15.0f},
                                   with_alpha(t.text_muted, alpha), ui::text_align::left);
         }
     }

--- a/src/scenes/title/seamless_song_select_view.h
+++ b/src/scenes/title/seamless_song_select_view.h
@@ -36,9 +36,13 @@ struct update_result {
     bool create_song_requested = false;
     bool edit_song_requested = false;
     bool upload_song_requested = false;
+    bool import_song_requested = false;
+    bool export_song_requested = false;
     bool create_chart_requested = false;
     bool edit_chart_requested = false;
     bool upload_chart_requested = false;
+    bool import_chart_requested = false;
+    bool export_chart_requested = false;
     bool edit_mv_requested = false;
     bool manage_library_requested = false;
 };

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -10,12 +10,17 @@
 #include <memory>
 #include <string>
 #include <thread>
+#include <utility>
 
+#include "core/file_dialog.h"
 #include "raylib.h"
 #include "scene_common.h"
 #include "scene_manager.h"
 #include "song_select/song_catalog_service.h"
+#include "song_select/song_import_export_service.h"
+#include "song_select/song_select_command_controller.h"
 #include "song_select/song_select_confirmation_dialog.h"
+#include "song_select/song_select_detail_view.h"
 #include "song_select/song_select_layout.h"
 #include "song_select/song_select_login_dialog.h"
 #include "song_select/song_select_navigation.h"
@@ -432,7 +437,101 @@ void title_scene::apply_play_delete_result(const song_select::delete_result& res
     song_select::queue_status_message(play_state_, result.message, false);
 }
 
+void title_scene::apply_play_transfer_result(const song_select::transfer_result& result) {
+    if (result.cancelled) {
+        return;
+    }
+    if (!result.success) {
+        song_select::queue_status_message(play_state_, result.message, true);
+        return;
+    }
+
+    if (result.reload_catalog) {
+        preferred_song_id_ = result.preferred_song_id;
+        preferred_chart_id_ = result.preferred_chart_id;
+        title_online_view::reload_catalog(online_state_);
+        request_play_catalog_reload(preferred_song_id_, preferred_chart_id_,
+                                    mode_ == hub_mode::play || mode_ == hub_mode::create);
+    }
+    song_select::queue_status_message(play_state_, result.message, false);
+}
+
+void title_scene::open_overwrite_song_confirmation(song_select::song_import_request request) {
+    transfer_controller_.set_pending_song_import_request(std::move(request));
+    song_select::open_confirmation_dialog(
+        play_state_, song_select::pending_confirmation_action::overwrite_song_import,
+        "Overwrite Song",
+        "A user song with the same song ID already exists. Overwrite it?",
+        "",
+        "OVERWRITE");
+}
+
+void title_scene::open_overwrite_chart_confirmation(song_select::chart_import_request request) {
+    transfer_controller_.set_pending_chart_import_request(std::move(request));
+    song_select::open_confirmation_dialog(
+        play_state_, song_select::pending_confirmation_action::overwrite_chart_import,
+        "Overwrite Chart",
+        "A user chart with the same chart ID already exists. Overwrite it?",
+        "",
+        "OVERWRITE");
+}
+
+void title_scene::poll_play_transfer() {
+    if (const auto prepared = transfer_controller_.poll_song_import_prepare(); prepared.has_value()) {
+        if (!prepared->request.has_value()) {
+            apply_play_transfer_result(prepared->transfer);
+        } else if (prepared->request->overwrite_existing) {
+            open_overwrite_song_confirmation(*prepared->request);
+        } else {
+            transfer_controller_.start_song_import(*prepared->request);
+            song_select::queue_status_message(play_state_, transfer_controller_.busy_label(), false);
+        }
+    }
+    if (const auto result = transfer_controller_.poll_background_transfer(); result.has_value()) {
+        apply_play_transfer_result(*result);
+    }
+}
+
+void title_scene::start_song_import() {
+    const std::string source_path = file_dialog::open_song_package_file();
+    if (source_path.empty()) {
+        return;
+    }
+    transfer_controller_.start_song_import_prepare(play_state_, source_path);
+    song_select::queue_status_message(play_state_, transfer_controller_.busy_label(), false);
+}
+
+void title_scene::start_chart_import() {
+    song_select::transfer_result result;
+    if (const auto request = song_select::prepare_chart_import(play_state_, result); request.has_value()) {
+        if (request->overwrite_existing) {
+            open_overwrite_chart_confirmation(*request);
+        } else {
+            apply_play_transfer_result(song_select::import_chart_package(*request));
+        }
+    } else {
+        apply_play_transfer_result(result);
+    }
+}
+
+void title_scene::start_song_export() {
+    const int song_index = play_state_.selected_song_index;
+    if (const auto request = song_select::prepare_song_export(play_state_, song_index); request.has_value()) {
+        transfer_controller_.start_song_export(*request);
+        song_select::queue_status_message(play_state_, transfer_controller_.busy_label(), false);
+    }
+}
+
+void title_scene::start_chart_export() {
+    apply_play_transfer_result(
+        song_select::export_chart_package(play_state_, play_state_.selected_song_index, play_state_.difficulty_index));
+}
+
 void title_scene::update_play_mode(float dt) {
+    if (transfer_controller_.busy()) {
+        return;
+    }
+
     const title_play_view::update_result result =
         title_play_view::update(play_state_, title_play_view::mode::play, play_view_anim_, play_entry_origin_rect_, dt);
 
@@ -464,9 +563,13 @@ void title_scene::update_create_mode(float dt) {
         result.create_song_requested ||
         result.edit_song_requested ||
         result.upload_song_requested ||
+        result.import_song_requested ||
+        result.export_song_requested ||
         result.create_chart_requested ||
         result.edit_chart_requested ||
         result.upload_chart_requested ||
+        result.import_chart_requested ||
+        result.export_chart_requested ||
         result.edit_mv_requested ||
         result.manage_library_requested;
 
@@ -485,6 +588,10 @@ void title_scene::update_create_mode(float dt) {
         ui::push_notice(play_state_.notices, "Wait for the current upload to finish.", ui::notice_tone::info, 1.8f);
         return;
     }
+    if (transfer_controller_.busy() && create_action_requested) {
+        ui::push_notice(play_state_.notices, "Wait for the current transfer to finish.", ui::notice_tone::info, 1.8f);
+        return;
+    }
 
     const song_select::song_entry* song = song_select::selected_song(play_state_);
     const auto filtered = song_select::filtered_charts_for_selected_song(play_state_);
@@ -496,6 +603,18 @@ void title_scene::update_create_mode(float dt) {
     }
     if (result.edit_song_requested && song != nullptr) {
         manager_.change_scene(song_select::make_edit_song_scene(manager_, *song));
+        return;
+    }
+    if (result.import_song_requested) {
+        start_song_import();
+        return;
+    }
+    if (result.export_song_requested) {
+        if (song == nullptr) {
+            song_select::queue_status_message(play_state_, "Select a song to export.", true);
+        } else {
+            start_song_export();
+        }
         return;
     }
     if (result.upload_song_requested) {
@@ -512,6 +631,22 @@ void title_scene::update_create_mode(float dt) {
     }
     if (result.edit_chart_requested && song != nullptr && chart != nullptr) {
         manager_.change_scene(song_select::make_edit_chart_scene(manager_, *song, *chart));
+        return;
+    }
+    if (result.import_chart_requested) {
+        if (song == nullptr) {
+            song_select::queue_status_message(play_state_, "Select a song before importing a chart.", true);
+        } else {
+            start_chart_import();
+        }
+        return;
+    }
+    if (result.export_chart_requested) {
+        if (song == nullptr || chart == nullptr) {
+            song_select::queue_status_message(play_state_, "Select a chart to export.", true);
+        } else {
+            start_chart_export();
+        }
         return;
     }
     if (result.upload_chart_requested) {
@@ -576,6 +711,7 @@ void title_scene::update_common_animation(float dt) {
     auth_overlay::poll_restore(auth_controller_, play_state_.auth, play_state_.login_dialog);
     auth_overlay::poll_request(auth_controller_, play_state_.auth, play_state_.login_dialog);
     poll_play_catalog_reload();
+    poll_play_transfer();
     poll_play_ranking_reload();
     poll_scoring_ruleset_warm();
     poll_create_upload();
@@ -814,6 +950,7 @@ void title_scene::on_enter() {
 
 void title_scene::on_exit() {
     play_state_.login_dialog.open = false;
+    transfer_controller_.on_exit();
     title_online_view::on_exit(online_state_);
     audio_controller_.on_exit();
 }
@@ -852,6 +989,17 @@ void title_scene::update(float dt) {
         if (quit_fade_.complete()) {
             CloseWindow();
         }
+        return;
+    }
+
+    if (play_state_.confirmation_dialog.open && IsKeyPressed(KEY_ESCAPE)) {
+        transfer_controller_.clear_pending_song_import_request(true);
+        transfer_controller_.clear_pending_chart_import_request();
+        play_state_.confirmation_dialog = {};
+        return;
+    }
+
+    if (transfer_controller_.busy()) {
         return;
     }
 
@@ -943,13 +1091,14 @@ void title_scene::draw() {
         account_chip_rect.height
     };
     if (mode_ == hub_mode::play || mode_ == hub_mode::create) {
-        const song_select::confirmation_command command = song_select::draw_confirmation_dialog(play_state_);
-        if (command == song_select::confirmation_command::confirm &&
-            play_state_.confirmation_dialog.action == song_select::pending_confirmation_action::delete_song) {
-            apply_play_delete_result(
-                song_select::delete_song(play_state_, play_state_.confirmation_dialog.song_index));
-        } else if (command == song_select::confirmation_command::cancel) {
-            play_state_.confirmation_dialog = {};
+        if (transfer_controller_.busy()) {
+            song_select::draw_busy_overlay(transfer_controller_.busy_label());
+        } else {
+            const song_select::confirmation_command command = song_select::draw_confirmation_dialog(play_state_);
+            song_select::commands::apply_confirmation_command(
+                play_state_, audio_controller_.preview(), transfer_controller_, command,
+                [this](const song_select::delete_result& result) { apply_play_delete_result(result); },
+                [this](const song_select::transfer_result& result) { apply_play_transfer_result(result); });
         }
     }
     const song_select::login_dialog_command login_command =

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -6,6 +6,7 @@
 #include "song_select/song_catalog_service.h"
 #include "shared/scene_fade.h"
 #include "song_select/song_select_state.h"
+#include "song_select/song_transfer_controller.h"
 #include "title/create_upload_client.h"
 #include "title/online_download_view.h"
 #include "title/title_audio_controller.h"
@@ -56,6 +57,14 @@ private:
     void update_create_mode(float dt);
     void update_common_animation(float dt);
     void apply_play_delete_result(const song_select::delete_result& result);
+    void apply_play_transfer_result(const song_select::transfer_result& result);
+    void open_overwrite_song_confirmation(song_select::song_import_request request);
+    void open_overwrite_chart_confirmation(song_select::chart_import_request request);
+    void poll_play_transfer();
+    void start_song_import();
+    void start_chart_import();
+    void start_song_export();
+    void start_chart_export();
     bool handle_account_input();
     bool handle_login_dialog_input();
     void request_play_catalog_reload(std::string preferred_song_id = "",
@@ -105,6 +114,7 @@ private:
     std::future<title_create_upload::upload_result> create_upload_future_;
     bool create_upload_in_progress_ = false;
     std::future<ranking_service::listing> play_ranking_future_;
+    song_select::transfer::controller transfer_controller_;
     bool play_ranking_loading_ = false;
     bool play_ranking_reload_pending_ = false;
     int play_ranking_generation_ = 0;


### PR DESCRIPTION
## 概要
- シームレス曲選択のCREATE TOOLSを2列化し、曲/譜面のインポート・エクスポート操作を追加
- 既存の通常曲選択と同じインポート/エクスポートサービス、転送コントローラ、上書き確認ダイアログを再利用
- インポート後にローカル曲カタログとオンライン所有状態を再読込し、選択曲/譜面を維持

## 確認
- `cmake --build cmake-build-release --target raythm`
- `cmake --build cmake-build-release --target song_select_state_smoke play_flow_controller_smoke`
- `./cmake-build-release/song_select_state_smoke.exe`
- `./cmake-build-release/play_flow_controller_smoke.exe`
- `git diff --check`

Fixes #270