### PR TITLE
譜面難易度レベルの表示スケールを再調整

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/chart_parser.h
         src/gameplay/chart_difficulty.cpp
         src/gameplay/chart_difficulty.h
+        src/gameplay/chart_level_cache.cpp
+        src/gameplay/chart_level_cache.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
         src/models/data_models.h
@@ -425,10 +427,6 @@ add_executable(editor_meter_map_smoke
 add_executable(song_loader_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
-        src/gameplay/chart_difficulty.cpp
-        src/gameplay/chart_difficulty.h
-        src/gameplay/timing_engine.cpp
-        src/gameplay/timing_engine.h
         src/models/data_models.h
         src/gameplay/song_loader.cpp
         src/gameplay/song_loader.h

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,6 +396,8 @@ add_executable(chart_serializer_smoke
         src/gameplay/chart_difficulty.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
+        src/gameplay/timing_engine.cpp
+        src/gameplay/timing_engine.h
         src/tests/chart_serializer_smoke.cpp
         src/models/data_models.h)
 
@@ -427,6 +429,10 @@ add_executable(editor_meter_map_smoke
 add_executable(song_loader_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
+        src/gameplay/chart_difficulty.cpp
+        src/gameplay/chart_difficulty.h
+        src/gameplay/timing_engine.cpp
+        src/gameplay/timing_engine.h
         src/models/data_models.h
         src/gameplay/song_loader.cpp
         src/gameplay/song_loader.h
@@ -570,6 +576,8 @@ add_executable(editor_flow_controller_smoke
         src/scenes/editor/editor_state.h
         src/scenes/editor/editor_timeline_view.h
         src/scenes/editor/editor_timing_panel.h
+        src/gameplay/chart_difficulty.cpp
+        src/gameplay/chart_difficulty.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
         src/gameplay/timing_engine.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -392,12 +392,8 @@ add_executable(chart_parser_smoke
 add_executable(chart_serializer_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
-        src/gameplay/chart_difficulty.cpp
-        src/gameplay/chart_difficulty.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
-        src/gameplay/timing_engine.cpp
-        src/gameplay/timing_engine.h
         src/tests/chart_serializer_smoke.cpp
         src/models/data_models.h)
 
@@ -576,8 +572,6 @@ add_executable(editor_flow_controller_smoke
         src/scenes/editor/editor_state.h
         src/scenes/editor/editor_timeline_view.h
         src/scenes/editor/editor_timing_panel.h
-        src/gameplay/chart_difficulty.cpp
-        src/gameplay/chart_difficulty.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
         src/gameplay/timing_engine.cpp

--- a/src/core/file_dialog.cpp
+++ b/src/core/file_dialog.cpp
@@ -16,6 +16,7 @@
 #include <commdlg.h>
 #include <filesystem>
 #include <string>
+#include <vector>
 #endif
 
 namespace file_dialog {
@@ -70,6 +71,47 @@ std::string open_file_dialog(const wchar_t* filter, const wchar_t* title) {
     return {};
 }
 
+std::vector<std::string> open_file_dialog_multi(const wchar_t* filter, const wchar_t* title) {
+    fullscreen_dialog_guard fullscreen_guard;
+    std::vector<wchar_t> buffer(32768, L'\0');
+
+    OPENFILENAMEW ofn = {};
+    ofn.lStructSize = sizeof(ofn);
+    ofn.hwndOwner = static_cast<HWND>(window_dialog_support::native_window_handle());
+    ofn.lpstrFilter = filter;
+    ofn.lpstrFile = buffer.data();
+    ofn.nMaxFile = static_cast<DWORD>(buffer.size());
+    ofn.lpstrTitle = title;
+    ofn.Flags = OFN_ALLOWMULTISELECT | OFN_EXPLORER | OFN_FILEMUSTEXIST | OFN_PATHMUSTEXIST | OFN_NOCHANGEDIR;
+
+    if (ofn.hwndOwner != nullptr) {
+        SetForegroundWindow(ofn.hwndOwner);
+    }
+
+    if (GetOpenFileNameW(&ofn) == 0) {
+        return {};
+    }
+
+    std::vector<std::wstring> parts;
+    for (const wchar_t* cursor = buffer.data(); *cursor != L'\0'; cursor += std::wcslen(cursor) + 1) {
+        parts.emplace_back(cursor);
+    }
+    if (parts.empty()) {
+        return {};
+    }
+    if (parts.size() == 1) {
+        return {path_utils::to_utf8(std::filesystem::path(parts.front()))};
+    }
+
+    std::vector<std::string> paths;
+    paths.reserve(parts.size() - 1);
+    const std::filesystem::path directory(parts.front());
+    for (size_t index = 1; index < parts.size(); ++index) {
+        paths.push_back(path_utils::to_utf8(directory / parts[index]));
+    }
+    return paths;
+}
+
 std::string save_file_dialog(const wchar_t* filter, const wchar_t* title,
                              const wchar_t* default_extension,
                              const std::string& default_file_name) {
@@ -119,10 +161,22 @@ std::string open_chart_package_file() {
         L"Import Chart Package");
 }
 
+std::vector<std::string> open_chart_package_files() {
+    return open_file_dialog_multi(
+        L"raythm Chart Package (*.rchart)\0*.rchart\0All Files (*.*)\0*.*\0",
+        L"Import Chart Packages");
+}
+
 std::string open_song_package_file() {
     return open_file_dialog(
         L"raythm Song Package (*.rpack)\0*.rpack\0All Files (*.*)\0*.*\0",
         L"Import Song Package");
+}
+
+std::vector<std::string> open_song_package_files() {
+    return open_file_dialog_multi(
+        L"raythm Song Package (*.rpack)\0*.rpack\0All Files (*.*)\0*.*\0",
+        L"Import Song Packages");
 }
 
 std::string open_mv_script_file() {
@@ -169,7 +223,9 @@ bool confirm_yes_no(const std::string& title, const std::string& message) {
 std::string open_audio_file() { return {}; }
 std::string open_image_file() { return {}; }
 std::string open_chart_package_file() { return {}; }
+std::vector<std::string> open_chart_package_files() { return {}; }
 std::string open_song_package_file() { return {}; }
+std::vector<std::string> open_song_package_files() { return {}; }
 std::string open_mv_script_file() { return {}; }
 std::string save_chart_package_file(const std::string&) { return {}; }
 std::string save_song_package_file(const std::string&) { return {}; }

--- a/src/core/file_dialog.h
+++ b/src/core/file_dialog.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace file_dialog {
 
@@ -13,8 +14,14 @@ std::string open_image_file();
 // Open a file dialog for selecting an .rchart file. Returns empty string if cancelled.
 std::string open_chart_package_file();
 
+// Open a file dialog for selecting one or more .rchart files. Returns empty vector if cancelled.
+std::vector<std::string> open_chart_package_files();
+
 // Open a file dialog for selecting an .rpack file. Returns empty string if cancelled.
 std::string open_song_package_file();
+
+// Open a file dialog for selecting one or more .rpack files. Returns empty vector if cancelled.
+std::vector<std::string> open_song_package_files();
 
 // Open a file dialog for selecting an .rmv file. Returns empty string if cancelled.
 std::string open_mv_script_file();

--- a/src/gameplay/chart_difficulty.cpp
+++ b/src/gameplay/chart_difficulty.cpp
@@ -72,10 +72,10 @@ constexpr float kWeightOverlap = 1.20f;
 constexpr float kWeightPattern = 1.40f;
 constexpr float kWeightBalance = 0.35f;
 constexpr float kWeightStamina = 0.5f;
-constexpr float kWeightChord = 0.85f;
-constexpr float kWeightHand = 0.70f;
-constexpr float kWeightHoldConflict = 0.95f;
-constexpr float kWeightRead = 1.20f;
+constexpr float kWeightChord = 0.28f;
+constexpr float kWeightHand = 0.34f;
+constexpr float kWeightHoldConflict = 0.42f;
+constexpr float kWeightRead = 1.10f;
 
 // 各要素の非線形補正。大きいほど、その要素の「高い値」を強調しやすい。
 constexpr float kGammaDensity = 1.50f;
@@ -104,8 +104,8 @@ constexpr float kCouplingHoldJump = 0.22f;
 constexpr float kCouplingOverlapJump = 0.16f;
 constexpr float kCouplingStaminaStream = 0.14f;
 constexpr float kCouplingReadOverlap = 0.10f;
-constexpr float kCouplingChordJump = 0.08f;
-constexpr float kCouplingHandHold = 0.12f;
+constexpr float kCouplingChordJump = 0.025f;
+constexpr float kCouplingHandHold = 0.035f;
 
 template <typename Predicate>
 std::vector<const note_event*> collect_events_near(const std::vector<note_event>& events,
@@ -357,7 +357,7 @@ float local_chord_factor(const std::vector<note_event>& events, double center_ms
             const float spread = static_cast<float>(max_lane - min_lane) / static_cast<float>(key_count - 1);
             const float one_hand_bias =
                 static_cast<float>(std::max(hands[0], hands[1])) / static_cast<float>(count);
-            sum += std::pow(static_cast<float>(count), kGammaChord) * (1.0f + 0.35f * spread + 0.45f * one_hand_bias);
+            sum += std::pow(static_cast<float>(count), kGammaChord) * (1.0f + 0.25f * spread + 0.30f * one_hand_bias);
         }
         i = j;
     }
@@ -404,7 +404,9 @@ float local_hold_responsibility_conflict_factor(const std::vector<note_event>& e
                     std::abs(nearby.time_ms - event.time_ms) > 140.0) {
                     continue;
                 }
-                sum += 1.35f / static_cast<float>(std::abs(nearby.time_ms - event.time_ms) / 1000.0 + kTimeEpsilonSeconds);
+                const float urgency =
+                    1.0f / static_cast<float>(std::abs(nearby.time_ms - event.time_ms) / 1000.0 + kTimeEpsilonSeconds);
+                sum += 0.45f * std::min(urgency, 8.0f);
             }
             continue;
         }
@@ -414,7 +416,7 @@ float local_hold_responsibility_conflict_factor(const std::vector<note_event>& e
         }
         const int same_hand_holds = active_hold_count_for_hand_at(holds, event.time_ms, hand, key_count);
         if (same_hand_holds > 0) {
-            sum += std::pow(1.0f + static_cast<float>(same_hand_holds), kGammaHoldConflict);
+            sum += 0.65f * std::pow(1.0f + static_cast<float>(same_hand_holds), kGammaHoldConflict);
         }
     }
 
@@ -501,9 +503,9 @@ float local_pattern_factor(const std::vector<transition_sample>& transitions,
     return 0.45f * irregularity +
            0.90f * (jack_count == 0 ? 0.0f : jack_sum / static_cast<float>(jack_count)) +
            0.60f * burst +
-           0.22f * trill +
-           0.16f * stair +
-           0.18f * anchor;
+           0.16f * trill +
+           0.10f * stair +
+           0.12f * anchor;
 }
 
 float local_balance_factor(const std::vector<note_event>& events, double center_ms, int key_count) {

--- a/src/gameplay/chart_difficulty.cpp
+++ b/src/gameplay/chart_difficulty.cpp
@@ -43,6 +43,7 @@ constexpr double kBalanceRadiusMs = 800.0;
 constexpr double kReadRadiusMs = 500.0;
 constexpr double kStaminaWindowMs = 8000.0;
 constexpr double kTimeEpsilonSeconds = 0.015;
+constexpr double kChordMergeMs = 2.0;
 
 constexpr float kScale = 12.0f;
 constexpr float kPeakPower = 2.2f;
@@ -58,6 +59,9 @@ constexpr float kStaminaThreshold = 3.2f;
 // pattern: ジャック・配置の崩れ・局所バーストなどの最大風速寄り要素
 // balance: 左右寄りの偏り
 // stamina: 数秒単位で高密度が続く持久力負荷
+// chord: 同時押しの個数・形・押し分けづらさ
+// hand: 片手へ寄る局所密度と回復不足
+// hold_conflict: LN 拘束中に同じ手で別ノーツや離しを処理する負荷
 // read: 見た目の詰まりや読みづらさ
 constexpr float kWeightDensity = 1.50f;
 constexpr float kWeightStream = 1.00f;
@@ -68,6 +72,9 @@ constexpr float kWeightOverlap = 1.20f;
 constexpr float kWeightPattern = 1.40f;
 constexpr float kWeightBalance = 0.35f;
 constexpr float kWeightStamina = 0.5f;
+constexpr float kWeightChord = 0.85f;
+constexpr float kWeightHand = 0.70f;
+constexpr float kWeightHoldConflict = 0.95f;
 constexpr float kWeightRead = 1.20f;
 
 // 各要素の非線形補正。大きいほど、その要素の「高い値」を強調しやすい。
@@ -82,6 +89,9 @@ constexpr float kGammaJack = 0.95f;
 constexpr float kGammaBurst = 1.30f;
 constexpr float kGammaBalance = 0.80f;
 constexpr float kGammaStamina = 1.10f;
+constexpr float kGammaChord = 1.25f;
+constexpr float kGammaHand = 0.88f;
+constexpr float kGammaHoldConflict = 1.05f;
 constexpr float kGammaReadOverlap = 0.70f;
 constexpr float kGammaReadTail = 0.60f;
 
@@ -94,6 +104,8 @@ constexpr float kCouplingHoldJump = 0.22f;
 constexpr float kCouplingOverlapJump = 0.16f;
 constexpr float kCouplingStaminaStream = 0.14f;
 constexpr float kCouplingReadOverlap = 0.10f;
+constexpr float kCouplingChordJump = 0.08f;
+constexpr float kCouplingHandHold = 0.12f;
 
 template <typename Predicate>
 std::vector<const note_event*> collect_events_near(const std::vector<note_event>& events,
@@ -164,6 +176,17 @@ std::vector<transition_sample> build_transitions(const std::vector<note_event>& 
     return transitions;
 }
 
+bool is_press_event(const note_event& event) {
+    return event.type == note_event::kind::tap || event.type == note_event::kind::hold_head;
+}
+
+int hand_for_lane(int lane, int key_count) {
+    if (key_count <= 1) {
+        return 0;
+    }
+    return lane < key_count / 2 ? 0 : 1;
+}
+
 double total_chart_length_ms(const std::vector<note_event>& events, const std::vector<hold_interval>& holds) {
     double total = 0.0;
     if (!events.empty()) {
@@ -179,6 +202,17 @@ int active_hold_count_at(const std::vector<hold_interval>& holds, double time_ms
     int count = 0;
     for (const hold_interval& hold : holds) {
         if (hold.start_ms <= time_ms && time_ms < hold.end_ms) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+int active_hold_count_for_hand_at(const std::vector<hold_interval>& holds, double time_ms, int hand, int key_count) {
+    int count = 0;
+    for (const hold_interval& hold : holds) {
+        if (hold.start_ms <= time_ms && time_ms < hold.end_ms &&
+            hand_for_lane(hold.lane, key_count) == hand) {
             ++count;
         }
     }
@@ -289,8 +323,110 @@ float local_overlap_factor(const std::vector<note_event>& events, const std::vec
     return sum / static_cast<float>((400.0 * 2.0) / 1000.0);
 }
 
-float local_pattern_factor(const std::vector<transition_sample>& transitions, double center_ms, const std::vector<note_event>& events) {
+float local_chord_factor(const std::vector<note_event>& events, double center_ms, int key_count) {
+    if (key_count <= 1) {
+        return 0.0f;
+    }
+
+    float sum = 0.0f;
+    size_t i = 0;
+    while (i < events.size()) {
+        const note_event& first = events[i];
+        if (!is_press_event(first)) {
+            ++i;
+            continue;
+        }
+
+        size_t j = i + 1;
+        int count = 1;
+        int min_lane = first.lane;
+        int max_lane = first.lane;
+        int hands[2] = {0, 0};
+        ++hands[hand_for_lane(first.lane, key_count)];
+        while (j < events.size() && std::abs(events[j].time_ms - first.time_ms) <= kChordMergeMs) {
+            if (is_press_event(events[j])) {
+                ++count;
+                min_lane = std::min(min_lane, events[j].lane);
+                max_lane = std::max(max_lane, events[j].lane);
+                ++hands[hand_for_lane(events[j].lane, key_count)];
+            }
+            ++j;
+        }
+
+        if (count >= 2 && std::abs(first.time_ms - center_ms) <= kReadRadiusMs) {
+            const float spread = static_cast<float>(max_lane - min_lane) / static_cast<float>(key_count - 1);
+            const float one_hand_bias =
+                static_cast<float>(std::max(hands[0], hands[1])) / static_cast<float>(count);
+            sum += std::pow(static_cast<float>(count), kGammaChord) * (1.0f + 0.35f * spread + 0.45f * one_hand_bias);
+        }
+        i = j;
+    }
+
+    return sum / static_cast<float>((kReadRadiusMs * 2.0) / 1000.0);
+}
+
+float local_hand_load_factor(const std::vector<note_event>& events, const std::vector<hold_interval>& holds,
+                             double center_ms, int key_count) {
+    float hand_load[2] = {0.0f, 0.0f};
+    for (const note_event& event : events) {
+        if (!is_press_event(event) || std::abs(event.time_ms - center_ms) > kBalanceRadiusMs) {
+            continue;
+        }
+
+        const int hand = hand_for_lane(event.lane, key_count);
+        const int active_holds = active_hold_count_for_hand_at(holds, event.time_ms, hand, key_count);
+        hand_load[hand] += 1.0f + 0.55f * static_cast<float>(active_holds);
+    }
+
+    const float seconds = static_cast<float>((kBalanceRadiusMs * 2.0) / 1000.0);
+    const float left_rate = hand_load[0] / seconds;
+    const float right_rate = hand_load[1] / seconds;
+    const float peak = std::max(left_rate, right_rate);
+    const float skew = std::abs(left_rate - right_rate);
+    return std::pow(peak, kGammaHand) + 0.55f * std::pow(skew, kGammaHand);
+}
+
+float local_hold_responsibility_conflict_factor(const std::vector<note_event>& events,
+                                                const std::vector<hold_interval>& holds,
+                                                double center_ms,
+                                                int key_count) {
+    float sum = 0.0f;
+    for (const note_event& event : events) {
+        if (std::abs(event.time_ms - center_ms) > kReleaseRadiusMs) {
+            continue;
+        }
+
+        const int hand = hand_for_lane(event.lane, key_count);
+        if (event.type == note_event::kind::hold_tail) {
+            for (const note_event& nearby : events) {
+                if (!is_press_event(nearby) ||
+                    hand_for_lane(nearby.lane, key_count) != hand ||
+                    std::abs(nearby.time_ms - event.time_ms) > 140.0) {
+                    continue;
+                }
+                sum += 1.35f / static_cast<float>(std::abs(nearby.time_ms - event.time_ms) / 1000.0 + kTimeEpsilonSeconds);
+            }
+            continue;
+        }
+
+        if (!is_press_event(event)) {
+            continue;
+        }
+        const int same_hand_holds = active_hold_count_for_hand_at(holds, event.time_ms, hand, key_count);
+        if (same_hand_holds > 0) {
+            sum += std::pow(1.0f + static_cast<float>(same_hand_holds), kGammaHoldConflict);
+        }
+    }
+
+    return sum / static_cast<float>((kReleaseRadiusMs * 2.0) / 1000.0);
+}
+
+float local_pattern_factor(const std::vector<transition_sample>& transitions,
+                           double center_ms,
+                           const std::vector<note_event>& events,
+                           int key_count) {
     std::vector<float> alt_costs;
+    std::vector<const note_event*> presses;
     float jack_sum = 0.0f;
     int jack_count = 0;
 
@@ -305,6 +441,45 @@ float local_pattern_factor(const std::vector<transition_sample>& transitions, do
         if (transition.same_lane) {
             jack_sum += std::pow(1.0 / (transition.dt_seconds + kTimeEpsilonSeconds), kGammaJack);
             ++jack_count;
+        }
+    }
+
+    for (const note_event& event : events) {
+        if (is_press_event(event) && std::abs(event.time_ms - center_ms) <= 700.0) {
+            presses.push_back(&event);
+        }
+    }
+
+    float trill = 0.0f;
+    float stair = 0.0f;
+    float anchor = 0.0f;
+    for (size_t i = 3; i < presses.size(); ++i) {
+        const note_event& a = *presses[i - 3];
+        const note_event& b = *presses[i - 2];
+        const note_event& c = *presses[i - 1];
+        const note_event& d = *presses[i];
+        const double span_seconds = std::max((d.time_ms - a.time_ms) / 1000.0, kTimeEpsilonSeconds);
+        if (span_seconds > 0.9) {
+            continue;
+        }
+
+        const float speed = static_cast<float>(3.0 / span_seconds);
+        if (a.lane == c.lane && b.lane == d.lane && a.lane != b.lane) {
+            const bool one_hand = hand_for_lane(a.lane, key_count) == hand_for_lane(b.lane, key_count);
+            trill += speed * (one_hand ? 1.35f : 1.0f);
+        }
+
+        const int ab = b.lane - a.lane;
+        const int bc = c.lane - b.lane;
+        const int cd = d.lane - c.lane;
+        if (ab != 0 && bc != 0 && cd != 0 &&
+            (ab > 0) == (bc > 0) && (bc > 0) == (cd > 0)) {
+            stair += speed * 0.80f;
+        }
+
+        if ((a.lane == c.lane && a.lane != b.lane) ||
+            (b.lane == d.lane && b.lane != c.lane)) {
+            anchor += speed * 0.65f;
         }
     }
 
@@ -323,8 +498,12 @@ float local_pattern_factor(const std::vector<transition_sample>& transitions, do
                                  local_density_per_second(events, center_ms, kAverageRadiusMs));
     burst = std::pow(burst, kGammaBurst);
 
-    return 0.45f * irregularity + 0.90f * (jack_count == 0 ? 0.0f : jack_sum / static_cast<float>(jack_count)) +
-           0.60f * burst;
+    return 0.45f * irregularity +
+           0.90f * (jack_count == 0 ? 0.0f : jack_sum / static_cast<float>(jack_count)) +
+           0.60f * burst +
+           0.22f * trill +
+           0.16f * stair +
+           0.18f * anchor;
 }
 
 float local_balance_factor(const std::vector<note_event>& events, double center_ms, int key_count) {
@@ -361,7 +540,32 @@ float local_stamina_factor(const std::vector<note_event>& events, double center_
 float local_read_factor(const std::vector<note_event>& events, const std::vector<hold_interval>& holds, double center_ms) {
     const float overlap = std::pow(local_density_per_second(events, center_ms, kReadRadiusMs), kGammaReadOverlap);
     const float tail_clutter = std::pow(static_cast<float>(active_hold_count_at(holds, center_ms)), kGammaReadTail);
-    return overlap + tail_clutter;
+
+    std::vector<double> gaps;
+    const note_event* previous = nullptr;
+    for (const note_event& event : events) {
+        if (!is_press_event(event) || std::abs(event.time_ms - center_ms) > kReadRadiusMs) {
+            continue;
+        }
+        if (previous != nullptr) {
+            gaps.push_back((event.time_ms - previous->time_ms) / 1000.0);
+        }
+        previous = &event;
+    }
+
+    float rhythm_variance = 0.0f;
+    if (gaps.size() >= 2) {
+        const double mean = std::accumulate(gaps.begin(), gaps.end(), 0.0) / static_cast<double>(gaps.size());
+        double variance = 0.0;
+        for (double gap : gaps) {
+            const double delta = gap - mean;
+            variance += delta * delta;
+        }
+        rhythm_variance = static_cast<float>(std::sqrt(variance / static_cast<double>(gaps.size())) /
+                                             (mean + kTimeEpsilonSeconds));
+    }
+
+    return overlap + tail_clutter + 0.55f * rhythm_variance;
 }
 
 float local_difficulty_at(const std::vector<note_event>& events, const std::vector<hold_interval>& holds,
@@ -372,9 +576,12 @@ float local_difficulty_at(const std::vector<note_event>& events, const std::vect
     const float hold = std::pow(static_cast<float>(active_hold_count_at(holds, center_ms)), kGammaHold);
     const float release = local_release_factor(events, center_ms);
     const float overlap = local_overlap_factor(events, holds, center_ms, key_count);
-    const float pattern = local_pattern_factor(transitions, center_ms, events);
+    const float pattern = local_pattern_factor(transitions, center_ms, events, key_count);
     const float balance = local_balance_factor(events, center_ms, key_count);
     const float stamina = local_stamina_factor(events, center_ms);
+    const float chord = local_chord_factor(events, center_ms, key_count);
+    const float hand = local_hand_load_factor(events, holds, center_ms, key_count);
+    const float hold_conflict = local_hold_responsibility_conflict_factor(events, holds, center_ms, key_count);
     const float read = local_read_factor(events, holds, center_ms);
 
     const float base =
@@ -388,6 +595,9 @@ float local_difficulty_at(const std::vector<note_event>& events, const std::vect
         kWeightPattern * pattern +
         kWeightBalance * balance +
         kWeightStamina * stamina +
+        kWeightChord * chord +
+        kWeightHand * hand +
+        kWeightHoldConflict * hold_conflict +
         kWeightRead * read;
 
     const float coupling =
@@ -396,7 +606,9 @@ float local_difficulty_at(const std::vector<note_event>& events, const std::vect
         kCouplingHoldJump * hold * jump +
         kCouplingOverlapJump * overlap * jump +
         kCouplingStaminaStream * stamina * stream +
-        kCouplingReadOverlap * read * overlap;
+        kCouplingReadOverlap * read * overlap +
+        kCouplingChordJump * chord * jump +
+        kCouplingHandHold * hand * hold_conflict;
 
     return base * coupling;
 }

--- a/src/gameplay/chart_difficulty.cpp
+++ b/src/gameplay/chart_difficulty.cpp
@@ -668,4 +668,13 @@ float calculate_level(const chart_data& data) {
     return level_from_rating(calculate_rating(data));
 }
 
+chart_data with_auto_level(chart_data data) {
+    apply_auto_level(data);
+    return data;
+}
+
+void apply_auto_level(chart_data& data) {
+    data.meta.level = calculate_level(data);
+}
+
 }  // namespace chart_difficulty

--- a/src/gameplay/chart_difficulty.cpp
+++ b/src/gameplay/chart_difficulty.cpp
@@ -440,13 +440,18 @@ float calculate_rating(const chart_data& data) {
     return kScale * static_cast<float>(std::pow(weighted_sum / total_weight_ms, 1.0 / kPeakPower));
 }
 
-float calculate_level(const chart_data& data) {
-    const float raw_rating = calculate_rating(data);
+float level_from_rating(float raw_rating) {
     if (raw_rating <= 0.0f) {
         return 0.0f;
     }
-    const float normalized = 0.5f * std::log10(1.0f + raw_rating);
-    return std::max(0.1f, std::round(normalized * 10.0f) / 10.0f);
+
+    const float calibrated = 3.0f * std::log10(raw_rating) - 6.5f;
+    const float rounded = std::round(calibrated * 10.0f) / 10.0f;
+    return std::clamp(rounded, 0.1f, 15.0f);
+}
+
+float calculate_level(const chart_data& data) {
+    return level_from_rating(calculate_rating(data));
 }
 
 }  // namespace chart_difficulty

--- a/src/gameplay/chart_difficulty.h
+++ b/src/gameplay/chart_difficulty.h
@@ -7,5 +7,7 @@ namespace chart_difficulty {
 float calculate_rating(const chart_data& data);
 float level_from_rating(float raw_rating);
 float calculate_level(const chart_data& data);
+chart_data with_auto_level(chart_data data);
+void apply_auto_level(chart_data& data);
 
 }  // namespace chart_difficulty

--- a/src/gameplay/chart_difficulty.h
+++ b/src/gameplay/chart_difficulty.h
@@ -5,6 +5,7 @@
 namespace chart_difficulty {
 
 float calculate_rating(const chart_data& data);
+float level_from_rating(float raw_rating);
 float calculate_level(const chart_data& data);
 
 }  // namespace chart_difficulty

--- a/src/gameplay/chart_level_cache.cpp
+++ b/src/gameplay/chart_level_cache.cpp
@@ -1,0 +1,81 @@
+#include "chart_level_cache.h"
+
+#include <filesystem>
+#include <mutex>
+#include <unordered_map>
+
+#include "chart_difficulty.h"
+#include "path_utils.h"
+
+namespace {
+
+struct cache_entry {
+    std::filesystem::file_time_type write_time{};
+    float level = 0.0f;
+};
+
+std::mutex& cache_mutex() {
+    static std::mutex mutex;
+    return mutex;
+}
+
+std::unordered_map<std::string, cache_entry>& cache() {
+    static std::unordered_map<std::string, cache_entry> values;
+    return values;
+}
+
+std::optional<std::filesystem::file_time_type> chart_write_time(const std::string& chart_path) {
+    std::error_code ec;
+    const auto write_time = std::filesystem::last_write_time(path_utils::from_utf8(chart_path), ec);
+    if (ec) {
+        return std::nullopt;
+    }
+    return write_time;
+}
+
+}  // namespace
+
+namespace chart_level_cache {
+
+std::optional<float> find_level(const std::string& chart_path) {
+    const std::optional<std::filesystem::file_time_type> write_time = chart_write_time(chart_path);
+    if (!write_time.has_value()) {
+        return std::nullopt;
+    }
+
+    std::lock_guard lock(cache_mutex());
+    const auto it = cache().find(chart_path);
+    if (it == cache().end() || it->second.write_time != *write_time) {
+        return std::nullopt;
+    }
+    return it->second.level;
+}
+
+float get_or_calculate(const std::string& chart_path, const chart_data& chart) {
+    if (const std::optional<float> cached = find_level(chart_path); cached.has_value()) {
+        return *cached;
+    }
+    return calculate_and_store(chart_path, chart);
+}
+
+float calculate_and_store(const std::string& chart_path, const chart_data& chart) {
+    const float level = chart_difficulty::calculate_level(chart);
+    const std::optional<std::filesystem::file_time_type> write_time = chart_write_time(chart_path);
+    if (!write_time.has_value()) {
+        return level;
+    }
+
+    std::lock_guard lock(cache_mutex());
+    cache()[chart_path] = cache_entry{
+        .write_time = *write_time,
+        .level = level,
+    };
+    return level;
+}
+
+void clear() {
+    std::lock_guard lock(cache_mutex());
+    cache().clear();
+}
+
+}  // namespace chart_level_cache

--- a/src/gameplay/chart_level_cache.h
+++ b/src/gameplay/chart_level_cache.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "data_models.h"
+
+namespace chart_level_cache {
+
+std::optional<float> find_level(const std::string& chart_path);
+float get_or_calculate(const std::string& chart_path, const chart_data& chart);
+float calculate_and_store(const std::string& chart_path, const chart_data& chart);
+void clear();
+
+}  // namespace chart_level_cache

--- a/src/gameplay/chart_parser.cpp
+++ b/src/gameplay/chart_parser.cpp
@@ -219,12 +219,7 @@ chart_meta chart_parser::parse_metadata(const std::vector<numbered_line>& lines,
         } else if (key == "difficulty") {
             meta.difficulty = value;
         } else if (key == "level") {
-            const std::optional<float> parsed = parse_float(value);
-            if (!parsed.has_value()) {
-                errors.push_back(format_line_error(line.first, "level must be a number"));
-            } else {
-                meta.level = *parsed;
-            }
+            // Legacy field. Runtime levels are always calculated from chart notes.
         } else if (key == "chartName" || key == "description") {
             // Accept legacy metadata fields for backward compatibility, but they are no longer used.
         } else if (key == "chartAuthor") {
@@ -257,11 +252,10 @@ chart_meta chart_parser::parse_metadata(const std::vector<numbered_line>& lines,
         }
     }
 
-    const std::array<std::string, 7> required_fields = {
+    const std::array<std::string, 6> required_fields = {
         "chartId",
         "keyCount",
         "difficulty",
-        "level",
         "chartAuthor",
         "formatVersion",
         "resolution",
@@ -392,10 +386,6 @@ std::vector<std::string> chart_parser::validate(const chart_data& data) {
 
     if (data.meta.key_count != 4 && data.meta.key_count != 6) {
         errors.push_back("Metadata keyCount must be 4 or 6");
-    }
-
-    if (data.meta.level < 0) {
-        errors.push_back("Metadata level must be zero or greater");
     }
 
     if (data.meta.format_version <= 0) {

--- a/src/gameplay/chart_serializer.cpp
+++ b/src/gameplay/chart_serializer.cpp
@@ -7,7 +7,6 @@
 #include <limits>
 #include <sstream>
 
-#include "chart_difficulty.h"
 #include "path_utils.h"
 #include <vector>
 
@@ -15,12 +14,6 @@ namespace {
 std::string format_float(float value) {
     std::ostringstream stream;
     stream << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
-    return stream.str();
-}
-
-std::string format_level(float value) {
-    std::ostringstream stream;
-    stream << std::fixed << std::setprecision(1) << value;
     return stream.str();
 }
 
@@ -57,7 +50,6 @@ bool chart_serializer::serialize(const chart_data& data, const std::string& file
     output << "chartId=" << data.meta.chart_id << '\n';
     output << "keyCount=" << data.meta.key_count << '\n';
     output << "difficulty=" << data.meta.difficulty << '\n';
-    output << "level=" << format_level(chart_difficulty::calculate_level(data)) << '\n';
     output << "chartAuthor=" << data.meta.chart_author << '\n';
     output << "formatVersion=" << data.meta.format_version << '\n';
     output << "resolution=" << data.meta.resolution << '\n';

--- a/src/gameplay/chart_serializer.cpp
+++ b/src/gameplay/chart_serializer.cpp
@@ -7,6 +7,7 @@
 #include <limits>
 #include <sstream>
 
+#include "chart_difficulty.h"
 #include "path_utils.h"
 #include <vector>
 
@@ -56,7 +57,7 @@ bool chart_serializer::serialize(const chart_data& data, const std::string& file
     output << "chartId=" << data.meta.chart_id << '\n';
     output << "keyCount=" << data.meta.key_count << '\n';
     output << "difficulty=" << data.meta.difficulty << '\n';
-    output << "level=" << format_level(data.meta.level) << '\n';
+    output << "level=" << format_level(chart_difficulty::calculate_level(data)) << '\n';
     output << "chartAuthor=" << data.meta.chart_author << '\n';
     output << "formatVersion=" << data.meta.format_version << '\n';
     output << "resolution=" << data.meta.resolution << '\n';

--- a/src/gameplay/song_loader.cpp
+++ b/src/gameplay/song_loader.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string_view>
 
+#include "chart_difficulty.h"
 #include "path_utils.h"
 
 namespace {
@@ -373,7 +374,11 @@ song_load_result song_loader::load_directory(const std::string& song_dir_utf8) {
 }
 
 chart_parse_result song_loader::load_chart(const std::string& path) {
-    return chart_parser::parse(path);
+    chart_parse_result result = chart_parser::parse(path);
+    if (result.success && result.data.has_value()) {
+        chart_difficulty::apply_auto_level(*result.data);
+    }
+    return result;
 }
 
 void song_loader::attach_external_charts(const std::string& charts_dir, std::vector<song_data>& songs) {

--- a/src/gameplay/song_loader.cpp
+++ b/src/gameplay/song_loader.cpp
@@ -9,7 +9,6 @@
 #include <sstream>
 #include <string_view>
 
-#include "chart_difficulty.h"
 #include "path_utils.h"
 
 namespace {
@@ -374,11 +373,7 @@ song_load_result song_loader::load_directory(const std::string& song_dir_utf8) {
 }
 
 chart_parse_result song_loader::load_chart(const std::string& path) {
-    chart_parse_result result = chart_parser::parse(path);
-    if (result.success && result.data.has_value()) {
-        chart_difficulty::apply_auto_level(*result.data);
-    }
-    return result;
+    return chart_parser::parse(path);
 }
 
 void song_loader::attach_external_charts(const std::string& charts_dir, std::vector<song_data>& songs) {

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -6,6 +6,7 @@
 #include "app_paths.h"
 #include "audio_manager.h"
 #include "audio_waveform.h"
+#include "chart_difficulty.h"
 #include "game_settings.h"
 #include "path_utils.h"
 #include "player_note_offsets.h"
@@ -112,6 +113,7 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
         return state;
     }
 
+    chart_difficulty::apply_auto_level(*state.chart_data);
     state.chart_data = play_chart_filter::prepare_chart_for_playback(*state.chart_data, state.start_tick);
 
     state.input_handler = input_handler(g_settings.keys);

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -6,7 +6,7 @@
 #include "app_paths.h"
 #include "audio_manager.h"
 #include "audio_waveform.h"
-#include "chart_difficulty.h"
+#include "chart_level_cache.h"
 #include "game_settings.h"
 #include "path_utils.h"
 #include "player_note_offsets.h"
@@ -28,7 +28,12 @@ std::optional<chart_data> load_chart_for_key_count(const song_data& song, int ke
         const chart_parse_result parse_result = song_loader::load_chart(chart_path);
         if (parse_result.success && parse_result.data.has_value() &&
             parse_result.data->meta.key_count == key_count) {
-            return parse_result.data;
+            chart_data chart = *parse_result.data;
+            if (const std::optional<float> cached_level = chart_level_cache::find_level(chart_path);
+                cached_level.has_value()) {
+                chart.meta.level = *cached_level;
+            }
+            return chart;
         }
     }
     return std::nullopt;
@@ -98,6 +103,13 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
         if (parse_result.success && parse_result.data.has_value()) {
             state.chart_data = parse_result.data;
             state.key_count = state.chart_data->meta.key_count;
+            if (request.selected_chart_level.has_value()) {
+                state.chart_data->meta.level = *request.selected_chart_level;
+            } else if (const std::optional<float> cached_level =
+                           chart_level_cache::find_level(*state.selected_chart_path);
+                       cached_level.has_value()) {
+                state.chart_data->meta.level = *cached_level;
+            }
         } else {
             state.status_text = "Failed to load selected chart";
             draw_queue.clear();
@@ -113,7 +125,6 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
         return state;
     }
 
-    chart_difficulty::apply_auto_level(*state.chart_data);
     state.chart_data = play_chart_filter::prepare_chart_for_playback(*state.chart_data, state.start_tick);
 
     state.input_handler = input_handler(g_settings.keys);

--- a/src/scenes/play/play_session_types.h
+++ b/src/scenes/play/play_session_types.h
@@ -42,6 +42,7 @@ struct play_start_request {
     int key_count = 4;
     std::optional<song_data> song_data;
     std::optional<std::string> selected_chart_path;
+    std::optional<float> selected_chart_level;
     std::optional<chart_data> chart_data;
     std::optional<editor_resume_state> editor_resume_state;
     int start_tick = 0;

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -138,11 +138,13 @@ play_scene::play_scene(scene_manager& manager, int key_count) : scene(manager) {
     request_.key_count = key_count;
 }
 
-play_scene::play_scene(scene_manager& manager, song_data song, std::string chart_path, int key_count)
+play_scene::play_scene(scene_manager& manager, song_data song, std::string chart_path, int key_count,
+                       float chart_level)
     : scene(manager) {
     request_.key_count = key_count;
     request_.song_data = std::move(song);
     request_.selected_chart_path = std::move(chart_path);
+    request_.selected_chart_level = chart_level;
 }
 
 play_scene::play_scene(scene_manager& manager, song_data song, chart_data chart, int start_tick,

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -16,7 +16,8 @@ namespace mv { class mv_runtime; }
 class play_scene final : public scene {
 public:
     explicit play_scene(scene_manager& manager, int key_count);
-    play_scene(scene_manager& manager, song_data song, std::string chart_path, int key_count);
+    play_scene(scene_manager& manager, song_data song, std::string chart_path, int key_count,
+               float chart_level = 0.0f);
     play_scene(scene_manager& manager, song_data song, chart_data chart, int start_tick,
                editor_resume_state editor_resume);
     ~play_scene() override;

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -2,11 +2,10 @@
 
 #include <algorithm>
 #include <filesystem>
-#include <unordered_map>
 #include <system_error>
 
 #include "app_paths.h"
-#include "chart_difficulty.h"
+#include "chart_level_cache.h"
 #include "mv/mv_storage.h"
 #include "path_utils.h"
 #include "player_note_offsets.h"
@@ -40,33 +39,6 @@ bool is_within_root(const std::filesystem::path& path, const std::filesystem::pa
 
 bool is_chart_file_path(const std::filesystem::path& path) {
     return path.extension() == ".rchart";
-}
-
-struct chart_level_cache_entry {
-    std::filesystem::file_time_type write_time{};
-    float level = 0.0f;
-};
-
-float cached_chart_level(const std::string& chart_path, const chart_data& chart) {
-    static std::unordered_map<std::string, chart_level_cache_entry> cache;
-
-    std::error_code ec;
-    const std::filesystem::path path = path_utils::from_utf8(chart_path);
-    const auto write_time = std::filesystem::last_write_time(path, ec);
-    if (ec) {
-        return chart_difficulty::calculate_level(chart);
-    }
-
-    if (const auto it = cache.find(chart_path); it != cache.end() && it->second.write_time == write_time) {
-        return it->second.level;
-    }
-
-    const float level = chart_difficulty::calculate_level(chart);
-    cache[chart_path] = chart_level_cache_entry{
-        .write_time = write_time,
-        .level = level,
-    };
-    return level;
 }
 
 std::optional<rank> load_best_local_rank(const std::string& chart_id) {
@@ -109,7 +81,7 @@ std::pair<float, float> collect_bpm_range(const chart_data& chart) {
 
 namespace song_select {
 
-catalog_data load_catalog() {
+catalog_data load_catalog(bool calculate_missing_levels) {
     catalog_data catalog;
     const player_chart_offset_map chart_offsets = load_player_chart_offsets();
 
@@ -134,7 +106,12 @@ catalog_data load_catalog() {
             }
 
             chart_meta meta = parse_result.data->meta;
-            meta.level = cached_chart_level(chart_path, *parse_result.data);
+            if (calculate_missing_levels) {
+                meta.level = chart_level_cache::get_or_calculate(chart_path, *parse_result.data);
+            } else if (const std::optional<float> cached_level = chart_level_cache::find_level(chart_path);
+                       cached_level.has_value()) {
+                meta.level = *cached_level;
+            }
             const auto [min_bpm, max_bpm] = collect_bpm_range(*parse_result.data);
 
             entry.charts.push_back({

--- a/src/scenes/song_select/song_catalog_service.h
+++ b/src/scenes/song_select/song_catalog_service.h
@@ -13,7 +13,7 @@ struct delete_result {
     std::string preferred_chart_id;
 };
 
-catalog_data load_catalog();
+catalog_data load_catalog(bool calculate_missing_levels = false);
 delete_result delete_song(const state& state, int song_index);
 delete_result delete_chart(const state& state, int song_index, int chart_index);
 

--- a/src/scenes/song_select/song_import_export_service.cpp
+++ b/src/scenes/song_select/song_import_export_service.cpp
@@ -23,6 +23,7 @@
 #endif
 
 #include "app_paths.h"
+#include "chart_level_cache.h"
 #include "chart_parser.h"
 #include "chart_serializer.h"
 #include "file_dialog.h"
@@ -375,6 +376,7 @@ transfer_result import_chart_package(const chart_import_request& request) {
         result.message = "Failed to save the imported chart.";
         return result;
     }
+    chart_level_cache::calculate_and_store(path_utils::to_utf8(destination_path), request.chart);
 
     result.success = true;
     result.reload_catalog = true;
@@ -567,6 +569,35 @@ transfer_result import_song_package(const song_import_request& request) {
         !copy_file_into_directory(jacket_source, destination_root, path_utils::from_utf8(request.imported_song.meta.jacket_file))) {
         result.message = "Failed to import the song package.";
         return result;
+    }
+    if (!request.imported_song.chart_paths.empty()) {
+        const fs::path charts_destination = destination_root / "charts";
+        std::error_code chart_ec;
+        fs::create_directories(charts_destination, chart_ec);
+        if (chart_ec) {
+            result.message = "Failed to import the song package charts.";
+            return result;
+        }
+
+        for (const std::string& chart_path_utf8 : request.imported_song.chart_paths) {
+            const chart_parse_result parsed_chart = chart_parser::parse(chart_path_utf8);
+            if (!parsed_chart.success || !parsed_chart.data.has_value()) {
+                result.message = "Failed to read a chart from the song package.";
+                return result;
+            }
+
+            const fs::path source_chart_path = path_utils::from_utf8(chart_path_utf8);
+            const fs::path chart_file_name = source_chart_path.filename().empty()
+                ? path_utils::from_utf8(sanitize_file_stem(parsed_chart.data->meta.chart_id, "chart") + ".rchart")
+                : source_chart_path.filename();
+            const fs::path destination_chart_path = charts_destination / chart_file_name;
+            const std::string destination_chart_utf8 = path_utils::to_utf8(destination_chart_path);
+            if (!chart_serializer::serialize(*parsed_chart.data, destination_chart_utf8)) {
+                result.message = "Failed to import the song package charts.";
+                return result;
+            }
+            chart_level_cache::calculate_and_store(destination_chart_utf8, *parsed_chart.data);
+        }
     }
 
     result.success = true;

--- a/src/scenes/song_select/song_import_export_service.cpp
+++ b/src/scenes/song_select/song_import_export_service.cpp
@@ -5,6 +5,8 @@
 #include <filesystem>
 #include <optional>
 #include <system_error>
+#include <unordered_set>
+#include <vector>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -359,13 +361,55 @@ std::optional<chart_import_request> prepare_chart_import(const state& state, tra
     }
 
     const std::optional<chart_option> existing_chart = find_chart_by_id(state, parsed.data->meta.chart_id);
-
     return chart_import_request{
         .source_path = source_path,
         .target_song_id = target_song->song.meta.song_id,
         .chart = *parsed.data,
         .overwrite_existing = existing_chart.has_value(),
     };
+}
+
+std::optional<chart_import_batch_request> prepare_chart_imports(const state& state, transfer_result& result) {
+    const std::vector<std::string> source_paths = file_dialog::open_chart_package_files();
+    if (source_paths.empty()) {
+        result.cancelled = true;
+        return std::nullopt;
+    }
+
+    chart_import_batch_request batch;
+    std::unordered_set<std::string> seen_chart_ids;
+    for (const std::string& source_path : source_paths) {
+        const chart_parse_result parsed = chart_parser::parse(source_path);
+        if (!parsed.success || !parsed.data.has_value()) {
+            result.message = "Failed to import the chart package.";
+            return std::nullopt;
+        }
+
+        const std::optional<song_entry> target_song = find_song_by_id(state, parsed.data->meta.song_id);
+        if (!target_song.has_value()) {
+            result.message = "No song with a matching song ID was found.";
+            return std::nullopt;
+        }
+
+        const std::optional<chart_option> existing_chart = find_chart_by_id(state, parsed.data->meta.chart_id);
+        const bool duplicate_selection = !seen_chart_ids.insert(parsed.data->meta.chart_id).second;
+
+        batch.requests.push_back(chart_import_request{
+            .source_path = source_path,
+            .target_song_id = target_song->song.meta.song_id,
+            .chart = *parsed.data,
+            .overwrite_existing = existing_chart.has_value() || duplicate_selection,
+        });
+        if (existing_chart.has_value() || duplicate_selection) {
+            ++batch.overwrite_count;
+        }
+    }
+
+    if (batch.requests.empty()) {
+        result.cancelled = true;
+        return std::nullopt;
+    }
+    return batch;
 }
 
 transfer_result import_chart_package(const chart_import_request& request) {
@@ -383,6 +427,35 @@ transfer_result import_chart_package(const chart_import_request& request) {
     result.message = "Chart imported.";
     result.preferred_song_id = request.target_song_id;
     result.preferred_chart_id = request.chart.meta.chart_id;
+    return result;
+}
+
+transfer_result import_chart_packages(const std::vector<chart_import_request>& requests) {
+    transfer_result result;
+    if (requests.empty()) {
+        result.cancelled = true;
+        return result;
+    }
+
+    int imported_count = 0;
+    for (const chart_import_request& request : requests) {
+        transfer_result single = import_chart_package(request);
+        if (!single.success) {
+            result = single;
+            result.message = imported_count == 0
+                ? single.message
+                : single.message + " (" + std::to_string(imported_count) + " chart(s) imported before failure.)";
+            return result;
+        }
+        ++imported_count;
+        result.preferred_song_id = single.preferred_song_id;
+        result.preferred_chart_id = single.preferred_chart_id;
+    }
+
+    result.success = true;
+    result.reload_catalog = true;
+    result.message = imported_count == 1 ? "Chart imported."
+                                          : std::to_string(imported_count) + " charts imported.";
     return result;
 }
 
@@ -534,6 +607,33 @@ song_import_prepare_result prepare_song_import_from_path(const state& state, con
     return prepared;
 }
 
+song_import_prepare_batch_result prepare_song_imports_from_paths(const state& state,
+                                                                 const std::vector<std::string>& source_paths) {
+    song_import_prepare_batch_result batch;
+    if (source_paths.empty()) {
+        batch.transfer.cancelled = true;
+        return batch;
+    }
+
+    std::unordered_set<std::string> seen_song_ids;
+    for (const std::string& source_path : source_paths) {
+        song_import_prepare_result prepared = prepare_song_import_from_path(state, source_path);
+        if (!prepared.request.has_value()) {
+            batch.transfer = prepared.transfer;
+            cleanup_song_import_requests(batch.requests);
+            return batch;
+        }
+        const bool duplicate_selection = !seen_song_ids.insert(prepared.request->imported_song.meta.song_id).second;
+        prepared.request->overwrite_existing = prepared.request->overwrite_existing || duplicate_selection;
+        if (prepared.request->overwrite_existing) {
+            ++batch.overwrite_count;
+        }
+        batch.requests.push_back(std::move(*prepared.request));
+    }
+
+    return batch;
+}
+
 transfer_result import_song_package(const song_import_request& request) {
     transfer_result result;
     const fs::path extracted_song_root = path_utils::from_utf8(request.imported_song.directory);
@@ -607,6 +707,35 @@ transfer_result import_song_package(const song_import_request& request) {
     return result;
 }
 
+transfer_result import_song_packages(const std::vector<song_import_request>& requests) {
+    transfer_result result;
+    if (requests.empty()) {
+        result.cancelled = true;
+        return result;
+    }
+
+    int imported_count = 0;
+    for (const song_import_request& request : requests) {
+        transfer_result single = import_song_package(request);
+        if (!single.success) {
+            result = single;
+            result.message = imported_count == 0
+                ? single.message
+                : single.message + " (" + std::to_string(imported_count) + " song(s) imported before failure.)";
+            return result;
+        }
+        ++imported_count;
+        result.preferred_song_id = single.preferred_song_id;
+        result.preferred_chart_id = single.preferred_chart_id;
+    }
+
+    result.success = true;
+    result.reload_catalog = true;
+    result.message = imported_count == 1 ? "Song package imported."
+                                          : std::to_string(imported_count) + " song packages imported.";
+    return result;
+}
+
 void cleanup_song_import_request(song_import_request& request) {
     if (request.extracted_root.empty()) {
         return;
@@ -615,6 +744,13 @@ void cleanup_song_import_request(song_import_request& request) {
     std::error_code ec;
     fs::remove_all(path_utils::from_utf8(request.extracted_root), ec);
     request.extracted_root.clear();
+}
+
+void cleanup_song_import_requests(std::vector<song_import_request>& requests) {
+    for (song_import_request& request : requests) {
+        cleanup_song_import_request(request);
+    }
+    requests.clear();
 }
 
 }  // namespace song_select

--- a/src/scenes/song_select/song_import_export_service.h
+++ b/src/scenes/song_select/song_import_export_service.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 #include "song_select/song_select_state.h"
 
@@ -40,17 +41,34 @@ struct song_import_prepare_result {
     std::optional<song_import_request> request;
 };
 
+struct chart_import_batch_request {
+    std::vector<chart_import_request> requests;
+    int overwrite_count = 0;
+};
+
+struct song_import_prepare_batch_result {
+    transfer_result transfer;
+    std::vector<song_import_request> requests;
+    int overwrite_count = 0;
+};
+
 transfer_result export_chart_package(const state& state, int song_index, int chart_index);
 transfer_result import_chart_package(const state& state, int song_index);
 transfer_result export_song_package(const state& state, int song_index);
 transfer_result import_song_package(const state& state);
 std::optional<chart_import_request> prepare_chart_import(const state& state, transfer_result& result);
+std::optional<chart_import_batch_request> prepare_chart_imports(const state& state, transfer_result& result);
 std::optional<song_export_request> prepare_song_export(const state& state, int song_index);
 std::optional<song_import_request> prepare_song_import(const state& state, transfer_result& result);
 song_import_prepare_result prepare_song_import_from_path(const state& state, const std::string& source_path);
+song_import_prepare_batch_result prepare_song_imports_from_paths(const state& state,
+                                                                 const std::vector<std::string>& source_paths);
 transfer_result import_chart_package(const chart_import_request& request);
+transfer_result import_chart_packages(const std::vector<chart_import_request>& requests);
 transfer_result export_song_package(const song_export_request& request);
 transfer_result import_song_package(const song_import_request& request);
+transfer_result import_song_packages(const std::vector<song_import_request>& requests);
 void cleanup_song_import_request(song_import_request& request);
+void cleanup_song_import_requests(std::vector<song_import_request>& requests);
 
 }  // namespace song_select

--- a/src/scenes/song_select/song_select_command_controller.cpp
+++ b/src/scenes/song_select/song_select_command_controller.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <system_error>
+#include <vector>
 
 #include "core/file_dialog.h"
 #include "core/path_utils.h"
@@ -66,9 +67,9 @@ void apply_context_menu_command(scene_manager& manager, state& state,
     case context_menu_command::import_song:
         close_context_menu(state);
         {
-            const std::string source_path = file_dialog::open_song_package_file();
-            if (!source_path.empty()) {
-                transfer_controller.start_song_import_prepare(state, source_path);
+            const std::vector<std::string> source_paths = file_dialog::open_song_package_files();
+            if (!source_paths.empty()) {
+                transfer_controller.start_song_import_prepare(state, source_paths);
                 queue_status_message(state, transfer_controller.busy_label(), false);
             }
         }
@@ -93,11 +94,11 @@ void apply_context_menu_command(scene_manager& manager, state& state,
     {
         close_context_menu(state);
         transfer_result result;
-        if (const auto request = prepare_chart_import(state, result); request.has_value()) {
-            if (request->overwrite_existing) {
-                open_overwrite_chart_confirmation(*request);
+        if (const auto batch = prepare_chart_imports(state, result); batch.has_value()) {
+            if (batch->overwrite_count > 0) {
+                open_overwrite_chart_confirmation(batch->requests);
             } else {
-                apply_transfer_result(import_chart_package(*request));
+                apply_transfer_result(import_chart_packages(batch->requests));
             }
         } else {
             apply_transfer_result(result);
@@ -250,15 +251,15 @@ void apply_confirmation_command(state& state,
                                              state.confirmation_dialog.chart_index));
         } else if (state.confirmation_dialog.action == pending_confirmation_action::overwrite_song_import) {
             state.confirmation_dialog = {};
-            if (transfer_controller.pending_song_import_request().has_value()) {
-                song_import_request request = *transfer_controller.pending_song_import_request();
-                transfer_controller.start_song_import(request);
+            if (!transfer_controller.pending_song_import_requests().empty()) {
+                std::vector<song_import_request> requests = transfer_controller.pending_song_import_requests();
+                transfer_controller.start_song_imports(std::move(requests));
                 queue_status_message(state, transfer_controller.busy_label(), false);
             }
         } else if (state.confirmation_dialog.action == pending_confirmation_action::overwrite_chart_import) {
             state.confirmation_dialog = {};
-            if (transfer_controller.pending_chart_import_request().has_value()) {
-                apply_transfer_result(import_chart_package(*transfer_controller.pending_chart_import_request()));
+            if (!transfer_controller.pending_chart_import_requests().empty()) {
+                apply_transfer_result(import_chart_packages(transfer_controller.pending_chart_import_requests()));
                 transfer_controller.clear_pending_chart_import_request();
             }
         }

--- a/src/scenes/song_select/song_select_command_controller.h
+++ b/src/scenes/song_select/song_select_command_controller.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <functional>
+#include <vector>
 
 #include "core/scene_manager.h"
 #include "song_select/song_preview_controller.h"
@@ -15,8 +16,8 @@ namespace song_select::commands {
 using apply_transfer_result_fn = std::function<void(const transfer_result&)>;
 using apply_delete_result_fn = std::function<void(const delete_result&)>;
 using reload_song_library_fn = std::function<void(const std::string&, const std::string&)>;
-using open_overwrite_song_confirmation_fn = std::function<void(song_import_request)>;
-using open_overwrite_chart_confirmation_fn = std::function<void(chart_import_request)>;
+using open_overwrite_song_confirmation_fn = std::function<void(std::vector<song_import_request>)>;
+using open_overwrite_chart_confirmation_fn = std::function<void(std::vector<chart_import_request>)>;
 
 void apply_context_menu_command(scene_manager& manager, state& state,
                                 transfer::controller& transfer_controller,

--- a/src/scenes/song_select/song_select_navigation.cpp
+++ b/src/scenes/song_select/song_select_navigation.cpp
@@ -84,7 +84,7 @@ std::unique_ptr<scene> make_edit_chart_scene(scene_manager& manager, const song_
 
 std::unique_ptr<scene> make_play_scene(scene_manager& manager, const song_entry& song, const chart_option& chart) {
     save_last_played_selection(song.song.meta.song_id, chart.meta.chart_id);
-    return std::make_unique<play_scene>(manager, song.song, chart.path, chart.meta.key_count);
+    return std::make_unique<play_scene>(manager, song.song, chart.path, chart.meta.key_count, chart.meta.level);
 }
 
 std::unique_ptr<scene> make_mv_editor_scene(scene_manager& manager, const song_entry& song) {

--- a/src/scenes/song_select/song_transfer_controller.cpp
+++ b/src/scenes/song_select/song_transfer_controller.cpp
@@ -14,13 +14,17 @@ void controller::on_exit() {
 }
 
 void controller::start_song_import_prepare(const state& catalog_state, std::string source_path) {
+    start_song_import_prepare(catalog_state, std::vector<std::string>{std::move(source_path)});
+}
+
+void controller::start_song_import_prepare(const state& catalog_state, std::vector<std::string> source_paths) {
     prepare_active_ = true;
-    busy_label_ = "Reading song package...";
-    std::promise<song_import_prepare_result> promise;
+    busy_label_ = source_paths.size() <= 1 ? "Reading song package..." : "Reading song packages...";
+    std::promise<song_import_prepare_batch_result> promise;
     background_song_import_prepare_ = promise.get_future();
-    std::thread([promise = std::move(promise), catalog_state, source_path = std::move(source_path)]() mutable {
+    std::thread([promise = std::move(promise), catalog_state, source_paths = std::move(source_paths)]() mutable {
         try {
-            promise.set_value(prepare_song_import_from_path(catalog_state, source_path));
+            promise.set_value(prepare_song_imports_from_paths(catalog_state, source_paths));
         } catch (...) {
             promise.set_exception(std::current_exception());
         }
@@ -42,21 +46,25 @@ void controller::start_song_export(song_export_request request) {
 }
 
 void controller::start_song_import(song_import_request request) {
+    start_song_imports(std::vector<song_import_request>{std::move(request)});
+}
+
+void controller::start_song_imports(std::vector<song_import_request> requests) {
     transfer_active_ = true;
-    busy_label_ = "Importing song package...";
-    pending_song_import_request_ = request;
+    busy_label_ = requests.size() <= 1 ? "Importing song package..." : "Importing song packages...";
+    pending_song_import_requests_ = requests;
     std::promise<transfer_result> promise;
     background_transfer_ = promise.get_future();
-    std::thread([promise = std::move(promise), request = std::move(request)]() mutable {
+    std::thread([promise = std::move(promise), requests = std::move(requests)]() mutable {
         try {
-            promise.set_value(import_song_package(request));
+            promise.set_value(import_song_packages(requests));
         } catch (...) {
             promise.set_exception(std::current_exception());
         }
     }).detach();
 }
 
-std::optional<song_import_prepare_result> controller::poll_song_import_prepare() {
+std::optional<song_import_prepare_batch_result> controller::poll_song_import_prepare() {
     if (!prepare_active_) {
         return std::nullopt;
     }
@@ -69,12 +77,12 @@ std::optional<song_import_prepare_result> controller::poll_song_import_prepare()
     try {
         return background_song_import_prepare_.get();
     } catch (const std::exception& ex) {
-        song_import_prepare_result result;
+        song_import_prepare_batch_result result;
         result.transfer.success = false;
         result.transfer.message = ex.what();
         return result;
     } catch (...) {
-        song_import_prepare_result result;
+        song_import_prepare_batch_result result;
         result.transfer.success = false;
         result.transfer.message = "Failed to read song package.";
         return result;
@@ -106,22 +114,30 @@ std::optional<transfer_result> controller::poll_background_transfer() {
 }
 
 void controller::set_pending_song_import_request(song_import_request request) {
-    pending_song_import_request_ = std::move(request);
+    set_pending_song_import_requests(std::vector<song_import_request>{std::move(request)});
+}
+
+void controller::set_pending_song_import_requests(std::vector<song_import_request> requests) {
+    pending_song_import_requests_ = std::move(requests);
 }
 
 void controller::clear_pending_song_import_request(bool cleanup_request) {
-    if (cleanup_request && pending_song_import_request_.has_value()) {
-        cleanup_song_import_request(*pending_song_import_request_);
+    if (cleanup_request) {
+        cleanup_song_import_requests(pending_song_import_requests_);
     }
-    pending_song_import_request_.reset();
+    pending_song_import_requests_.clear();
 }
 
 void controller::set_pending_chart_import_request(chart_import_request request) {
-    pending_chart_import_request_ = std::move(request);
+    set_pending_chart_import_requests(std::vector<chart_import_request>{std::move(request)});
+}
+
+void controller::set_pending_chart_import_requests(std::vector<chart_import_request> requests) {
+    pending_chart_import_requests_ = std::move(requests);
 }
 
 void controller::clear_pending_chart_import_request() {
-    pending_chart_import_request_.reset();
+    pending_chart_import_requests_.clear();
 }
 
 }  // namespace song_select::transfer

--- a/src/scenes/song_select/song_transfer_controller.h
+++ b/src/scenes/song_select/song_transfer_controller.h
@@ -3,6 +3,7 @@
 #include <future>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "song_select/song_import_export_service.h"
 
@@ -18,32 +19,36 @@ public:
     [[nodiscard]] const std::string& busy_label() const { return busy_label_; }
 
     void start_song_import_prepare(const state& catalog_state, std::string source_path);
+    void start_song_import_prepare(const state& catalog_state, std::vector<std::string> source_paths);
     void start_song_export(song_export_request request);
     void start_song_import(song_import_request request);
+    void start_song_imports(std::vector<song_import_request> requests);
 
-    std::optional<song_import_prepare_result> poll_song_import_prepare();
+    std::optional<song_import_prepare_batch_result> poll_song_import_prepare();
     std::optional<transfer_result> poll_background_transfer();
 
     void set_pending_song_import_request(song_import_request request);
-    [[nodiscard]] const std::optional<song_import_request>& pending_song_import_request() const {
-        return pending_song_import_request_;
+    void set_pending_song_import_requests(std::vector<song_import_request> requests);
+    [[nodiscard]] const std::vector<song_import_request>& pending_song_import_requests() const {
+        return pending_song_import_requests_;
     }
     void clear_pending_song_import_request(bool cleanup_request);
 
     void set_pending_chart_import_request(chart_import_request request);
-    [[nodiscard]] const std::optional<chart_import_request>& pending_chart_import_request() const {
-        return pending_chart_import_request_;
+    void set_pending_chart_import_requests(std::vector<chart_import_request> requests);
+    [[nodiscard]] const std::vector<chart_import_request>& pending_chart_import_requests() const {
+        return pending_chart_import_requests_;
     }
     void clear_pending_chart_import_request();
 
 private:
     std::future<transfer_result> background_transfer_;
-    std::future<song_import_prepare_result> background_song_import_prepare_;
+    std::future<song_import_prepare_batch_result> background_song_import_prepare_;
     bool transfer_active_ = false;
     bool prepare_active_ = false;
     std::string busy_label_;
-    std::optional<song_import_request> pending_song_import_request_;
-    std::optional<chart_import_request> pending_chart_import_request_;
+    std::vector<song_import_request> pending_song_import_requests_;
+    std::vector<chart_import_request> pending_chart_import_requests_;
 };
 
 }  // namespace song_select::transfer

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -237,22 +237,26 @@ void song_select_scene::apply_transfer_result(const song_select::transfer_result
     song_select::queue_status_message(state_, result.message, false);
 }
 
-void song_select_scene::open_overwrite_song_confirmation(song_select::song_import_request request) {
-    transfer_controller_.set_pending_song_import_request(std::move(request));
+void song_select_scene::open_overwrite_song_confirmation(std::vector<song_select::song_import_request> requests) {
+    const size_t overwrite_count = requests.size();
+    transfer_controller_.set_pending_song_import_requests(std::move(requests));
     song_select::open_confirmation_dialog(
         state_, song_select::pending_confirmation_action::overwrite_song_import,
-        "Overwrite Song",
-        "A user song with the same song ID already exists. Overwrite it?",
+        overwrite_count <= 1 ? "Overwrite Song" : "Overwrite Songs",
+        overwrite_count <= 1 ? "A user song with the same song ID already exists. Overwrite it?"
+                             : "Some selected songs already exist. Overwrite them?",
         "",
         "OVERWRITE");
 }
 
-void song_select_scene::open_overwrite_chart_confirmation(song_select::chart_import_request request) {
-    transfer_controller_.set_pending_chart_import_request(std::move(request));
+void song_select_scene::open_overwrite_chart_confirmation(std::vector<song_select::chart_import_request> requests) {
+    const size_t overwrite_count = requests.size();
+    transfer_controller_.set_pending_chart_import_requests(std::move(requests));
     song_select::open_confirmation_dialog(
         state_, song_select::pending_confirmation_action::overwrite_chart_import,
-        "Overwrite Chart",
-        "A user chart with the same chart ID already exists. Overwrite it?",
+        overwrite_count <= 1 ? "Overwrite Chart" : "Overwrite Charts",
+        overwrite_count <= 1 ? "A user chart with the same chart ID already exists. Overwrite it?"
+                             : "Some selected charts already exist. Overwrite them?",
         "",
         "OVERWRITE");
 }
@@ -425,12 +429,12 @@ void song_select_scene::update(float dt) {
     }
     auth_overlay::poll_request(auth_controller_, state_.auth, state_.login_dialog);
     if (const auto prepared = transfer_controller_.poll_song_import_prepare(); prepared.has_value()) {
-        if (!prepared->request.has_value()) {
+        if (prepared->requests.empty()) {
             apply_transfer_result(prepared->transfer);
-        } else if (prepared->request->overwrite_existing) {
-            open_overwrite_song_confirmation(*prepared->request);
+        } else if (prepared->overwrite_count > 0) {
+            open_overwrite_song_confirmation(prepared->requests);
         } else {
-            transfer_controller_.start_song_import(*prepared->request);
+            transfer_controller_.start_song_imports(prepared->requests);
             song_select::queue_status_message(state_, transfer_controller_.busy_label(), false);
         }
     }
@@ -666,8 +670,12 @@ void song_select_scene::draw() {
             [this](const std::string& preferred_song_id, const std::string& preferred_chart_id) {
                 reload_song_library(preferred_song_id, preferred_chart_id);
             },
-            [this](song_select::song_import_request request) { open_overwrite_song_confirmation(std::move(request)); },
-            [this](song_select::chart_import_request request) { open_overwrite_chart_confirmation(std::move(request)); });
+            [this](std::vector<song_select::song_import_request> requests) {
+                open_overwrite_song_confirmation(std::move(requests));
+            },
+            [this](std::vector<song_select::chart_import_request> requests) {
+                open_overwrite_chart_confirmation(std::move(requests));
+            });
         const song_select::login_dialog_command login_command =
             song_select::draw_login_dialog(state_, auth_controller_.request_active);
         if (login_command == song_select::login_dialog_command::close) {
@@ -699,8 +707,12 @@ void song_select_scene::draw() {
         [this](const std::string& preferred_song_id, const std::string& preferred_chart_id) {
             reload_song_library(preferred_song_id, preferred_chart_id);
         },
-        [this](song_select::song_import_request request) { open_overwrite_song_confirmation(std::move(request)); },
-        [this](song_select::chart_import_request request) { open_overwrite_chart_confirmation(std::move(request)); });
+        [this](std::vector<song_select::song_import_request> requests) {
+            open_overwrite_song_confirmation(std::move(requests));
+        },
+        [this](std::vector<song_select::chart_import_request> requests) {
+            open_overwrite_chart_confirmation(std::move(requests));
+        });
     song_select::commands::apply_confirmation_command(
         state_, preview_controller_, transfer_controller_, song_select::draw_confirmation_dialog(state_),
         [this](const song_select::delete_result& result) { apply_delete_result(result); },

--- a/src/scenes/song_select_scene.h
+++ b/src/scenes/song_select_scene.h
@@ -3,6 +3,7 @@
 #include <future>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "raylib.h"
 #include "scene.h"
@@ -41,8 +42,8 @@ private:
     void poll_selected_chart_ranking();
     void refresh_auth_state();
     bool handle_song_list_pointer(Vector2 mouse, bool left_pressed, bool right_pressed);
-    void open_overwrite_song_confirmation(song_select::song_import_request request);
-    void open_overwrite_chart_confirmation(song_select::chart_import_request request);
+    void open_overwrite_song_confirmation(std::vector<song_select::song_import_request> requests);
+    void open_overwrite_chart_confirmation(std::vector<song_select::chart_import_request> requests);
 
     song_select::state state_;
     song_select::preview_controller preview_controller_;

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -118,6 +118,15 @@ bool select_local_song(song_select::state& state, const std::string& song_id) {
     return false;
 }
 
+bool consume_startup_level_calculation() {
+    static bool consumed = false;
+    if (consumed) {
+        return false;
+    }
+    consumed = true;
+    return true;
+}
+
 }  // namespace
 
 title_scene::title_scene(scene_manager& manager,
@@ -900,6 +909,16 @@ title_audio_policy::hub_mode title_scene::current_audio_mode() const {
 }
 
 void title_scene::on_enter() {
+    const bool calculate_startup_levels = consume_startup_level_calculation();
+    song_select::catalog_data startup_catalog;
+    try {
+        startup_catalog = song_select::load_catalog(calculate_startup_levels);
+    } catch (const std::exception& ex) {
+        startup_catalog.load_errors = {ex.what()};
+    } catch (...) {
+        startup_catalog.load_errors = {"Failed to load song catalog."};
+    }
+
     audio_controller_.configure(kTitleIntroPath, kTitleLoopPath);
     audio_controller_.on_enter();
     song_select::reset_for_enter(play_state_);
@@ -937,10 +956,10 @@ void title_scene::on_enter() {
     play_entry_origin_rect_ = {};
     play_state_.login_dialog.open = false;
     title_online_view::reload_catalog(online_state_);
-    request_play_catalog_reload(preferred_song_id_, preferred_chart_id_,
-                                mode_ == hub_mode::play || mode_ == hub_mode::create);
+    song_select::apply_catalog(play_state_, std::move(startup_catalog), preferred_song_id_, preferred_chart_id_);
     if (mode_ == hub_mode::play || mode_ == hub_mode::create) {
         play_entry_origin_rect_ = title_home_view::button_rect(home_menu_selected_index_, home_menu_anim_);
+        sync_play_media();
     }
     if (play_state_.auth.logged_in) {
         auth_overlay::start_restore(auth_controller_, play_state_.login_dialog);

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <thread>
 #include <utility>
+#include <vector>
 
 #include "core/file_dialog.h"
 #include "raylib.h"
@@ -465,34 +466,38 @@ void title_scene::apply_play_transfer_result(const song_select::transfer_result&
     song_select::queue_status_message(play_state_, result.message, false);
 }
 
-void title_scene::open_overwrite_song_confirmation(song_select::song_import_request request) {
-    transfer_controller_.set_pending_song_import_request(std::move(request));
+void title_scene::open_overwrite_song_confirmation(std::vector<song_select::song_import_request> requests) {
+    const size_t overwrite_count = requests.size();
+    transfer_controller_.set_pending_song_import_requests(std::move(requests));
     song_select::open_confirmation_dialog(
         play_state_, song_select::pending_confirmation_action::overwrite_song_import,
-        "Overwrite Song",
-        "A user song with the same song ID already exists. Overwrite it?",
+        overwrite_count <= 1 ? "Overwrite Song" : "Overwrite Songs",
+        overwrite_count <= 1 ? "A user song with the same song ID already exists. Overwrite it?"
+                             : "Some selected songs already exist. Overwrite them?",
         "",
         "OVERWRITE");
 }
 
-void title_scene::open_overwrite_chart_confirmation(song_select::chart_import_request request) {
-    transfer_controller_.set_pending_chart_import_request(std::move(request));
+void title_scene::open_overwrite_chart_confirmation(std::vector<song_select::chart_import_request> requests) {
+    const size_t overwrite_count = requests.size();
+    transfer_controller_.set_pending_chart_import_requests(std::move(requests));
     song_select::open_confirmation_dialog(
         play_state_, song_select::pending_confirmation_action::overwrite_chart_import,
-        "Overwrite Chart",
-        "A user chart with the same chart ID already exists. Overwrite it?",
+        overwrite_count <= 1 ? "Overwrite Chart" : "Overwrite Charts",
+        overwrite_count <= 1 ? "A user chart with the same chart ID already exists. Overwrite it?"
+                             : "Some selected charts already exist. Overwrite them?",
         "",
         "OVERWRITE");
 }
 
 void title_scene::poll_play_transfer() {
     if (const auto prepared = transfer_controller_.poll_song_import_prepare(); prepared.has_value()) {
-        if (!prepared->request.has_value()) {
+        if (prepared->requests.empty()) {
             apply_play_transfer_result(prepared->transfer);
-        } else if (prepared->request->overwrite_existing) {
-            open_overwrite_song_confirmation(*prepared->request);
+        } else if (prepared->overwrite_count > 0) {
+            open_overwrite_song_confirmation(prepared->requests);
         } else {
-            transfer_controller_.start_song_import(*prepared->request);
+            transfer_controller_.start_song_imports(prepared->requests);
             song_select::queue_status_message(play_state_, transfer_controller_.busy_label(), false);
         }
     }
@@ -502,21 +507,21 @@ void title_scene::poll_play_transfer() {
 }
 
 void title_scene::start_song_import() {
-    const std::string source_path = file_dialog::open_song_package_file();
-    if (source_path.empty()) {
+    const std::vector<std::string> source_paths = file_dialog::open_song_package_files();
+    if (source_paths.empty()) {
         return;
     }
-    transfer_controller_.start_song_import_prepare(play_state_, source_path);
+    transfer_controller_.start_song_import_prepare(play_state_, source_paths);
     song_select::queue_status_message(play_state_, transfer_controller_.busy_label(), false);
 }
 
 void title_scene::start_chart_import() {
     song_select::transfer_result result;
-    if (const auto request = song_select::prepare_chart_import(play_state_, result); request.has_value()) {
-        if (request->overwrite_existing) {
-            open_overwrite_chart_confirmation(*request);
+    if (const auto batch = song_select::prepare_chart_imports(play_state_, result); batch.has_value()) {
+        if (batch->overwrite_count > 0) {
+            open_overwrite_chart_confirmation(batch->requests);
         } else {
-            apply_play_transfer_result(song_select::import_chart_package(*request));
+            apply_play_transfer_result(song_select::import_chart_packages(batch->requests));
         }
     } else {
         apply_play_transfer_result(result);

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -13,6 +13,7 @@
 #include <future>
 #include <optional>
 #include <string>
+#include <vector>
 
 // タイトル画面。曲選択画面・設定画面への遷移を提供する。
 class title_scene final : public scene {
@@ -58,8 +59,8 @@ private:
     void update_common_animation(float dt);
     void apply_play_delete_result(const song_select::delete_result& result);
     void apply_play_transfer_result(const song_select::transfer_result& result);
-    void open_overwrite_song_confirmation(song_select::song_import_request request);
-    void open_overwrite_chart_confirmation(song_select::chart_import_request request);
+    void open_overwrite_song_confirmation(std::vector<song_select::song_import_request> requests);
+    void open_overwrite_chart_confirmation(std::vector<song_select::chart_import_request> requests);
     void poll_play_transfer();
     void start_song_import();
     void start_chart_import();

--- a/src/tests/chart_difficulty_smoke.cpp
+++ b/src/tests/chart_difficulty_smoke.cpp
@@ -1,6 +1,9 @@
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "chart_difficulty.h"
 
@@ -58,6 +61,68 @@ chart_data make_hard_chart() {
     return data;
 }
 
+chart_data make_chart(std::string chart_id, std::vector<note_data> notes) {
+    chart_data data;
+    data.meta.chart_id = std::move(chart_id);
+    data.meta.key_count = 4;
+    data.meta.difficulty = "Pattern";
+    data.meta.resolution = 480;
+    data.meta.format_version = 1;
+    data.timing_events = {
+        {timing_event_type::bpm, 0, 120.0f, 4, 4},
+        {timing_event_type::meter, 0, 0.0f, 4, 4},
+    };
+    data.notes = std::move(notes);
+    return data;
+}
+
+chart_data make_hold_conflict_chart(bool same_hand) {
+    std::vector<note_data> notes = {
+        {note_type::hold, 0, 0, 2160},
+    };
+    const int tap_lane = same_hand ? 1 : 3;
+    for (int tick = 120; tick <= 2040; tick += 120) {
+        notes.push_back({note_type::tap, tick, tap_lane, 0});
+    }
+    return make_chart(same_hand ? "same_hand_hold" : "opposite_hand_hold", std::move(notes));
+}
+
+chart_data make_chord_shape_chart() {
+    std::vector<note_data> notes;
+    for (int tick = 0; tick < 3840; tick += 240) {
+        notes.push_back({note_type::tap, tick, 0, 0});
+        notes.push_back({note_type::tap, tick, 3, 0});
+    }
+    return make_chart("wide_chords", std::move(notes));
+}
+
+chart_data make_split_shape_chart() {
+    std::vector<note_data> notes;
+    const int lanes[] = {0, 3};
+    for (int i = 0; i < 32; ++i) {
+        notes.push_back({note_type::tap, i * 120, lanes[i % 2], 0});
+    }
+    return make_chart("split_taps", std::move(notes));
+}
+
+chart_data make_one_hand_stream_chart() {
+    std::vector<note_data> notes;
+    const int lanes[] = {0, 1};
+    for (int i = 0; i < 32; ++i) {
+        notes.push_back({note_type::tap, i * 120, lanes[i % 2], 0});
+    }
+    return make_chart("one_hand_stream", std::move(notes));
+}
+
+chart_data make_balanced_stream_chart() {
+    std::vector<note_data> notes;
+    const int lanes[] = {0, 2, 1, 3};
+    for (int i = 0; i < 32; ++i) {
+        notes.push_back({note_type::tap, i * 120, lanes[i % 4], 0});
+    }
+    return make_chart("balanced_stream", std::move(notes));
+}
+
 bool approx(float actual, float expected, float tolerance = 0.05f) {
     return std::fabs(actual - expected) <= tolerance;
 }
@@ -100,6 +165,30 @@ int main() {
         chart_difficulty::level_from_rating(1000.0f) >= chart_difficulty::level_from_rating(10000.0f) ||
         chart_difficulty::level_from_rating(10000.0f) >= chart_difficulty::level_from_rating(100000.0f)) {
         std::cerr << "Expected calibrated display levels to stay monotonic across rating decades\n";
+        return EXIT_FAILURE;
+    }
+
+    const float same_hand_hold = chart_difficulty::calculate_rating(make_hold_conflict_chart(true));
+    const float opposite_hand_hold = chart_difficulty::calculate_rating(make_hold_conflict_chart(false));
+    if (same_hand_hold <= opposite_hand_hold * 1.08f) {
+        std::cerr << "Expected same-hand LN responsibility conflict to rate higher than opposite-hand handling: "
+                  << same_hand_hold << " <= " << opposite_hand_hold << "\n";
+        return EXIT_FAILURE;
+    }
+
+    const float wide_chords = chart_difficulty::calculate_rating(make_chord_shape_chart());
+    const float split_taps = chart_difficulty::calculate_rating(make_split_shape_chart());
+    if (wide_chords <= split_taps) {
+        std::cerr << "Expected simultaneous chord shapes to rate higher than split taps with the same note count: "
+                  << wide_chords << " <= " << split_taps << "\n";
+        return EXIT_FAILURE;
+    }
+
+    const float one_hand_stream = chart_difficulty::calculate_rating(make_one_hand_stream_chart());
+    const float balanced_stream = chart_difficulty::calculate_rating(make_balanced_stream_chart());
+    if (one_hand_stream <= balanced_stream * 0.95f) {
+        std::cerr << "Expected one-hand stream burden to stay visible against balanced streams: "
+                  << one_hand_stream << " <= " << balanced_stream << "\n";
         return EXIT_FAILURE;
     }
 

--- a/src/tests/chart_difficulty_smoke.cpp
+++ b/src/tests/chart_difficulty_smoke.cpp
@@ -168,6 +168,15 @@ int main() {
         return EXIT_FAILURE;
     }
 
+    chart_data legacy_level = hard;
+    legacy_level.meta.level = 55.0f;
+    chart_difficulty::apply_auto_level(legacy_level);
+    if (legacy_level.meta.level == 55.0f ||
+        !approx(legacy_level.meta.level, chart_difficulty::calculate_level(hard))) {
+        std::cerr << "Expected legacy rchart level metadata to be replaced with auto level\n";
+        return EXIT_FAILURE;
+    }
+
     const float same_hand_hold = chart_difficulty::calculate_rating(make_hold_conflict_chart(true));
     const float opposite_hand_hold = chart_difficulty::calculate_rating(make_hold_conflict_chart(false));
     if (same_hand_hold <= opposite_hand_hold * 1.08f) {

--- a/src/tests/chart_difficulty_smoke.cpp
+++ b/src/tests/chart_difficulty_smoke.cpp
@@ -1,3 +1,4 @@
+#include <cmath>
 #include <cstdlib>
 #include <iostream>
 
@@ -57,6 +58,10 @@ chart_data make_hard_chart() {
     return data;
 }
 
+bool approx(float actual, float expected, float tolerance = 0.05f) {
+    return std::fabs(actual - expected) <= tolerance;
+}
+
 }  // namespace
 
 int main() {
@@ -72,6 +77,29 @@ int main() {
     }
     if (hard_level <= easy_level) {
         std::cerr << "Expected hard chart level to exceed easy chart level\n";
+        return EXIT_FAILURE;
+    }
+
+    const float normal_sample = chart_difficulty::level_from_rating(3837.7f);
+    const float hard_sample = chart_difficulty::level_from_rating(18741.8f);
+    const float prism_sample = chart_difficulty::level_from_rating(44933.6f);
+    const float ray_sample = chart_difficulty::level_from_rating(130846.7f);
+
+    if (!approx(normal_sample, 4.3f) ||
+        !approx(hard_sample, 6.3f) ||
+        !approx(prism_sample, 7.5f) ||
+        !approx(ray_sample, 8.9f)) {
+        std::cerr << "Expected known raw ratings to map into the calibrated display range\n";
+        return EXIT_FAILURE;
+    }
+    if (ray_sample - normal_sample < 4.0f) {
+        std::cerr << "Expected display levels to keep enough separation across known charts\n";
+        return EXIT_FAILURE;
+    }
+    if (chart_difficulty::level_from_rating(100.0f) >= chart_difficulty::level_from_rating(1000.0f) ||
+        chart_difficulty::level_from_rating(1000.0f) >= chart_difficulty::level_from_rating(10000.0f) ||
+        chart_difficulty::level_from_rating(10000.0f) >= chart_difficulty::level_from_rating(100000.0f)) {
+        std::cerr << "Expected calibrated display levels to stay monotonic across rating decades\n";
         return EXIT_FAILURE;
     }
 

--- a/src/tests/chart_serializer_smoke.cpp
+++ b/src/tests/chart_serializer_smoke.cpp
@@ -8,7 +8,6 @@
 #include <iostream>
 #include <string>
 
-#include "chart_difficulty.h"
 #include "chart_parser.h"
 #include "chart_serializer.h"
 
@@ -21,7 +20,6 @@ bool equal_chart_meta(const chart_meta& left, const chart_meta& right) {
     return left.chart_id == right.chart_id &&
            left.key_count == right.key_count &&
            left.difficulty == right.difficulty &&
-           left.level == right.level &&
            left.chart_author == right.chart_author &&
            left.format_version == right.format_version &&
            left.resolution == right.resolution &&
@@ -129,7 +127,7 @@ int main() {
     bool ok = true;
 
     ok = content.find("offset=-35") != std::string::npos && ok;
-    ok = content.find("level=9.0") == std::string::npos && ok;
+    ok = content.find("level=") == std::string::npos && ok;
     ok = expect_contains_in_order(content, "meter,0,4/4", "bpm,960,180.5") && ok;
     ok = expect_contains_in_order(content, "tap,480,0", "hold,480,2,840") && ok;
 
@@ -144,7 +142,6 @@ int main() {
     }
 
     chart_data expected = normalized_chart(source);
-    chart_difficulty::apply_auto_level(expected);
     if (!equal_chart_data(expected, *reparsed.data)) {
         std::cerr << "Round-trip chart data mismatch\n";
         ok = false;

--- a/src/tests/chart_serializer_smoke.cpp
+++ b/src/tests/chart_serializer_smoke.cpp
@@ -8,6 +8,7 @@
 #include <iostream>
 #include <string>
 
+#include "chart_difficulty.h"
 #include "chart_parser.h"
 #include "chart_serializer.h"
 
@@ -128,6 +129,7 @@ int main() {
     bool ok = true;
 
     ok = content.find("offset=-35") != std::string::npos && ok;
+    ok = content.find("level=9.0") == std::string::npos && ok;
     ok = expect_contains_in_order(content, "meter,0,4/4", "bpm,960,180.5") && ok;
     ok = expect_contains_in_order(content, "tap,480,0", "hold,480,2,840") && ok;
 
@@ -141,7 +143,8 @@ int main() {
         return EXIT_FAILURE;
     }
 
-    const chart_data expected = normalized_chart(source);
+    chart_data expected = normalized_chart(source);
+    chart_difficulty::apply_auto_level(expected);
     if (!equal_chart_data(expected, *reparsed.data)) {
         std::cerr << "Round-trip chart data mismatch\n";
         ok = false;

--- a/src/tests/song_loader_smoke.cpp
+++ b/src/tests/song_loader_smoke.cpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <string>
 
-#include "chart_difficulty.h"
 #include "song_loader.h"
 
 namespace {
@@ -104,10 +103,8 @@ int main() {
         }
         ok = false;
     } else {
-        const float expected_level = chart_difficulty::calculate_level(*chart_result.data);
-        if (chart_result.data->meta.level == 55.0f ||
-            chart_result.data->meta.level != expected_level) {
-            std::cerr << "Expected loaded chart level to be normalized to auto level\n";
+        if (chart_result.data->meta.level != 0.0f) {
+            std::cerr << "Expected legacy chart level metadata to be ignored by the loader\n";
             ok = false;
         }
     }
@@ -131,11 +128,6 @@ int main() {
                 std::cerr << "Expected deferred chart load to succeed\n";
                 ok = false;
             } else {
-                const float expected_level = chart_difficulty::calculate_level(*loaded_chart.data);
-                if (loaded_chart.data->meta.level != expected_level) {
-                    std::cerr << "Expected loaded chart level to be normalized to auto level\n";
-                    ok = false;
-                }
             }
         }
     }

--- a/src/tests/song_loader_smoke.cpp
+++ b/src/tests/song_loader_smoke.cpp
@@ -1,8 +1,10 @@
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 
+#include "chart_difficulty.h"
 #include "song_loader.h"
 
 namespace {
@@ -14,6 +16,10 @@ std::string songs_root() {
 
 size_t expected_song_count() {
     const std::filesystem::path root = songs_root();
+    if (!std::filesystem::exists(root)) {
+        return 0;
+    }
+
     size_t count = 0;
     for (const auto& entry : std::filesystem::directory_iterator(root)) {
         if (entry.is_directory() && std::filesystem::exists(entry.path() / "song.json")) {
@@ -22,24 +28,92 @@ size_t expected_song_count() {
     }
     return count;
 }
+
+std::filesystem::path write_temp_chart() {
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "raythm_song_loader_auto_level.rchart";
+    std::ofstream output(path, std::ios::trunc);
+    output << "[Metadata]\n"
+           << "chartId=song-loader-auto-level\n"
+           << "keyCount=4\n"
+           << "difficulty=Legacy\n"
+           << "level=55.0\n"
+           << "chartAuthor=Codex\n"
+           << "formatVersion=1\n"
+           << "resolution=480\n"
+           << "offset=0\n"
+           << "songId=song-loader-song\n"
+           << "isPublic=false\n\n"
+           << "[Timing]\n"
+           << "bpm,0,120\n"
+           << "meter,0,4/4\n\n"
+           << "[Notes]\n"
+           << "tap,0,0\n"
+           << "tap,240,1\n"
+           << "tap,480,2\n"
+           << "tap,720,3\n";
+    return path;
+}
 }
 
 int main() {
-    const song_load_result load_result = song_loader::load_all(songs_root());
-
     bool ok = true;
-    if (load_result.songs.size() != expected_song_count()) {
-        std::cerr << "Expected every song package under assets/songs to load, got "
-                  << load_result.songs.size() << '\n';
-        ok = false;
+    song_load_result load_result;
+    if (std::filesystem::exists(songs_root())) {
+        load_result = song_loader::load_all(songs_root());
+
+        if (load_result.songs.size() != expected_song_count()) {
+            std::cerr << "Expected every song package under assets/songs to load, got "
+                      << load_result.songs.size() << '\n';
+            ok = false;
+        }
+
+        if (!load_result.errors.empty()) {
+            std::cerr << "Expected no song loading errors\n";
+            ok = false;
+        }
+
+        if (ok) {
+            const song_data* song_with_chart = nullptr;
+            for (const song_data& candidate : load_result.songs) {
+                if (!candidate.chart_paths.empty()) {
+                    song_with_chart = &candidate;
+                    break;
+                }
+            }
+
+            if (song_with_chart != nullptr) {
+                const chart_parse_result chart_result = song_loader::load_chart(song_with_chart->chart_paths.front());
+                if (!chart_result.success || !chart_result.data.has_value()) {
+                    std::cerr << "Expected deferred chart load to succeed\n";
+                    for (const std::string& error : chart_result.errors) {
+                        std::cerr << "  " << error << '\n';
+                    }
+                    ok = false;
+                }
+            }
+        }
     }
 
-    if (!load_result.errors.empty()) {
-        std::cerr << "Expected no song loading errors\n";
+    const std::filesystem::path temp_chart = write_temp_chart();
+    const chart_parse_result chart_result = song_loader::load_chart(temp_chart.string());
+    if (!chart_result.success || !chart_result.data.has_value()) {
+        std::cerr << "Expected temp chart load to succeed\n";
+        for (const std::string& error : chart_result.errors) {
+            std::cerr << "  " << error << '\n';
+        }
         ok = false;
+    } else {
+        const float expected_level = chart_difficulty::calculate_level(*chart_result.data);
+        if (chart_result.data->meta.level == 55.0f ||
+            chart_result.data->meta.level != expected_level) {
+            std::cerr << "Expected loaded chart level to be normalized to auto level\n";
+            ok = false;
+        }
     }
+    std::filesystem::remove(temp_chart);
 
-    if (ok) {
+    if (std::filesystem::exists(songs_root()) && ok) {
         const song_data* song_with_chart = nullptr;
         for (const song_data& candidate : load_result.songs) {
             if (!candidate.chart_paths.empty()) {
@@ -52,13 +126,16 @@ int main() {
             std::cerr << "Expected at least one loaded song to have a chart\n";
             ok = false;
         } else {
-            const chart_parse_result chart_result = song_loader::load_chart(song_with_chart->chart_paths.front());
-            if (!chart_result.success || !chart_result.data.has_value()) {
+            const chart_parse_result loaded_chart = song_loader::load_chart(song_with_chart->chart_paths.front());
+            if (!loaded_chart.success || !loaded_chart.data.has_value()) {
                 std::cerr << "Expected deferred chart load to succeed\n";
-                for (const std::string& error : chart_result.errors) {
-                    std::cerr << "  " << error << '\n';
-                }
                 ok = false;
+            } else {
+                const float expected_level = chart_difficulty::calculate_level(*loaded_chart.data);
+                if (loaded_chart.data->meta.level != expected_level) {
+                    std::cerr << "Expected loaded chart level to be normalized to auto level\n";
+                    ok = false;
+                }
             }
         }
     }


### PR DESCRIPTION
## 概要
- `calculate_rating()` の解析結果から表示用 `Lv.` へ変換する `level_from_rating()` を追加
- 従来の強すぎる圧縮式を、実譜面サンプルが 4.3 / 6.3 / 7.5 / 8.9 付近へ広がるキャリブレーションへ変更
- 難易度計算に、同時押し形状、片手局所負荷、LN中の同手責務衝突、トリル/階段/アンカー系パターン、リズムの読みにくさを追加
- 新規特徴量は主成分を食いすぎないよう重みと複合ボーナスを抑え、LN終点付近の同手衝突には上限を設定
- `rchart` 形式から `level=` を削除し、保存時に出力しないよう変更
- 既存譜面に残っている legacy `level=` は読み込み時に無視
- 難易度計算結果はメモリ上の `chart_level_cache` に保持し、起動初回のカタログロード時だけ未計算譜面をまとめて計算
- 起動初回のカタログロードはタイトルBGM開始・イントロフェード開始より前に同期実行
- 譜面/曲パッケージのインポート時は保存直後に1回だけ難易度を計算してキャッシュへ反映
- 曲パッケージ `.rpack` と譜面 `.rchart` のインポートで複数ファイル選択に対応
- 複数インポート時は同名ID/既存IDをまとめて上書き確認し、成功件数をステータス表示
- プレイ開始時の `load_chart()` / `play_session_loader` では難易度を再計算せず、曲選択で保持していた自動計算済みレベルをMVコンテキストとリザルトへ渡す
- `chart_difficulty_smoke` / `chart_serializer_smoke` / `song_loader_smoke` に legacy level 無視・保存時非出力・loader非計算の検証を追加

## 確認
- `cmake --build cmake-build-release --target raythm`
- `cmake --build cmake-build-release --target chart_difficulty_smoke chart_serializer_smoke song_loader_smoke raythm`
- `./cmake-build-release/chart_difficulty_smoke.exe`
- `./cmake-build-release/chart_serializer_smoke.exe`
- `./cmake-build-release/song_loader_smoke.exe`
- `./cmake-build-release/chart_autogen_smoke.exe`
- `git diff --check`

補足: `cmake --build cmake-build-release --target chart_autogen_smoke` はこのCMake設定ではターゲット名が存在せず失敗しましたが、既存の `chart_autogen_smoke.exe` は実行して通過しています。

Fixes #233