### PR TITLE
UIを1920x1080向けに再調整

### DIFF
--- a/src/core/window_dialog_support.cpp
+++ b/src/core/window_dialog_support.cpp
@@ -30,8 +30,8 @@ namespace window_dialog_support {
 
 namespace {
 
-int g_last_windowed_width = 1280;
-int g_last_windowed_height = 720;
+int g_last_windowed_width = 1920;
+int g_last_windowed_height = 1080;
 
 }
 

--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -10,9 +10,9 @@ struct resolution_preset {
 };
 
 inline constexpr resolution_preset kResolutionPresets[] = {
-    {1280, 720, "1280x720"},
     {1920, 1080, "1920x1080"},
     {2560, 1440, "2560x1440"},
+    {3840, 2160, "3840x2160"},
 };
 inline constexpr int kResolutionPresetCount = 3;
 inline constexpr float kMinLaneWidth = 0.6f;
@@ -31,9 +31,9 @@ struct game_settings {
     float se_volume = 1.0f;
     int target_fps = 144;
     key_config keys;
-    int resolution_index = 1;  // デフォルト 1920x1080
-    int windowed_width = 1280;
-    int windowed_height = 720;
+    int resolution_index = 0;  // デフォルト 1920x1080
+    int windowed_width = 1920;
+    int windowed_height = 1080;
     bool fullscreen = false;
     bool dark_mode = false;
 };

--- a/src/mv/api/mv_builtins.cpp
+++ b/src/mv/api/mv_builtins.cpp
@@ -358,8 +358,8 @@ beat_grid_node extract_beat_grid(const std::shared_ptr<mv_object>& obj) {
     beat_grid_node n;
     n.x = static_cast<float>(as_number(obj->get_attr("x")));
     n.y = static_cast<float>(as_number(obj->get_attr("y")));
-    n.w = static_cast<float>(as_number(obj->get_attr("w"), 1280));
-    n.h = static_cast<float>(as_number(obj->get_attr("h"), 720));
+    n.w = static_cast<float>(as_number(obj->get_attr("w"), 1920));
+    n.h = static_cast<float>(as_number(obj->get_attr("h"), 1080));
     n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 1));
     n.beat_phase = static_cast<float>(as_number(obj->get_attr("beat_phase")));
     n.opacity = static_cast<float>(as_number(obj->get_attr("opacity"), 1.0));
@@ -380,8 +380,8 @@ beat_grid_node extract_beat_grid(const std::shared_ptr<mv_object>& obj) {
 
 pulse_ring_node extract_pulse_ring(const std::shared_ptr<mv_object>& obj) {
     pulse_ring_node n;
-    n.cx = static_cast<float>(as_number(obj->get_attr("cx"), 640));
-    n.cy = static_cast<float>(as_number(obj->get_attr("cy"), 360));
+    n.cx = static_cast<float>(as_number(obj->get_attr("cx"), 960));
+    n.cy = static_cast<float>(as_number(obj->get_attr("cy"), 540));
     n.radius = static_cast<float>(as_number(obj->get_attr("radius"), 100));
     n.thickness = static_cast<float>(as_number(obj->get_attr("thickness"), 3));
     n.beat_phase = static_cast<float>(as_number(obj->get_attr("beat_phase")));

--- a/src/mv/api/mv_context.h
+++ b/src/mv/api/mv_context.h
@@ -50,8 +50,8 @@ struct context_input {
     int key_count = 4;
 
     // screen
-    float screen_w = 1280;
-    float screen_h = 720;
+    float screen_w = 1920;
+    float screen_h = 1080;
 };
 
 // Build the ctx mv_object from context_input.

--- a/src/mv/api/mv_scene.h
+++ b/src/mv/api/mv_scene.h
@@ -63,7 +63,7 @@ struct spectrum_bar_node {
 };
 
 struct beat_grid_node {
-    float x = 0, y = 0, w = 1280, h = 720;
+    float x = 0, y = 0, w = 1920, h = 1080;
     color stroke{255, 255, 255, 60};
     float thickness = 1.0f;
     float beat_phase = 0; // 0..1, fraction within current beat
@@ -71,7 +71,7 @@ struct beat_grid_node {
 };
 
 struct pulse_ring_node {
-    float cx = 640, cy = 360, radius = 100;
+    float cx = 960, cy = 540, radius = 100;
     color stroke{255, 255, 255, 255};
     float thickness = 3.0f;
     float beat_phase = 0; // drives expansion/fade

--- a/src/mv/lang/mv_vm.h
+++ b/src/mv/lang/mv_vm.h
@@ -437,8 +437,8 @@ protected:
 struct ctx_screen_object final : mv_object {
     ctx_screen_object() : mv_object(mv_object_kind::ctx_screen, "screen") {}
 
-    double w = 1280.0;
-    double h = 720.0;
+    double w = 1920.0;
+    double h = 1080.0;
 
 protected:
     std::optional<mv_value> get_known_attr(std::string_view name) const override {

--- a/src/mv/render/mv_renderer.cpp
+++ b/src/mv/render/mv_renderer.cpp
@@ -7,6 +7,7 @@
 #include <cmath>
 
 #include "ui/ui_font.h"
+#include "scenes/scene_common.h"
 
 namespace mv {
 
@@ -102,7 +103,7 @@ void draw_node(const pulse_ring_node& n) {
 
 void draw_node(const background_node& n) {
     Color col = to_raylib(n.fill, n.opacity);
-    DrawRectangle(0, 0, 1280, 720, col);
+    DrawRectangle(0, 0, kScreenWidth, kScreenHeight, col);
 }
 
 } // anonymous namespace
@@ -110,7 +111,7 @@ void draw_node(const background_node& n) {
 void render_scene(const scene& sc) {
     // Clear with scene clear color if alpha > 0
     if (sc.clear_color.a > 0) {
-        DrawRectangle(0, 0, 1280, 720,
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
                       to_raylib(sc.clear_color));
     }
 

--- a/src/mv/render/mv_renderer.h
+++ b/src/mv/render/mv_renderer.h
@@ -5,7 +5,7 @@
 namespace mv {
 
 // Render a scene using raylib 2D draw calls.
-// Assumes virtual_screen coordinate system (1280x720) is already active.
+// Assumes virtual_screen coordinate system (1920x1080) is already active.
 void render_scene(const scene& sc);
 
 } // namespace mv

--- a/src/scenes/editor/editor_timeline_view.cpp
+++ b/src/scenes/editor/editor_timeline_view.cpp
@@ -80,7 +80,7 @@ void editor_timeline_view::draw(const editor_timeline_view_model& model) {
     const Rectangle content = model.metrics.content_rect();
     const Rectangle track = model.metrics.scrollbar_track_rect();
 
-    DrawRectangleRec(ui::inset(model.metrics.panel_rect, 10.0f), t.section);
+    ui::draw_rect_f(ui::inset(model.metrics.panel_rect, 10.0f), t.section);
     {
         ui::scoped_clip_rect clip_scope(content);
 
@@ -107,8 +107,8 @@ void editor_timeline_view::draw(const editor_timeline_view_model& model) {
 
         for (int lane = 0; lane < std::max(1, model.metrics.key_count); ++lane) {
             const Rectangle rect = model.metrics.lane_rect(lane);
-            DrawRectangleRec(rect, lane % 2 == 0 ? with_alpha(t.row, 20) : with_alpha(t.section, 20));
-            DrawRectangleLinesEx(rect, 1.0f, with_alpha(t.border_light, 180));
+            ui::draw_rect_f(rect, lane % 2 == 0 ? with_alpha(t.row, 20) : with_alpha(t.section, 20));
+            ui::draw_rect_lines(rect, 1.0f, with_alpha(t.border_light, 180));
             ui::draw_text_in_rect(TextFormat("L%d", lane + 1), 16,
                                   {rect.x, model.metrics.panel_rect.y + 4.0f, rect.width, 20.0f},
                                   t.text_hint);
@@ -146,11 +146,11 @@ void editor_timeline_view::draw(const editor_timeline_view_model& model) {
             if (info.has_body) {
                 DrawRectangleRounded(info.body_rect, 0.4f, 6, hold_fill);
                 DrawRectangleRounded(info.tail_rect, 0.4f, 6, selected ? with_alpha(t.row_active, 230) : with_alpha(t.accent, 220));
-                DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
+                ui::draw_rect_lines(info.tail_rect, 1.5f, outline);
             }
 
             DrawRectangleRounded(info.head_rect, 0.3f, 6, head_fill);
-            DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
+            ui::draw_rect_lines(info.head_rect, 1.5f, outline);
         }
 
         if (model.preview_note.has_value()) {
@@ -160,10 +160,10 @@ void editor_timeline_view::draw(const editor_timeline_view_model& model) {
             if (info.has_body) {
                 DrawRectangleRounded(info.body_rect, 0.4f, 6, fill);
                 DrawRectangleRounded(info.tail_rect, 0.4f, 6, fill);
-                DrawRectangleLinesEx(info.tail_rect, 1.5f, outline);
+                ui::draw_rect_lines(info.tail_rect, 1.5f, outline);
             }
             DrawRectangleRounded(info.head_rect, 0.3f, 6, fill);
-            DrawRectangleLinesEx(info.head_rect, 1.5f, outline);
+            ui::draw_rect_lines(info.head_rect, 1.5f, outline);
         }
 
         if (model.playback_tick.has_value()) {
@@ -175,5 +175,5 @@ void editor_timeline_view::draw(const editor_timeline_view_model& model) {
 
     ui::draw_scrollbar(track, model.content_height_pixels, model.scroll_offset_pixels,
                        t.scrollbar_track, t.scrollbar_thumb, 40.0f);
-    DrawRectangleLinesEx(model.metrics.panel_rect, 2.0f, t.border);
+    ui::draw_rect_lines(model.metrics.panel_rect, 2.0f, t.border);
 }

--- a/src/scenes/editor/editor_timing_panel.cpp
+++ b/src/scenes/editor/editor_timing_panel.cpp
@@ -73,8 +73,8 @@ editor_timing_panel_result editor_timing_panel::draw(const editor_timing_panel_m
             content_rect.height - 8.0f
         };
 
-        DrawRectangleRec(input_rect, with_alpha(t.section, 255));
-        DrawRectangleLinesEx(input_rect, 1.5f, state.bar_pick_mode ? t.accent : t.border_light);
+        ui::draw_rect_f(input_rect, with_alpha(t.section, 255));
+        ui::draw_rect_lines(input_rect, 1.5f, state.bar_pick_mode ? t.accent : t.border_light);
         ui::draw_text_in_rect(label, 16, label_rect,
                               selected ? t.text : t.text_secondary, ui::text_align::left);
 

--- a/src/scenes/editor/view/editor_cursor_hud_view.cpp
+++ b/src/scenes/editor/view/editor_cursor_hud_view.cpp
@@ -15,8 +15,8 @@ void editor_cursor_hud_view::draw(const editor_cursor_hud_view_model& model) {
 
     const auto& t = *g_theme;
     const Rectangle hud_rect = layout::cursor_hud_rect();
-    DrawRectangleRec(hud_rect, with_alpha(t.panel, 240));
-    DrawRectangleLinesEx(hud_rect, 1.5f, t.border);
+    ui::draw_rect_f(hud_rect, with_alpha(t.panel, 240));
+    ui::draw_rect_lines(hud_rect, 1.5f, t.border);
     ui::draw_text_f(TextFormat("bar %d:%d   beat %.2f   snap %d", model.measure, model.beat_index, model.beat, model.snapped_tick),
                     hud_rect.x + 12.0f, hud_rect.y + 8.0f, 18, t.text);
 }

--- a/src/scenes/editor/view/editor_layout.h
+++ b/src/scenes/editor/view/editor_layout.h
@@ -6,91 +6,91 @@
 namespace editor::layout {
 
 inline constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-inline constexpr Rectangle kHeaderRect = ui::place(kScreenRect, 1220.0f, 48.0f,
+inline constexpr Rectangle kHeaderRect = ui::place(kScreenRect, 1830.0f, 72.0f,
                                                    ui::anchor::top_center, ui::anchor::top_center,
-                                                   {0.0f, 12.0f});
-inline constexpr Rectangle kLeftPanelRect = ui::place(kScreenRect, 248.0f, 620.0f,
+                                                   Vector2{0.0f, 18.0f});
+inline constexpr Rectangle kLeftPanelRect = ui::place(kScreenRect, 372.0f, 930.0f,
                                                       ui::anchor::top_left, ui::anchor::top_left,
-                                                      {20.0f, 72.0f});
-inline constexpr Rectangle kTimelineRect = ui::place(kScreenRect, 724.0f, 620.0f,
+                                                      Vector2{30.0f, 108.0f});
+inline constexpr Rectangle kTimelineRect = ui::place(kScreenRect, 1086.0f, 930.0f,
                                                      ui::anchor::top_center, ui::anchor::top_center,
-                                                     {0.0f, 72.0f});
-inline constexpr Rectangle kRightPanelRect = ui::place(kScreenRect, 248.0f, 620.0f,
+                                                     Vector2{0.0f, 108.0f});
+inline constexpr Rectangle kRightPanelRect = ui::place(kScreenRect, 372.0f, 930.0f,
                                                        ui::anchor::top_right, ui::anchor::top_right,
-                                                       {-20.0f, 72.0f});
-inline constexpr Rectangle kBackButtonRect = ui::place(kHeaderRect, 120.0f, 34.0f,
+                                                       Vector2{-30.0f, 108.0f});
+inline constexpr Rectangle kBackButtonRect = ui::place(kHeaderRect, 180.0f, 51.0f,
                                                        ui::anchor::center_left, ui::anchor::center_left,
-                                                       {16.0f, 0.0f});
-inline constexpr Rectangle kSettingsButtonRect = ui::place(kHeaderRect, 128.0f, 34.0f,
+                                                       Vector2{24.0f, 0.0f});
+inline constexpr Rectangle kSettingsButtonRect = ui::place(kHeaderRect, 192.0f, 51.0f,
                                                            ui::anchor::center_left, ui::anchor::center_left,
-                                                           {150.0f, 0.0f});
+                                                           Vector2{225.0f, 0.0f});
 
-inline constexpr Rectangle kHeaderToolsRect = ui::place(kHeaderRect, 168.0f, 34.0f,
+inline constexpr Rectangle kHeaderToolsRect = ui::place(kHeaderRect, 252.0f, 51.0f,
                                                         ui::anchor::center_right, ui::anchor::center_right,
-                                                        {-18.0f, 0.0f});
-inline constexpr Rectangle kChartOffsetRect = ui::place(kHeaderRect, 188.0f, 34.0f,
+                                                        Vector2{-27.0f, 0.0f});
+inline constexpr Rectangle kChartOffsetRect = ui::place(kHeaderRect, 282.0f, 51.0f,
                                                         ui::anchor::center_right, ui::anchor::center_right,
-                                                        {-338.0f, 0.0f});
-inline constexpr Rectangle kWaveformToggleRect = ui::place(kHeaderRect, 132.0f, 34.0f,
+                                                        Vector2{-507.0f, 0.0f});
+inline constexpr Rectangle kWaveformToggleRect = ui::place(kHeaderRect, 198.0f, 51.0f,
                                                            ui::anchor::center_right, ui::anchor::center_right,
-                                                           {-198.0f, 0.0f});
-inline constexpr Rectangle kPlaybackRect = ui::place(kTimelineRect, 232.0f, 34.0f,
+                                                           Vector2{-297.0f, 0.0f});
+inline constexpr Rectangle kPlaybackRect = ui::place(kTimelineRect, 348.0f, 51.0f,
                                                      ui::anchor::bottom_left, ui::anchor::bottom_left,
-                                                     {12.0f, -54.0f});
+                                                     Vector2{18.0f, -81.0f});
 
-inline constexpr float kDropdownItemHeight = 30.0f;
-inline constexpr float kDropdownItemSpacing = 4.0f;
+inline constexpr float kDropdownItemHeight = 45.0f;
+inline constexpr float kDropdownItemSpacing = 6.0f;
 inline constexpr Rectangle kSnapDropdownRect = kHeaderToolsRect;
 
-inline constexpr Rectangle kMetadataConfirmRect = ui::place(kScreenRect, 420.0f, 196.0f,
+inline constexpr Rectangle kMetadataConfirmRect = ui::place(kScreenRect, 630.0f, 294.0f,
                                                             ui::anchor::center, ui::anchor::center);
-inline constexpr Rectangle kUnsavedChangesRect = ui::place(kScreenRect, 456.0f, 210.0f,
+inline constexpr Rectangle kUnsavedChangesRect = ui::place(kScreenRect, 684.0f, 315.0f,
                                                            ui::anchor::center, ui::anchor::center);
-inline constexpr Rectangle kSaveDialogRect = ui::place(kScreenRect, 520.0f, 224.0f,
+inline constexpr Rectangle kSaveDialogRect = ui::place(kScreenRect, 780.0f, 336.0f,
                                                        ui::anchor::center, ui::anchor::center);
 
 inline Rectangle key_count_confirm_button_rect() {
-    return {kMetadataConfirmRect.x + 94.0f, kMetadataConfirmRect.y + 142.0f, 104.0f, 30.0f};
+    return {kMetadataConfirmRect.x + 141.0f, kMetadataConfirmRect.y + 213.0f, 156.0f, 45.0f};
 }
 
 inline Rectangle key_count_cancel_button_rect() {
-    return {kMetadataConfirmRect.x + 222.0f, kMetadataConfirmRect.y + 142.0f, 104.0f, 30.0f};
+    return {kMetadataConfirmRect.x + 333.0f, kMetadataConfirmRect.y + 213.0f, 156.0f, 45.0f};
 }
 
 inline Rectangle unsaved_save_button_rect() {
-    return {kUnsavedChangesRect.x + 32.0f, kUnsavedChangesRect.y + 154.0f, 112.0f, 32.0f};
+    return {kUnsavedChangesRect.x + 48.0f, kUnsavedChangesRect.y + 231.0f, 168.0f, 48.0f};
 }
 
 inline Rectangle unsaved_discard_button_rect() {
-    return {kUnsavedChangesRect.x + 172.0f, kUnsavedChangesRect.y + 154.0f, 112.0f, 32.0f};
+    return {kUnsavedChangesRect.x + 258.0f, kUnsavedChangesRect.y + 231.0f, 168.0f, 48.0f};
 }
 
 inline Rectangle unsaved_cancel_button_rect() {
-    return {kUnsavedChangesRect.x + 312.0f, kUnsavedChangesRect.y + 154.0f, 112.0f, 32.0f};
+    return {kUnsavedChangesRect.x + 468.0f, kUnsavedChangesRect.y + 231.0f, 168.0f, 48.0f};
 }
 
 inline Rectangle save_submit_button_rect() {
-    return {kSaveDialogRect.x + 136.0f, kSaveDialogRect.y + 172.0f, 108.0f, 32.0f};
+    return {kSaveDialogRect.x + 204.0f, kSaveDialogRect.y + 258.0f, 162.0f, 48.0f};
 }
 
 inline Rectangle save_cancel_button_rect() {
-    return {kSaveDialogRect.x + 276.0f, kSaveDialogRect.y + 172.0f, 108.0f, 32.0f};
+    return {kSaveDialogRect.x + 414.0f, kSaveDialogRect.y + 258.0f, 162.0f, 48.0f};
 }
 
 inline Rectangle snap_dropdown_menu_rect(int item_count) {
     return {
         kSnapDropdownRect.x,
-        kSnapDropdownRect.y + kSnapDropdownRect.height + 4.0f,
+        kSnapDropdownRect.y + kSnapDropdownRect.height + kDropdownItemSpacing,
         kSnapDropdownRect.width,
-        12.0f + static_cast<float>(item_count) * kDropdownItemHeight +
+        18.0f + static_cast<float>(item_count) * kDropdownItemHeight +
             static_cast<float>(item_count - 1) * kDropdownItemSpacing
     };
 }
 
 inline Rectangle cursor_hud_rect() {
-    return ui::place(kTimelineRect, 340.0f, 34.0f,
+    return ui::place(kTimelineRect, 510.0f, 51.0f,
                      ui::anchor::bottom_left, ui::anchor::bottom_left,
-                     {12.0f, -12.0f});
+                     Vector2{18.0f, -18.0f});
 }
 
 }  // namespace editor::layout

--- a/src/scenes/editor_scene.cpp
+++ b/src/scenes/editor_scene.cpp
@@ -230,7 +230,7 @@ void editor_scene::rebuild_hit_regions() const {
 void editor_scene::draw() {
     const auto& t = *g_theme;
     const double now = GetTime();
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     rebuild_hit_regions();
     ui::begin_draw_queue();
     ClearBackground(t.bg);

--- a/src/scenes/mv_editor_scene.cpp
+++ b/src/scenes/mv_editor_scene.cpp
@@ -14,23 +14,25 @@
 
 namespace {
 
-constexpr float kHeaderHeight = 48.0f;
-constexpr float kPadding = 16.0f;
-constexpr float kBackButtonWidth = 100.0f;
-constexpr float kBackButtonHeight = 30.0f;
-constexpr float kMetadataButtonWidth = 152.0f;
-constexpr float kMetadataModalWidth = 360.0f;
-constexpr float kMetadataModalHeight = 208.0f;
-constexpr float kMetadataModalOffsetY = 18.0f;
-constexpr float kMetadataModalPaddingX = 18.0f;
-constexpr float kMetadataHeaderTop = 18.0f;
-constexpr float kMetadataTitleHeight = 26.0f;
-constexpr float kMetadataSubtitleHeight = 18.0f;
-constexpr float kMetadataHeaderGap = 6.0f;
-constexpr float kMetadataBodyTop = 78.0f;
-constexpr float kMetadataRowHeight = 36.0f;
-constexpr float kMetadataRowGap = 8.0f;
-constexpr float kMetadataButtonHeight = 36.0f;
+constexpr float kHeaderHeight = 72.0f;
+constexpr float kPadding = 24.0f;
+constexpr float kBackButtonWidth = 150.0f;
+constexpr float kBackButtonHeight = 45.0f;
+constexpr float kMetadataButtonWidth = 228.0f;
+constexpr float kMetadataModalWidth = 540.0f;
+constexpr float kMetadataModalHeight = 312.0f;
+constexpr float kMetadataModalOffsetY = 27.0f;
+constexpr float kMetadataModalPaddingX = 27.0f;
+constexpr float kMetadataHeaderTop = 27.0f;
+constexpr float kMetadataTitleHeight = 39.0f;
+constexpr float kMetadataSubtitleHeight = 27.0f;
+constexpr float kMetadataHeaderGap = 9.0f;
+constexpr float kMetadataBodyTop = 117.0f;
+constexpr float kMetadataRowHeight = 54.0f;
+constexpr float kMetadataRowGap = 12.0f;
+constexpr float kMetadataModalScreenMargin = 18.0f;
+constexpr float kMetadataModalOpenOffsetY = 27.0f;
+constexpr float kMetadataInputLabelWidth = 180.0f;
 
 bool wide_text_filter(int codepoint, const std::string&) {
     return codepoint >= 32;
@@ -45,7 +47,7 @@ Rectangle metadata_button_rect() {
         kPadding,
         (kHeaderHeight - kBackButtonHeight) * 0.5f,
         kMetadataButtonWidth,
-        30.0f
+        kBackButtonHeight
     };
 }
 
@@ -56,10 +58,12 @@ Rectangle metadata_modal_rect(float open_anim = 1.0f) {
         kMetadataModalWidth,
         kMetadataModalHeight
     };
-    rect.x = std::clamp(rect.x, 12.0f, static_cast<float>(kScreenWidth) - rect.width - 12.0f);
-    rect.y = std::clamp(rect.y, 12.0f, static_cast<float>(kScreenHeight) - rect.height - 12.0f);
+    rect.x = std::clamp(rect.x, kMetadataModalScreenMargin,
+                        static_cast<float>(kScreenWidth) - rect.width - kMetadataModalScreenMargin);
+    rect.y = std::clamp(rect.y, kMetadataModalScreenMargin,
+                        static_cast<float>(kScreenHeight) - rect.height - kMetadataModalScreenMargin);
     const float anim_t = tween::ease_out_cubic(open_anim);
-    rect.y -= (1.0f - anim_t) * 18.0f;
+    rect.y -= (1.0f - anim_t) * kMetadataModalOpenOffsetY;
     return rect;
 }
 
@@ -139,7 +143,7 @@ void mv_editor_scene::update(float dt) {
 }
 
 void mv_editor_scene::draw() {
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
     ui::begin_draw_queue();
@@ -150,8 +154,8 @@ void mv_editor_scene::draw() {
 
     // Header
     Rectangle header = {0, 0, static_cast<float>(kScreenWidth), kHeaderHeight};
-    DrawRectangleRec(header, g_theme->section);
-    DrawRectangleLinesEx(header, 1.0f, g_theme->border_light);
+    ui::draw_rect_f(header, g_theme->section);
+    ui::draw_rect_lines(header, 1.5f, g_theme->border_light);
 
     Rectangle back_btn = {
         static_cast<float>(kScreenWidth) - kBackButtonWidth - kPadding,
@@ -199,13 +203,13 @@ void mv_editor_scene::draw() {
             modal.x + kMetadataModalPaddingX,
             modal.y + kMetadataBodyTop,
             modal.width - kMetadataModalPaddingX * 2.0f,
-            modal.height - kMetadataBodyTop - 18.0f
+            modal.height - kMetadataBodyTop - kMetadataModalPaddingX
         };
         const Rectangle name_rect = {body.x, body.y, body.width, kMetadataRowHeight};
         const Rectangle author_rect = {body.x, body.y + kMetadataRowHeight + kMetadataRowGap,
                                        body.width, kMetadataRowHeight};
-        DrawRectangleRec({0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)},
-                         with_alpha(g_theme->pause_overlay, static_cast<unsigned char>(180.0f + anim_t * 40.0f)));
+        ui::draw_rect_f({0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)},
+                        with_alpha(g_theme->pause_overlay, static_cast<unsigned char>(180.0f + anim_t * 40.0f)));
         ui::draw_panel(modal);
         ui::draw_text_in_rect("MV Metadata", 28,
                               {modal.x + kMetadataModalPaddingX, modal.y + kMetadataHeaderTop,
@@ -219,10 +223,10 @@ void mv_editor_scene::draw() {
 
         const auto name_result = ui::draw_text_input(name_rect, name_input_, "MV Name", "Untitled MV",
                                                      nullptr, ui::draw_layer::modal, 16, 128,
-                                                     wide_text_filter, 120.0f);
+                                                     wide_text_filter, kMetadataInputLabelWidth);
         const auto author_result = ui::draw_text_input(author_rect, author_input_, "Author", "Author name",
                                                        nullptr, ui::draw_layer::modal, 16, 128,
-                                                       wide_text_filter, 120.0f);
+                                                       wide_text_filter, kMetadataInputLabelWidth);
         if (name_result.changed || author_result.changed) {
             dirty_ = true;
         }

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -1,6 +1,7 @@
 #include "play_renderer.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "game_settings.h"
 #include "scene_common.h"
@@ -12,46 +13,47 @@ namespace {
 constexpr float kLaneGap = 0.2f;
 constexpr float kJudgeLineGlowHeight = 0.04f;
 constexpr float kResultFadeMaxAlpha = 0.65f;
+constexpr float kUiFontScale = 1.5f;
 constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-constexpr Rectangle kPausePanelRect = ui::center(kScreenRect, 420.0f, 320.0f);
-constexpr Rectangle kPauseTitleRect = {kPausePanelRect.x, kPausePanelRect.y, kPausePanelRect.width, 64.0f};
+constexpr Rectangle kPausePanelRect = ui::center(kScreenRect, 630.0f, 480.0f);
+constexpr Rectangle kPauseTitleRect = {kPausePanelRect.x, kPausePanelRect.y, kPausePanelRect.width, 96.0f};
 constexpr Rectangle kPauseButtonArea = {
-    kPausePanelRect.x + 40.0f,
-    kPausePanelRect.y + 88.0f,
-    340.0f,
-    3.0f * 42.0f + 2.0f * 16.0f
+    kPausePanelRect.x + 60.0f,
+    kPausePanelRect.y + 132.0f,
+    510.0f,
+    3.0f * 63.0f + 2.0f * 24.0f
 };
 constexpr Rectangle kPauseHintRect = {
-    kPausePanelRect.x + 24.0f,
-    kPausePanelRect.y + kPausePanelRect.height - 50.0f,
-    kPausePanelRect.width - 48.0f,
-    30.0f
+    kPausePanelRect.x + 36.0f,
+    kPausePanelRect.y + kPausePanelRect.height - 75.0f,
+    kPausePanelRect.width - 72.0f,
+    45.0f
 };
-constexpr Rectangle kScoreRect = ui::place(kScreenRect, 400.0f, 60.0f,
+constexpr Rectangle kScoreRect = ui::place(kScreenRect, 600.0f, 90.0f,
                                            ui::anchor::top_left, ui::anchor::top_left,
-                                           {48.0f, 34.0f});
-constexpr Rectangle kTimeRect = ui::place(kScreenRect, 200.0f, 30.0f,
+                                           Vector2{72.0f, 51.0f});
+constexpr Rectangle kTimeRect = ui::place(kScreenRect, 300.0f, 45.0f,
                                           ui::anchor::top_center, ui::anchor::top_center,
-                                          {0.0f, 34.0f});
-constexpr Rectangle kFpsRect = ui::place(kScreenRect, 120.0f, 20.0f,
+                                          Vector2{0.0f, 51.0f});
+constexpr Rectangle kFpsRect = ui::place(kScreenRect, 180.0f, 30.0f,
                                          ui::anchor::bottom_right, ui::anchor::bottom_right,
-                                         {-10.0f, 0.0f});
-constexpr Rectangle kHealthLabelRect = ui::place(kScreenRect, 100.0f, 24.0f,
+                                         Vector2{-15.0f, 0.0f});
+constexpr Rectangle kHealthLabelRect = ui::place(kScreenRect, 150.0f, 36.0f,
                                                  ui::anchor::top_right, ui::anchor::top_right,
-                                                 {-48.0f, 34.0f});
-constexpr Rectangle kHealthBarRect = ui::place(kScreenRect, 260.0f, 24.0f,
+                                                 Vector2{-72.0f, 51.0f});
+constexpr Rectangle kHealthBarRect = ui::place(kScreenRect, 390.0f, 36.0f,
                                                ui::anchor::top_right, ui::anchor::top_right,
-                                               {-48.0f, 58.0f});
-constexpr Rectangle kComboNumberRect = ui::place(kScreenRect, 300.0f, 86.0f,
+                                               Vector2{-72.0f, 87.0f});
+constexpr Rectangle kComboNumberRect = ui::place(kScreenRect, 450.0f, 129.0f,
                                                  ui::anchor::center, ui::anchor::center,
-                                                 {0.0f, -80.0f});
-constexpr Rectangle kComboLabelRect = ui::place(kScreenRect, 200.0f, 24.0f,
+                                                 Vector2{0.0f, -120.0f});
+constexpr Rectangle kComboLabelRect = ui::place(kScreenRect, 300.0f, 36.0f,
                                                 ui::anchor::center, ui::anchor::center,
                                                 {0.0f, 0.0f});
-constexpr Rectangle kJudgeFeedbackRect = ui::place(kScreenRect, 320.0f, 42.0f,
+constexpr Rectangle kJudgeFeedbackRect = ui::place(kScreenRect, 480.0f, 63.0f,
                                                    ui::anchor::center, ui::anchor::center,
-                                                   {0.0f, 34.0f});
-constexpr Rectangle kFailureTextRect = ui::place(kScreenRect, 360.0f, 44.0f,
+                                                   Vector2{0.0f, 51.0f});
+constexpr Rectangle kFailureTextRect = ui::place(kScreenRect, 540.0f, 66.0f,
                                                  ui::anchor::center, ui::anchor::center);
 constexpr float kTapNoteBaseLength = 0.78f;
 constexpr float kJudgeLineY = 0.40f;
@@ -64,6 +66,10 @@ float lane_center_x(int lane, int key_count) {
     const float left = -total_width * 0.5f + g_settings.lane_width * 0.5f;
     const int visual_lane = key_count - 1 - lane;
     return left + visual_lane * (g_settings.lane_width + kLaneGap);
+}
+
+int ui_font(int font_size) {
+    return static_cast<int>(std::lround(static_cast<float>(font_size) * kUiFontScale));
 }
 
 void draw_note_plane(float center_x, float y, float center_z, float width, float length, Color fill) {
@@ -95,15 +101,15 @@ const char* judge_text(judge_result result) {
 void draw_hud(const play_session_state& state) {
     const result_data result = state.score_system.get_result_data();
     const float live_accuracy = state.score_system.get_live_accuracy();
-    ui::enqueue_text_in_rect(TextFormat("SCORE %07d", result.score), 30,
+    ui::enqueue_text_in_rect(TextFormat("SCORE %07d", result.score), ui_font(30),
                              kScoreRect, g_theme->hud_score, ui::text_align::left);
 
-    ui::enqueue_text_in_rect(TextFormat("FPS: %d", GetFPS()), 20,
+    ui::enqueue_text_in_rect(TextFormat("FPS: %d", GetFPS()), ui_font(20),
                              kFpsRect, g_theme->hud_fps, ui::text_align::right);
-    ui::enqueue_text_in_rect(TextFormat("%.2f%%", live_accuracy), 30,
+    ui::enqueue_text_in_rect(TextFormat("%.2f%%", live_accuracy), ui_font(30),
                              kTimeRect, g_theme->hud_time);
 
-    ui::enqueue_text_in_rect("HEALTH", 24, kHealthLabelRect,
+    ui::enqueue_text_in_rect("HEALTH", ui_font(24), kHealthLabelRect,
                              g_theme->hud_health_label, ui::text_align::right);
     const float gauge_ratio = state.gauge.get_value() / 100.0f;
     const Color gauge_color = state.gauge.get_value() >= 70.0f ? g_theme->health_high : g_theme->health_low;
@@ -113,25 +119,25 @@ void draw_hud(const play_session_state& state) {
     });
 
     if (state.combo_display > 0) {
-        ui::enqueue_text_in_rect(TextFormat("%03d", state.combo_display), 86,
+        ui::enqueue_text_in_rect(TextFormat("%03d", state.combo_display), ui_font(86),
                                  kComboNumberRect, g_theme->hud_combo);
-        ui::enqueue_text_in_rect("COMBO", 24, kComboLabelRect, g_theme->hud_combo);
+        ui::enqueue_text_in_rect("COMBO", ui_font(24), kComboLabelRect, g_theme->hud_combo);
     }
 }
 
 void draw_pause_overlay() {
     ui::enqueue_fullscreen_overlay(g_theme->pause_overlay, ui::draw_layer::overlay);
     ui::enqueue_panel(kPausePanelRect, ui::draw_layer::modal);
-    ui::enqueue_text_in_rect("PAUSED", 42, kPauseTitleRect, g_theme->text,
+    ui::enqueue_text_in_rect("PAUSED", ui_font(42), kPauseTitleRect, g_theme->text,
                              ui::text_align::center, ui::draw_layer::modal);
 
     const std::array<Rectangle, 3> buttons = play_renderer::pause_button_rects();
     const char* labels[] = {"RESUME", "RESTART", "SONG SELECT"};
     for (int i = 0; i < 3; ++i) {
-        ui::enqueue_button(buttons[static_cast<size_t>(i)], labels[i], 24, ui::draw_layer::modal);
+        ui::enqueue_button(buttons[static_cast<size_t>(i)], labels[i], ui_font(24), ui::draw_layer::modal);
     }
 
-    ui::enqueue_text_in_rect("ESC: Resume", 20, kPauseHintRect, g_theme->text_muted,
+    ui::enqueue_text_in_rect("ESC: Resume", ui_font(20), kPauseHintRect, g_theme->text_muted,
                              ui::text_align::left, ui::draw_layer::modal);
 }
 
@@ -142,7 +148,7 @@ void draw_judge_feedback(const play_session_state& state) {
 
     const Color color = Fade(judge_color(state.display_judge->result),
                              std::min(state.judge_feedback_timer / 1.0f, 1.0f));
-    ui::enqueue_text_in_rect(judge_text(state.display_judge->result), 42, kJudgeFeedbackRect, color);
+    ui::enqueue_text_in_rect(judge_text(state.display_judge->result), ui_font(42), kJudgeFeedbackRect, color);
 }
 
 void draw_intro_overlay(const play_session_state& state) {
@@ -156,7 +162,7 @@ void draw_failure_overlay(const play_session_state& state) {
     const float fade_progress = std::clamp(elapsed / play_session_constants::kFailureFadeDurationSeconds, 0.0f, 0.7f);
     const unsigned char alpha = static_cast<unsigned char>(fade_progress * 255.0f);
     ui::enqueue_fullscreen_overlay({0, 0, 0, alpha}, ui::draw_layer::overlay);
-    ui::enqueue_text_in_rect("FAILED...", 44, kFailureTextRect,
+    ui::enqueue_text_in_rect("FAILED...", ui_font(44), kFailureTextRect,
                              Fade(g_theme->hud_failure_text, std::min(fade_progress * 1.15f, 1.0f)),
                              ui::text_align::center, ui::draw_layer::modal);
 }
@@ -177,16 +183,16 @@ Rectangle pause_panel_rect() {
 
 std::array<Rectangle, 3> pause_button_rects() {
     std::array<Rectangle, 3> buttons = {};
-    ui::vstack(kPauseButtonArea, 42.0f, 16.0f, buttons);
+    ui::vstack(kPauseButtonArea, 63.0f, 24.0f, buttons);
     return buttons;
 }
 
 void draw_status(const play_session_state& state) {
     ClearBackground(g_theme->bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, g_theme->bg, g_theme->bg_alt);
-    DrawText("Play", 96, 90, 44, g_theme->error);
-    DrawText(state.status_text.c_str(), 96, 170, 28, g_theme->text);
-    DrawText("ESC: Back to Song Select", 96, 225, 22, g_theme->text_hint);
+    ui::draw_text_f("Play", 144.0f, 135.0f, ui_font(44), g_theme->error);
+    ui::draw_text_f(state.status_text.c_str(), 144.0f, 255.0f, ui_font(28), g_theme->text);
+    ui::draw_text_f("ESC: Back to Song Select", 144.0f, 337.5f, ui_font(22), g_theme->text_hint);
 }
 
 void draw_world_background() {

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -310,7 +310,7 @@ bool play_scene::get_lane_view_bounds(const Camera3D& camera, float& lane_start_
 
 void play_scene::draw() {
     if (!state_.initialized) {
-        virtual_screen::begin();
+        virtual_screen::begin_ui();
         play_renderer::draw_status(state_);
         virtual_screen::end();
 

--- a/src/scenes/result_scene.cpp
+++ b/src/scenes/result_scene.cpp
@@ -17,37 +17,72 @@
 
 namespace {
 
+constexpr float kOuterMargin = 36.0f;
+constexpr float kPanelPadding = 36.0f;
+constexpr float kLeftColumnWidth = 870.0f;
+constexpr float kColumnGap = 48.0f;
+constexpr float kSongInfoHeight = 162.0f;
+constexpr float kScoreTop = 198.0f;
+constexpr float kScoreHeight = 162.0f;
+constexpr float kJudgeTop = 396.0f;
+constexpr float kJudgeHeight = 390.0f;
+constexpr float kRankWidth = 300.0f;
+constexpr float kRankHeight = 252.0f;
+constexpr float kStatsTop = 288.0f;
+constexpr float kStatsHeight = 498.0f;
+constexpr float kContentInset = 24.0f;
+constexpr float kRankTitleHeight = 180.0f;
+constexpr float kRankBadgeBottom = 60.0f;
+constexpr float kRankBadgeHeight = 36.0f;
+constexpr float kStatsBottomReserved = 102.0f;
+constexpr float kStatsHintBottom = 96.0f;
+constexpr float kOnlineStatusBottom = 54.0f;
+constexpr float kSongTextPaddingX = 24.0f;
+constexpr float kSongMetaGap = 24.0f;
+constexpr float kFailedOffset = 30.0f;
+constexpr float kScoreLabelWidth = 150.0f;
+constexpr float kAccuracyLabelWidth = 210.0f;
+constexpr float kJudgeRowExtraHeight = 12.0f;
+constexpr float kJudgeRowGap = 6.0f;
+constexpr float kJudgeBadgeWidth = 240.0f;
+constexpr float kJudgeCountX = 264.0f;
+constexpr float kStatRowGap = 12.0f;
+
 constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-constexpr Rectangle kMainPanel = ui::inset(kScreenRect, 24.0f);
-constexpr Rectangle kContentRect = ui::inset(kMainPanel, 24.0f);
-constexpr Rectangle kLeftColRect = {kContentRect.x, kContentRect.y, 580.0f, kContentRect.height};
+constexpr Rectangle kMainPanel = ui::inset(kScreenRect, kOuterMargin);
+constexpr Rectangle kContentRect = ui::inset(kMainPanel, kPanelPadding);
+constexpr Rectangle kLeftColRect = {kContentRect.x, kContentRect.y, kLeftColumnWidth, kContentRect.height};
 constexpr Rectangle kRightColRect = {
-    kContentRect.x + 580.0f + 32.0f,
+    kContentRect.x + kLeftColumnWidth + kColumnGap,
     kContentRect.y,
-    kContentRect.width - 580.0f - 32.0f,
+    kContentRect.width - kLeftColumnWidth - kColumnGap,
     kContentRect.height
 };
-constexpr Rectangle kSongInfoRect = {kLeftColRect.x, kLeftColRect.y, kLeftColRect.width, 108.0f};
-constexpr Rectangle kScoreRect = {kLeftColRect.x, kLeftColRect.y + 132.0f, kLeftColRect.width, 108.0f};
-constexpr Rectangle kJudgeRect = {kLeftColRect.x, kLeftColRect.y + 264.0f, kLeftColRect.width, 260.0f};
-constexpr Rectangle kRankRect = {kRightColRect.x, kRightColRect.y, 200.0f, 168.0f};
-constexpr Rectangle kStatsRect = {kRightColRect.x, kRightColRect.y + 192.0f, kRightColRect.width, 332.0f};
-constexpr Rectangle kScoreContentRect = ui::inset(kScoreRect, 16.0f);
-constexpr Rectangle kRankTitleRect = {kRankRect.x, kRankRect.y, kRankRect.width, 120.0f};
-constexpr Rectangle kRankBadgeRect = {kRankRect.x, kRankRect.y + kRankRect.height - 40.0f, kRankRect.width, 24.0f};
-constexpr Rectangle kJudgeRowsRect = ui::inset(kJudgeRect, 16.0f);
-constexpr Rectangle kStatsRowsRect = ui::inset(kStatsRect, ui::edge_insets{24.0f, 24.0f, 68.0f, 24.0f});
+constexpr Rectangle kSongInfoRect = {kLeftColRect.x, kLeftColRect.y, kLeftColRect.width, kSongInfoHeight};
+constexpr Rectangle kScoreRect = {kLeftColRect.x, kLeftColRect.y + kScoreTop, kLeftColRect.width, kScoreHeight};
+constexpr Rectangle kJudgeRect = {kLeftColRect.x, kLeftColRect.y + kJudgeTop, kLeftColRect.width, kJudgeHeight};
+constexpr Rectangle kRankRect = {kRightColRect.x, kRightColRect.y, kRankWidth, kRankHeight};
+constexpr Rectangle kStatsRect = {kRightColRect.x, kRightColRect.y + kStatsTop, kRightColRect.width, kStatsHeight};
+constexpr Rectangle kScoreContentRect = ui::inset(kScoreRect, kContentInset);
+constexpr Rectangle kRankTitleRect = {kRankRect.x, kRankRect.y, kRankRect.width, kRankTitleHeight};
+constexpr Rectangle kRankBadgeRect = {
+    kRankRect.x, kRankRect.y + kRankRect.height - kRankBadgeBottom, kRankRect.width, kRankBadgeHeight
+};
+constexpr Rectangle kJudgeRowsRect = ui::inset(kJudgeRect, kContentInset);
+constexpr Rectangle kStatsRowsRect = ui::inset(kStatsRect, ui::edge_insets{
+    kContentInset, kContentInset, kStatsBottomReserved, kContentInset
+});
 constexpr Rectangle kStatsHintRect = {
-    kStatsRect.x + 24.0f,
-    kStatsRect.y + kStatsRect.height - 64.0f,
-    kStatsRect.width - 48.0f,
-    24.0f
+    kStatsRect.x + kContentInset,
+    kStatsRect.y + kStatsRect.height - kStatsHintBottom,
+    kStatsRect.width - kContentInset * 2.0f,
+    kContentInset
 };
 constexpr Rectangle kOnlineStatusRect = {
-    kStatsRect.x + 24.0f,
-    kStatsRect.y + kStatsRect.height - 36.0f,
-    kStatsRect.width - 48.0f,
-    24.0f
+    kStatsRect.x + kContentInset,
+    kStatsRect.y + kStatsRect.height - kOnlineStatusBottom,
+    kStatsRect.width - kContentInset * 2.0f,
+    kContentInset
 };
 
 const char* rank_label(rank r) {
@@ -78,6 +113,10 @@ Color rank_color(rank r) {
 
 const char* key_mode_label(int key_count) {
     return key_count == 6 ? "6K" : "4K";
+}
+
+Rectangle text_line_rect(float x, float y, float width, int font_size) {
+    return {x, y, width, ui::text_layout_font_size(static_cast<float>(font_size))};
 }
 
 }  // namespace
@@ -168,7 +207,7 @@ void result_scene::poll_online_submit() {
 
 void result_scene::draw() {
     const auto& t = *g_theme;
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
 
@@ -176,19 +215,29 @@ void result_scene::draw() {
 
     // 楽曲情報
     ui::draw_section(kSongInfoRect);
-    const float song_info_max_w = kSongInfoRect.width - 32.0f;
+    const float song_info_max_w = kSongInfoRect.width - kSongTextPaddingX * 2.0f;
     const double now = GetTime();
     {
-        const float sy = kSongInfoRect.y + (kSongInfoRect.height - 82.0f) * 0.5f;
-        const float lx = kSongInfoRect.x + 16.0f;
-        draw_marquee_text(song_.meta.title.c_str(), lx, sy, 32, t.text, song_info_max_w, now);
-        draw_marquee_text(song_.meta.artist.c_str(), lx, sy + 38, 22, t.text_dim, song_info_max_w, now);
+        const float title_h = ui::text_layout_font_size(32.0f);
+        const float artist_h = ui::text_layout_font_size(22.0f);
+        const float meta_h = ui::text_layout_font_size(20.0f);
+        constexpr float kTitleArtistGap = 9.0f;
+        constexpr float kArtistMetaGap = 12.0f;
+        const float block_h = title_h + kTitleArtistGap + artist_h + kArtistMetaGap + meta_h;
+        const float sy = kSongInfoRect.y + (kSongInfoRect.height - block_h) * 0.5f;
+        const float lx = kSongInfoRect.x + kSongTextPaddingX;
+        draw_marquee_text(song_.meta.title.c_str(), text_line_rect(lx, sy, song_info_max_w, 32),
+                          32, t.text, now);
+        draw_marquee_text(song_.meta.artist.c_str(),
+                          text_line_rect(lx, sy + title_h + kTitleArtistGap, song_info_max_w, 22),
+                          22, t.text_dim, now);
         const char* chart_label = TextFormat("%s %s Lv.%.1f", key_mode_label(chart_.key_count),
                                              chart_.difficulty.c_str(), chart_.level);
         const float chart_label_w = ui::measure_text_size(chart_label, 20.0f, 0.0f).x;
-        ui::draw_text_f(chart_label, lx, sy + 66.0f, 20, t.accent);
-        ui::draw_text_f(chart_.chart_author.c_str(), lx + chart_label_w + 16.0f,
-                        sy + 66.0f, 20, t.text_muted);
+        const float meta_y = sy + title_h + kTitleArtistGap + artist_h + kArtistMetaGap;
+        ui::draw_text_f(chart_label, lx, meta_y, 20, t.accent);
+        ui::draw_text_f(chart_.chart_author.c_str(), lx + chart_label_w + kSongMetaGap,
+                        meta_y, 20, t.text_muted);
     }
 
     // ランク表示
@@ -206,20 +255,23 @@ void result_scene::draw() {
 
     // FAILED 表示
     if (result_.failed) {
-        ui::draw_text_f("FAILED", kRankRect.x + kRankRect.width + 20.0f, kRankRect.y + 20.0f, 40, t.error);
+        ui::draw_text_f("FAILED", kRankRect.x + kRankRect.width + kFailedOffset,
+                        kRankRect.y + kFailedOffset, 40, t.error);
     }
 
     // スコア・精度（フレーム中央に配置）
     ui::draw_section(kScoreRect);
     {
         Rectangle score_rows[2];
-        ui::vstack(kScoreContentRect, 42.0f, 8.0f, score_rows);
+        const float score_row_h = ui::text_layout_font_size(36.0f);
+        const float score_gap = std::max(0.0f, (kScoreContentRect.height - score_row_h * 2.0f) * 0.5f);
+        ui::vstack(kScoreContentRect, score_row_h, score_gap, score_rows);
 
-        const ui::rect_pair score_columns = ui::split_columns(score_rows[0], 100.0f);
+        const ui::rect_pair score_columns = ui::split_columns(score_rows[0], kScoreLabelWidth);
         ui::draw_text_in_rect("SCORE", 20, score_columns.first, t.text_dim, ui::text_align::left);
         ui::draw_text_in_rect(TextFormat("%07d", result_.score), 36, score_columns.second, t.text, ui::text_align::left);
 
-        const ui::rect_pair accuracy_columns = ui::split_columns(score_rows[1], 140.0f);
+        const ui::rect_pair accuracy_columns = ui::split_columns(score_rows[1], kAccuracyLabelWidth);
         ui::draw_text_in_rect("ACCURACY", 20, accuracy_columns.first, t.text_dim, ui::text_align::left);
         ui::draw_text_in_rect(TextFormat("%.2f%%", result_.accuracy), 36, accuracy_columns.second,
                               t.text_secondary, ui::text_align::left);
@@ -243,19 +295,26 @@ void result_scene::draw() {
 
     {
         Rectangle judge_rects[5];
-        ui::vstack(kJudgeRowsRect, 42.0f, 0.0f, judge_rects);
+        const float judge_row_h = ui::text_layout_font_size(22.0f) + kJudgeRowExtraHeight;
+        const float judge_gap = kJudgeRowGap;
+        ui::vstack(kJudgeRowsRect, judge_row_h, judge_gap, judge_rects);
         for (int i = 0; i < 5; ++i) {
             const auto& row = rows[i];
             const ui::row_state row_state = ui::draw_row(judge_rects[i], t.section, t.section, t.border_light, 0.0f);
             const Rectangle content = ui::inset(row_state.visual, ui::edge_insets::symmetric(0.0f, 0.0f));
-            const Rectangle badge_rect = {content.x, content.y + 4.0f, 160.0f, 30.0f};
+            const Rectangle badge_rect = {
+                content.x,
+                content.y + (content.height - ui::text_layout_font_size(22.0f)) * 0.5f,
+                kJudgeBadgeWidth,
+                ui::text_layout_font_size(22.0f)
+            };
             const Rectangle count_rect = {
-                content.x + 176.0f,
+                content.x + kJudgeCountX,
                 content.y,
-                content.width - 176.0f,
+                content.width - kJudgeCountX,
                 content.height
             };
-            DrawRectangleRec(badge_rect, row.color);
+            ui::draw_rect_f(badge_rect, row.color);
             ui::draw_text_in_rect(row.label, 22, badge_rect, t.text);
             ui::draw_text_in_rect(TextFormat("%d", row.count), 22, count_rect, t.text, ui::text_align::left);
         }
@@ -266,16 +325,24 @@ void result_scene::draw() {
 
     {
         Rectangle stat_rows[4];
-        ui::vstack(kStatsRowsRect, 40.0f, 0.0f, stat_rows);
-        ui::draw_label_value(stat_rows[0], "Max Combo", TextFormat("%d", result_.max_combo), 24, t.text_dim, t.text);
-        ui::draw_label_value(stat_rows[1], "Avg Offset", TextFormat("%.1f ms", result_.avg_offset), 24, t.text_dim, t.text);
-        ui::draw_label_value(stat_rows[2], "Fast", TextFormat("%d", result_.fast_count), 24, t.text_dim, t.fast);
-        ui::draw_label_value(stat_rows[3], "Slow", TextFormat("%d", result_.slow_count), 24, t.text_dim, t.slow);
+        const float stat_row_h = ui::text_layout_font_size(24.0f);
+        ui::vstack(kStatsRowsRect, stat_row_h, kStatRowGap, stat_rows);
+        ui::draw_label_value(stat_rows[0], "Max Combo", TextFormat("%d", result_.max_combo),
+                             24, t.text_dim, t.text);
+        ui::draw_label_value(stat_rows[1], "Avg Offset", TextFormat("%.1f ms", result_.avg_offset),
+                             24, t.text_dim, t.text);
+        ui::draw_label_value(stat_rows[2], "Fast", TextFormat("%d", result_.fast_count),
+                             24, t.text_dim, t.fast);
+        ui::draw_label_value(stat_rows[3], "Slow", TextFormat("%d", result_.slow_count),
+                             24, t.text_dim, t.slow);
         ui::draw_text_in_rect("ENTER: Song Select    R: Retry    Use AUTO APPLY there", 20,
-                              kStatsHintRect, t.text_hint, ui::text_align::left);
+                              {kStatsHintRect.x, kStatsHintRect.y, kStatsHintRect.width,
+                               ui::text_layout_font_size(20.0f)},
+                              t.text_hint, ui::text_align::left);
         if (!online_submit_status_message_.empty()) {
             ui::draw_text_in_rect(online_submit_status_message_.c_str(), 18,
-                                  kOnlineStatusRect,
+                                  {kOnlineStatusRect.x, kOnlineStatusRect.y, kOnlineStatusRect.width,
+                                   ui::text_layout_font_size(18.0f)},
                                   online_submit_status_is_error_ ? t.error : t.text_secondary,
                                   ui::text_align::left);
         }

--- a/src/scenes/scene_common.cpp
+++ b/src/scenes/scene_common.cpp
@@ -81,6 +81,6 @@ void draw_marquee_text(const char* text, Rectangle clip_rect, int font_size, Col
 }
 
 void draw_marquee_text(const char* text, float x, float y, int font_size, Color color, float max_width, double time) {
-    draw_marquee_text(text, {x, y, max_width, static_cast<float>(font_size)},
+    draw_marquee_text(text, {x, y, max_width, ui::text_layout_font_size(static_cast<float>(font_size))},
                       font_size, color, time);
 }

--- a/src/scenes/scene_common.h
+++ b/src/scenes/scene_common.h
@@ -4,8 +4,8 @@
 
 // 仮想解像度。すべての2D UIはこの座標系で描画される。
 // 実際の表示は virtual_screen を通じてウィンドウサイズにスケーリングされる。
-constexpr int kScreenWidth = 1280;
-constexpr int kScreenHeight = 720;
+constexpr int kScreenWidth = 1920;
+constexpr int kScreenHeight = 1080;
 
 // メニュー系シーン共通のフレーム（グラデーション背景・角丸枠・タイトル文字列）を描画する。
 void draw_scene_frame(const char* title, const char* subtitle, Color accent);

--- a/src/scenes/settings/settings_layout.h
+++ b/src/scenes/settings/settings_layout.h
@@ -22,10 +22,41 @@ struct page_descriptor {
 
 inline constexpr ui::draw_layer kLayer = ui::draw_layer::base;
 inline constexpr int kPageCount = 4;
-inline constexpr float kSliderLeftInset = 218.0f;
-inline constexpr float kSliderRightInset = 42.0f;
-inline constexpr float kSliderTopOffset = 26.0f;
-inline constexpr float kArrowButtonSize = 34.0f;
+inline constexpr float kSliderLeftInset = 327.0f;
+inline constexpr float kSliderRightInset = 63.0f;
+inline constexpr float kSliderTopOffset = 39.0f;
+inline constexpr float kArrowButtonSize = 51.0f;
+inline constexpr float kSidebarWidth = 384.0f;
+inline constexpr float kPanelHeight = 990.0f;
+inline constexpr Vector2 kSidebarOffset = {36.0f, 66.0f};
+inline constexpr float kContentWidth = 1434.0f;
+inline constexpr Vector2 kContentOffset = {450.0f, 66.0f};
+inline constexpr float kSidebarItemWidth = 312.0f;
+inline constexpr float kSidebarHeaderHeight = 93.0f;
+inline constexpr Vector2 kSidebarHeaderOffset = {33.0f, 39.0f};
+inline constexpr float kSidebarHintHeight = 36.0f;
+inline constexpr Vector2 kSidebarHintOffset = {36.0f, 528.0f};
+inline constexpr float kTabRowHeight = 63.0f;
+inline constexpr float kTabRowGap = 12.0f;
+inline constexpr Vector2 kTabAreaOffset = {0.0f, 228.0f};
+inline constexpr float kBackHeight = 63.0f;
+inline constexpr Vector2 kBackOffset = {0.0f, -57.0f};
+inline constexpr float kContentHeaderWidth = 840.0f;
+inline constexpr float kContentHeaderHeight = 90.0f;
+inline constexpr Vector2 kContentHeaderOffset = {45.0f, 45.0f};
+inline constexpr float kRowWidth = 1335.0f;
+inline constexpr float kRowHeight = 72.0f;
+inline constexpr float kRowOffsetX = 45.0f;
+inline constexpr float kKeyModeHeight = 96.0f;
+inline constexpr float kSliderLabelWidth = 300.0f;
+inline constexpr float kSliderThickness = 27.0f;
+inline constexpr float kRowContentPaddingX = 27.0f;
+inline constexpr float kArrowGap = 15.0f;
+inline constexpr float kDoubleArrowExtraGap = 45.0f;
+inline constexpr float kKeySlotWidth = 840.0f;
+inline constexpr float kKeySlotHeight = 72.0f;
+inline constexpr float kKeySlotStartY = 321.0f;
+inline constexpr float kKeySlotStepY = 93.0f;
 
 inline constexpr std::array<page_descriptor, kPageCount> kPageDescriptors = {{
     {"Gameplay", "Gameplay", "Play feel and lane settings"},
@@ -35,47 +66,40 @@ inline constexpr std::array<page_descriptor, kPageCount> kPageDescriptors = {{
 }};
 
 inline const Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-inline const Rectangle kSidebarRect = ui::place(kScreenRect, 256.0f, 660.0f,
-                                                ui::anchor::top_left, ui::anchor::top_left,
-                                                {24.0f, 44.0f});
-inline const Rectangle kContentRect = ui::place(kScreenRect, 956.0f, 660.0f,
-                                                ui::anchor::top_left, ui::anchor::top_left,
-                                                {300.0f, 44.0f});
-inline const Rectangle kSidebarHeaderRect = ui::place(kSidebarRect, 208.0f, 62.0f,
-                                                      ui::anchor::top_left, ui::anchor::top_left,
-                                                      {22.0f, 26.0f});
-inline const Rectangle kSidebarHintRect = ui::place(kSidebarRect, 208.0f, 24.0f,
-                                                    ui::anchor::top_left, ui::anchor::top_left,
-                                                    {24.0f, 352.0f});
-inline const Rectangle kTabArea = ui::place(kSidebarRect, 208.0f, 4.0f * 42.0f + 3.0f * 8.0f,
-                                            ui::anchor::top_center, ui::anchor::top_center,
-                                            {0.0f, 152.0f});
-inline const Rectangle kBackRect = ui::place(kSidebarRect, 208.0f, 42.0f,
-                                             ui::anchor::bottom_center, ui::anchor::bottom_center,
-                                             {0.0f, -38.0f});
-inline const Rectangle kContentHeaderRect = ui::place(kContentRect, 560.0f, 60.0f,
-                                                      ui::anchor::top_left, ui::anchor::top_left,
-                                                      {30.0f, 30.0f});
+inline const Rectangle kSidebarRect = ui::place(kScreenRect, kSidebarWidth, kPanelHeight,
+                                                ui::anchor::top_left, ui::anchor::top_left, kSidebarOffset);
+inline const Rectangle kContentRect = ui::place(kScreenRect, kContentWidth, kPanelHeight,
+                                                ui::anchor::top_left, ui::anchor::top_left, kContentOffset);
+inline const Rectangle kSidebarHeaderRect = ui::place(kSidebarRect, kSidebarItemWidth, kSidebarHeaderHeight,
+                                                      ui::anchor::top_left, ui::anchor::top_left, kSidebarHeaderOffset);
+inline const Rectangle kSidebarHintRect = ui::place(kSidebarRect, kSidebarItemWidth, kSidebarHintHeight,
+                                                    ui::anchor::top_left, ui::anchor::top_left, kSidebarHintOffset);
+inline const Rectangle kTabArea = ui::place(kSidebarRect, kSidebarItemWidth, 4.0f * kTabRowHeight + 3.0f * kTabRowGap,
+                                            ui::anchor::top_center, ui::anchor::top_center, kTabAreaOffset);
+inline const Rectangle kBackRect = ui::place(kSidebarRect, kSidebarItemWidth, kBackHeight,
+                                             ui::anchor::bottom_center, ui::anchor::bottom_center, kBackOffset);
+inline const Rectangle kContentHeaderRect = ui::place(kContentRect, kContentHeaderWidth, kContentHeaderHeight,
+                                                      ui::anchor::top_left, ui::anchor::top_left, kContentHeaderOffset);
 inline const std::array<Rectangle, 8> kGeneralRows = {{
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 116.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 176.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 236.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 336.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 396.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 496.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 556.0f}),
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 616.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 174.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 264.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 354.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 504.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 594.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 744.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 834.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 924.0f}),
 }};
 inline const std::array<Rectangle, 5> kGameplayRows = {{
     kGeneralRows[0],
     kGeneralRows[1],
     kGeneralRows[2],
-    ui::place(kContentRect, 890.0f, 48.0f, ui::anchor::top_left, ui::anchor::top_left, {30.0f, 296.0f}),
+    ui::place(kContentRect, kRowWidth, kRowHeight, ui::anchor::top_left, ui::anchor::top_left, Vector2{kRowOffsetX, 444.0f}),
     kGeneralRows[4],
 }};
-inline const Rectangle kKeyModeRect = ui::place(kContentRect, 890.0f, 64.0f,
+inline const Rectangle kKeyModeRect = ui::place(kContentRect, kRowWidth, kKeyModeHeight,
                                                 ui::anchor::top_left, ui::anchor::top_left,
-                                                {30.0f, 126.0f});
+                                                Vector2{kRowOffsetX, 189.0f});
 
 inline float clamp01(float value) {
     return std::clamp(value, 0.0f, 1.0f);
@@ -86,53 +110,53 @@ inline const page_descriptor& page_descriptor_for(page_id page) {
 }
 
 inline Rectangle slider_track_rect(const Rectangle& row_rect) {
-    return ui::make_slider_layout(row_rect, kSliderLeftInset, kSliderRightInset, 200.0f, 18.0f, kSliderTopOffset).track_rect;
+    return ui::make_slider_layout(row_rect, kSliderLeftInset, kSliderRightInset, kSliderLabelWidth, kSliderThickness, kSliderTopOffset).track_rect;
 }
 
 inline Rectangle arrow_left_rect(const Rectangle& row_rect) {
-    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, 18.0f));
-    const ui::rect_pair columns = ui::split_columns(content, 200.0f);
-    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 2.0f + 10.0f, kArrowButtonSize,
+    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, kRowContentPaddingX));
+    const ui::rect_pair columns = ui::split_columns(content, kSliderLabelWidth);
+    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 2.0f + kArrowGap, kArrowButtonSize,
                                                  ui::anchor::center_right, ui::anchor::center_right);
     return {button_pair_area.x, button_pair_area.y, kArrowButtonSize, kArrowButtonSize};
 }
 
 inline Rectangle arrow_right_rect(const Rectangle& row_rect) {
     const Rectangle left = arrow_left_rect(row_rect);
-    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+    return {left.x + kArrowButtonSize + kArrowGap, left.y, kArrowButtonSize, kArrowButtonSize};
 }
 
 inline Rectangle double_arrow_left_rect(const Rectangle& row_rect) {
-    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, 18.0f));
-    const ui::rect_pair columns = ui::split_columns(content, 200.0f);
-    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 4.0f + 30.0f, kArrowButtonSize,
+    const Rectangle content = ui::inset(row_rect, ui::edge_insets::symmetric(0.0f, kRowContentPaddingX));
+    const ui::rect_pair columns = ui::split_columns(content, kSliderLabelWidth);
+    const Rectangle button_pair_area = ui::place(columns.second, kArrowButtonSize * 4.0f + kDoubleArrowExtraGap, kArrowButtonSize,
                                                  ui::anchor::center_right, ui::anchor::center_right);
     return {button_pair_area.x, button_pair_area.y, kArrowButtonSize, kArrowButtonSize};
 }
 
 inline Rectangle single_arrow_left_rect(const Rectangle& row_rect) {
     const Rectangle left = double_arrow_left_rect(row_rect);
-    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+    return {left.x + kArrowButtonSize + kArrowGap, left.y, kArrowButtonSize, kArrowButtonSize};
 }
 
 inline Rectangle single_arrow_right_rect(const Rectangle& row_rect) {
     const Rectangle left = single_arrow_left_rect(row_rect);
-    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+    return {left.x + kArrowButtonSize + kArrowGap, left.y, kArrowButtonSize, kArrowButtonSize};
 }
 
 inline Rectangle double_arrow_right_rect(const Rectangle& row_rect) {
     const Rectangle left = single_arrow_right_rect(row_rect);
-    return {left.x + kArrowButtonSize + 10.0f, left.y, kArrowButtonSize, kArrowButtonSize};
+    return {left.x + kArrowButtonSize + kArrowGap, left.y, kArrowButtonSize, kArrowButtonSize};
 }
 
 inline Rectangle key_slot_rect(int index) {
-    return ui::place(kContentRect, 560.0f, 48.0f,
+    return ui::place(kContentRect, kKeySlotWidth, kKeySlotHeight,
                      ui::anchor::top_left, ui::anchor::top_left,
-                     {30.0f, 214.0f + static_cast<float>(index) * 62.0f});
+                     Vector2{kRowOffsetX, kKeySlotStartY + static_cast<float>(index) * kKeySlotStepY});
 }
 
 inline void build_tab_rects(std::span<Rectangle> out) {
-    ui::vstack(kTabArea, 42.0f, 8.0f, out);
+    ui::vstack(kTabArea, kTabRowHeight, kTabRowGap, out);
 }
 
 inline float slider_ratio_from_mouse(const Rectangle& row_rect) {

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -72,7 +72,7 @@ void settings_scene::update(float dt) {
 
 void settings_scene::draw() {
     const auto& t = *g_theme;
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     ui::draw_panel(settings::kSidebarRect);

--- a/src/scenes/song_create_scene.cpp
+++ b/src/scenes/song_create_scene.cpp
@@ -32,21 +32,30 @@ constexpr ui::draw_layer kLayer = ui::draw_layer::base;
 constexpr int kScreenW = kScreenWidth;
 constexpr int kScreenH = kScreenHeight;
 constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenW), static_cast<float>(kScreenH)};
-constexpr Rectangle kCardFrameRect = ui::place(kScreenRect, 750.0f, 660.0f,
+constexpr Rectangle kCardFrameRect = ui::place(kScreenRect, 1125.0f, 990.0f,
                                                ui::anchor::top_left, ui::anchor::top_left,
-                                               {265.0f, 30.0f});
-constexpr Rectangle kHeaderRect = ui::place(kCardFrameRect, 620.0f, 60.0f,
+                                               Vector2{397.5f, 45.0f});
+constexpr Rectangle kHeaderRect = ui::place(kCardFrameRect, 930.0f, 90.0f,
                                             ui::anchor::top_left, ui::anchor::top_left,
-                                            {34.0f, 28.0f});
+                                            Vector2{51.0f, 42.0f});
 
-constexpr float kFormWidth = 700.0f;
-constexpr float kRowHeight = 42.0f;
-constexpr float kRowGap = 6.0f;
-constexpr float kFormStartY = 142.0f;
+constexpr float kFormWidth = 1050.0f;
+constexpr float kRowHeight = 63.0f;
+constexpr float kRowGap = 9.0f;
+constexpr float kFormStartY = 213.0f;
 constexpr float kFormX = (static_cast<float>(kScreenW) - kFormWidth) * 0.5f;
-constexpr Rectangle kFormCardRect = {kFormX - 26.0f, 118.0f, kFormWidth + 52.0f, 520.0f};
-constexpr Rectangle kDecisionCardRect = {350.0f, 210.0f, 580.0f, 220.0f};
-constexpr Rectangle kChartCardRect = {kFormX - 26.0f, 166.0f, kFormWidth + 52.0f, 420.0f};
+constexpr float kFormCardPaddingX = 39.0f;
+constexpr Rectangle kFormCardRect = {kFormX - kFormCardPaddingX, 177.0f, kFormWidth + kFormCardPaddingX * 2.0f, 780.0f};
+constexpr Rectangle kDecisionCardRect = {525.0f, 315.0f, 870.0f, 330.0f};
+constexpr float kTextInputLabelWidth = 180.0f;
+constexpr float kBrowseWidth = 138.0f;
+constexpr float kBrowseGap = 12.0f;
+constexpr float kButtonTopGap = 24.0f;
+constexpr float kButtonWidth = 270.0f;
+constexpr float kButtonHeight = 66.0f;
+constexpr float kButtonGap = 18.0f;
+constexpr float kErrorTopGap = 18.0f;
+constexpr float kErrorHeight = 36.0f;
 
 constexpr Rectangle make_row(int index) {
     return {kFormX, kFormStartY + static_cast<float>(index) * (kRowHeight + kRowGap), kFormWidth, kRowHeight};
@@ -126,7 +135,7 @@ void song_create_scene::draw() {
             break;
     }
 
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     ui::draw_header_block(kHeaderRect, content_title, content_subtitle);
@@ -166,22 +175,21 @@ void song_create_scene::draw_song_metadata() {
     int row = 0;
 
     ui::draw_text_input(make_row(row++), title_input_, "Title", "Song title",
-                        nullptr, kLayer, 16, 128, wide_text_filter, 120.0f);
+                        nullptr, kLayer, 16, 128, wide_text_filter, kTextInputLabelWidth);
 
     ui::draw_text_input(make_row(row++), artist_input_, "Artist", "Artist name",
-                        nullptr, kLayer, 16, 128, wide_text_filter, 120.0f);
+                        nullptr, kLayer, 16, 128, wide_text_filter, kTextInputLabelWidth);
 
     ui::draw_text_input(make_row(row++), bpm_input_, "BPM", "120.0",
-                        nullptr, kLayer, 16, 16, numeric_filter, 120.0f);
+                        nullptr, kLayer, 16, 16, numeric_filter, kTextInputLabelWidth);
 
     {
-        constexpr float kBrowseWidth = 92.0f;
         const Rectangle audio_row = make_row(row++);
-        const Rectangle input_rect = {audio_row.x, audio_row.y, audio_row.width - kBrowseWidth - 8.0f, audio_row.height};
+        const Rectangle input_rect = {audio_row.x, audio_row.y, audio_row.width - kBrowseWidth - kBrowseGap, audio_row.height};
         const Rectangle browse_rect = {audio_row.x + audio_row.width - kBrowseWidth, audio_row.y, kBrowseWidth, audio_row.height};
 
         ui::draw_text_input(input_rect, audio_path_input_, "Audio", "Select audio file...",
-                            nullptr, kLayer, 16, 512, nullptr, 120.0f);
+                            nullptr, kLayer, 16, 512, nullptr, kTextInputLabelWidth);
 
         if (ui::draw_button(browse_rect, "BROWSE", 14).clicked) {
             const std::string path = file_dialog::open_audio_file();
@@ -192,13 +200,12 @@ void song_create_scene::draw_song_metadata() {
     }
 
     {
-        constexpr float kBrowseWidth = 92.0f;
         const Rectangle jacket_row = make_row(row++);
-        const Rectangle input_rect = {jacket_row.x, jacket_row.y, jacket_row.width - kBrowseWidth - 8.0f, jacket_row.height};
+        const Rectangle input_rect = {jacket_row.x, jacket_row.y, jacket_row.width - kBrowseWidth - kBrowseGap, jacket_row.height};
         const Rectangle browse_rect = {jacket_row.x + jacket_row.width - kBrowseWidth, jacket_row.y, kBrowseWidth, jacket_row.height};
 
         ui::draw_text_input(input_rect, jacket_path_input_, "Jacket", "Select image file... (optional)",
-                            nullptr, kLayer, 16, 512, nullptr, 120.0f);
+                            nullptr, kLayer, 16, 512, nullptr, kTextInputLabelWidth);
 
         if (ui::draw_button(browse_rect, "BROWSE", 14).clicked) {
             const std::string path = file_dialog::open_image_file();
@@ -209,20 +216,18 @@ void song_create_scene::draw_song_metadata() {
     }
 
     ui::draw_text_input(make_row(row++), preview_ms_input_, "Preview (ms)", "0",
-                        "0", kLayer, 16, 10, int_filter, 120.0f);
+                        "0", kLayer, 16, 10, int_filter, kTextInputLabelWidth);
 
     ui::draw_text_input(make_row(row++), sns_youtube_input_, "YouTube", "URL (optional)",
-                        nullptr, kLayer, 16, 256, nullptr, 120.0f);
+                        nullptr, kLayer, 16, 256, nullptr, kTextInputLabelWidth);
     ui::draw_text_input(make_row(row++), sns_niconico_input_, "Niconico", "URL (optional)",
-                        nullptr, kLayer, 16, 256, nullptr, 120.0f);
+                        nullptr, kLayer, 16, 256, nullptr, kTextInputLabelWidth);
     ui::draw_text_input(make_row(row++), sns_x_input_, "X", "URL (optional)",
-                        nullptr, kLayer, 16, 256, nullptr, 120.0f);
+                        nullptr, kLayer, 16, 256, nullptr, kTextInputLabelWidth);
 
-    const float button_y = kFormStartY + static_cast<float>(row) * (kRowHeight + kRowGap) + 16.0f;
-    constexpr float kButtonWidth = 180.0f;
-    constexpr float kButtonHeight = 44.0f;
+    const float button_y = kFormStartY + static_cast<float>(row) * (kRowHeight + kRowGap) + kButtonTopGap;
     const Rectangle create_rect = {kFormX + kFormWidth - kButtonWidth, button_y, kButtonWidth, kButtonHeight};
-    const Rectangle cancel_rect = {kFormX + kFormWidth - kButtonWidth * 2.0f - 12.0f, button_y, kButtonWidth, kButtonHeight};
+    const Rectangle cancel_rect = {kFormX + kFormWidth - kButtonWidth * 2.0f - kButtonGap, button_y, kButtonWidth, kButtonHeight};
     const char* submit_label = is_edit_mode() ? "SAVE" : "CREATE";
     const char* cancel_label = is_edit_mode() ? "BACK" : "CANCEL";
 
@@ -240,28 +245,29 @@ void song_create_scene::draw_song_metadata() {
     }
 
     if (!error_.empty()) {
-        const Rectangle error_rect = {kFormX, button_y + kButtonHeight + 12.0f, kFormWidth, 24.0f};
+        const Rectangle error_rect = {kFormX, button_y + kButtonHeight + kErrorTopGap, kFormWidth, kErrorHeight};
         ui::draw_text_in_rect(error_.c_str(), 14, error_rect, g_theme->error, ui::text_align::left);
     }
 }
 
 void song_create_scene::draw_song_saved() {
-    constexpr float kCenterY = 310.0f;
-    constexpr float kButtonWidth = 220.0f;
-    constexpr float kButtonHeight = 48.0f;
-    constexpr float kGap = 16.0f;
-    const float total_width = kButtonWidth * 2.0f + kGap;
+    constexpr float kCenterY = 465.0f;
+    constexpr float kSavedButtonWidth = 330.0f;
+    constexpr float kSavedButtonHeight = 72.0f;
+    constexpr float kSavedButtonGap = 24.0f;
+    const float total_width = kSavedButtonWidth * 2.0f + kSavedButtonGap;
     const float start_x = (static_cast<float>(kScreenW) - total_width) * 0.5f;
 
-    const Rectangle title_rect = {kDecisionCardRect.x + 36.0f, kDecisionCardRect.y + 28.0f, kDecisionCardRect.width - 72.0f, 34.0f};
-    const Rectangle song_rect = {kDecisionCardRect.x + 36.0f, kDecisionCardRect.y + 72.0f, kDecisionCardRect.width - 72.0f, 30.0f};
-    const Rectangle msg_rect = {kDecisionCardRect.x + 36.0f, kDecisionCardRect.y + 118.0f, kDecisionCardRect.width - 72.0f, 30.0f};
+    const Rectangle title_rect = {kDecisionCardRect.x + 54.0f, kDecisionCardRect.y + 42.0f, kDecisionCardRect.width - 108.0f, 51.0f};
+    const Rectangle song_rect = {kDecisionCardRect.x + 54.0f, kDecisionCardRect.y + 108.0f, kDecisionCardRect.width - 108.0f, 45.0f};
+    const Rectangle msg_rect = {kDecisionCardRect.x + 54.0f, kDecisionCardRect.y + 177.0f, kDecisionCardRect.width - 108.0f, 45.0f};
     ui::draw_text_in_rect("Song has been created.", 24, title_rect, g_theme->text, ui::text_align::center);
     ui::draw_text_in_rect(created_song_.meta.title.c_str(), 22, song_rect, g_theme->text_secondary, ui::text_align::center);
     ui::draw_text_in_rect("What would you like to do next?", 20, msg_rect, g_theme->text_muted, ui::text_align::center);
 
-    const Rectangle add_chart_rect = {start_x, kCenterY + 45, kButtonWidth, kButtonHeight};
-    const Rectangle add_later_rect = {start_x + kButtonWidth + kGap, kCenterY + 45, kButtonWidth, kButtonHeight};
+    const Rectangle add_chart_rect = {start_x, kCenterY + 67.5f, kSavedButtonWidth, kSavedButtonHeight};
+    const Rectangle add_later_rect = {start_x + kSavedButtonWidth + kSavedButtonGap, kCenterY + 67.5f,
+                                      kSavedButtonWidth, kSavedButtonHeight};
 
     if (ui::draw_button(add_chart_rect, "ADD CHART", 16).clicked) {
         manager_.change_scene(std::make_unique<editor_scene>(manager_, created_song_, 4));

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -122,7 +122,7 @@ void draw_song_details(const state& state, const preview_controller& preview_con
     } else {
         ui::draw_text_in_rect("JACKET", 30, layout::kJacketRect, with_alpha(theme.text_muted, content_alpha));
     }
-    DrawRectangleLinesEx(layout::kJacketRect, 2.0f, theme.border_image);
+    ui::draw_rect_lines(layout::kJacketRect, 2.0f, theme.border_image);
 
     const float detail_x = layout::kDetailColumnX;
     const float detail_max_width = layout::kDetailColumnWidth;
@@ -153,8 +153,8 @@ void draw_song_details(const state& state, const preview_controller& preview_con
                 64.0f,
                 28.0f
             };
-            DrawRectangleRec(rank_rect, with_alpha(theme.section, chart_alpha));
-            DrawRectangleLinesEx(rank_rect, 1.5f, with_alpha(theme.border_light, chart_alpha));
+            ui::draw_rect_f(rank_rect, with_alpha(theme.section, chart_alpha));
+            ui::draw_rect_lines(rank_rect, 1.5f, with_alpha(theme.border_light, chart_alpha));
             ui::draw_text_in_rect(rank_label(*selected_chart->best_local_rank), 18, rank_rect,
                                   with_alpha(rank_color(*selected_chart->best_local_rank), chart_alpha), ui::text_align::center);
         }

--- a/src/scenes/song_select/song_select_layout.h
+++ b/src/scenes/song_select/song_select_layout.h
@@ -9,100 +9,117 @@
 namespace song_select::layout {
 
 inline constexpr ui::draw_layer kSceneLayer = ui::draw_layer::base;
-inline constexpr float kRowHeight = 60.0f;
-inline constexpr float kScrollWheelStep = 80.0f;
+inline constexpr float kRowHeight = 90.0f;
+inline constexpr float kScrollWheelStep = 120.0f;
 inline constexpr float kScrollLerpSpeed = 12.0f;
-inline constexpr float kOffsetAdjustButtonSize = 34.0f;
-inline constexpr float kAutoApplyButtonWidth = 72.0f;
+inline constexpr float kOffsetAdjustButtonSize = 51.0f;
+inline constexpr float kAutoApplyButtonWidth = 108.0f;
+inline constexpr float kButtonGap = 15.0f;
+inline constexpr float kPanelEdgeMargin = 18.0f;
+inline constexpr float kContextMenuTopPadding = 18.0f;
+inline constexpr float kRankingDropdownGap = 9.0f;
+inline constexpr float kRankingDropdownMenuHeight = 114.0f;
+inline constexpr float kDetailColumnGap = 30.0f;
+inline constexpr float kDetailRightPadding = 24.0f;
+inline constexpr float kLocalOffsetLabelOffsetY = 354.0f;
+inline constexpr float kLocalOffsetLabelHeight = 33.0f;
+inline constexpr float kLocalOffsetControlsOffsetY = 393.0f;
+inline constexpr float kLocalOffsetControlsHeight = 51.0f;
+inline constexpr float kLocalOffsetButtonsOffsetX = 156.0f;
+inline constexpr float kAutoApplyRightInset = 24.0f;
 inline constexpr Rectangle kScreenRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
-inline constexpr Rectangle kSettingsButtonRect = ui::place(kScreenRect, 162.0f, 30.0f,
+inline constexpr Rectangle kSettingsButtonRect = ui::place(kScreenRect, 243.0f, 45.0f,
                                                            ui::anchor::top_right, ui::anchor::top_right,
-                                                           {-24.0f, 4.0f});
-inline constexpr Rectangle kLoginButtonRect = ui::place(kSettingsButtonRect, 120.0f, 30.0f,
+                                                           {-36.0f, 6.0f});
+inline constexpr Rectangle kLoginButtonRect = ui::place(kSettingsButtonRect, 180.0f, 45.0f,
                                                         ui::anchor::top_left, ui::anchor::top_right,
-                                                        {-10.0f, 0.0f});
-inline constexpr Rectangle kSongListRect = ui::place(kScreenRect, 466.0f, 660.0f,
+                                                        {-15.0f, 0.0f});
+inline constexpr Rectangle kSongListRect = ui::place(kScreenRect, 699.0f, 990.0f,
                                                      ui::anchor::top_right, ui::anchor::top_right,
-                                                     {-24.0f, 44.0f});
-inline constexpr Rectangle kLeftPanelRect = ui::place(kScreenRect, 750.0f, 660.0f,
+                                                     {-36.0f, 66.0f});
+inline constexpr Rectangle kLeftPanelRect = ui::place(kScreenRect, 1125.0f, 990.0f,
                                                       ui::anchor::top_left, ui::anchor::top_left,
-                                                      {24.0f, 44.0f});
-inline constexpr Rectangle kJacketRect = ui::place(kLeftPanelRect, 320.0f, 320.0f,
+                                                      {36.0f, 66.0f});
+inline constexpr Rectangle kJacketRect = ui::place(kLeftPanelRect, 480.0f, 480.0f,
                                                    ui::anchor::top_left, ui::anchor::top_left,
-                                                   {20.0f, 24.0f});
-inline constexpr Rectangle kRankingPanelRect = ui::place(kLeftPanelRect, kLeftPanelRect.width - 40.0f, 272.0f,
+                                                   {30.0f, 36.0f});
+inline constexpr Rectangle kRankingPanelRect = ui::place(kLeftPanelRect, kLeftPanelRect.width - 60.0f, 408.0f,
                                                           ui::anchor::bottom_center, ui::anchor::bottom_center,
-                                                          {0.0f, -18.0f});
-inline constexpr Rectangle kRankingTitleRect = ui::place(kRankingPanelRect, 220.0f, 28.0f,
+                                                          {0.0f, -27.0f});
+inline constexpr Rectangle kRankingTitleRect = ui::place(kRankingPanelRect, 330.0f, 42.0f,
                                                          ui::anchor::top_left, ui::anchor::top_left,
-                                                         {20.0f, 10.0f});
-inline constexpr Rectangle kRankingSourceDropdownRect = ui::place(kRankingPanelRect, 116.0f, 28.0f,
+                                                         {30.0f, 15.0f});
+inline constexpr Rectangle kRankingSourceDropdownRect = ui::place(kRankingPanelRect, 174.0f, 42.0f,
                                                                   ui::anchor::top_right, ui::anchor::top_right,
-                                                                  {-16.0f, 10.0f});
-inline constexpr float kRankingHeaderHeight = 48.0f;
-inline constexpr float kRankingBottomPadding = 12.0f;
+                                                                  {-24.0f, 15.0f});
+inline constexpr float kRankingHeaderHeight = 72.0f;
+inline constexpr float kRankingBottomPadding = 18.0f;
 inline constexpr Rectangle kRankingListRect = ui::scroll_view(kRankingPanelRect, kRankingHeaderHeight, kRankingBottomPadding);
-inline constexpr Rectangle kRankingScrollbarTrackRect = ui::place(kRankingListRect, 6.0f, kRankingListRect.height,
+inline constexpr Rectangle kRankingScrollbarTrackRect = ui::place(kRankingListRect, 9.0f, kRankingListRect.height,
                                                                   ui::anchor::top_right, ui::anchor::top_right,
-                                                                  {-8.0f, 0.0f});
-inline constexpr float kRankingRowHeight = 54.0f;
-inline constexpr float kDetailColumnX = kJacketRect.x + kJacketRect.width + 20.0f;
-inline constexpr float kDetailColumnWidth = kLeftPanelRect.x + kLeftPanelRect.width - kDetailColumnX - 16.0f;
-inline constexpr Rectangle kLocalOffsetLabelRect = {kDetailColumnX, kJacketRect.y + 236.0f, kDetailColumnWidth, 22.0f};
-inline constexpr Rectangle kLocalOffsetControlsRect = {kDetailColumnX, kJacketRect.y + 262.0f, kDetailColumnWidth, 34.0f};
-inline constexpr Rectangle kSceneTitleRect = ui::place(kScreenRect, 360.0f, 30.0f,
+                                                                  {-12.0f, 0.0f});
+inline constexpr float kRankingRowHeight = 81.0f;
+inline constexpr float kDetailColumnX = kJacketRect.x + kJacketRect.width + kDetailColumnGap;
+inline constexpr float kDetailColumnWidth = kLeftPanelRect.x + kLeftPanelRect.width - kDetailColumnX - kDetailRightPadding;
+inline constexpr Rectangle kLocalOffsetLabelRect = {
+    kDetailColumnX, kJacketRect.y + kLocalOffsetLabelOffsetY, kDetailColumnWidth, kLocalOffsetLabelHeight
+};
+inline constexpr Rectangle kLocalOffsetControlsRect = {
+    kDetailColumnX, kJacketRect.y + kLocalOffsetControlsOffsetY, kDetailColumnWidth, kLocalOffsetControlsHeight
+};
+inline constexpr Rectangle kSceneTitleRect = ui::place(kScreenRect, 540.0f, 45.0f,
                                                        ui::anchor::top_left, ui::anchor::top_left,
-                                                       {30.0f, 12.0f});
-inline constexpr Rectangle kSongListTitleRect = ui::place(kSongListRect, 180.0f, 28.0f,
+                                                       {45.0f, 18.0f});
+inline constexpr Rectangle kSongListTitleRect = ui::place(kSongListRect, 270.0f, 42.0f,
                                                           ui::anchor::top_left, ui::anchor::top_left,
-                                                          {20.0f, 10.0f});
-inline constexpr Rectangle kSongListNewSongButtonRect = ui::place(kSongListRect, 124.0f, 30.0f,
+                                                          {30.0f, 15.0f});
+inline constexpr Rectangle kSongListNewSongButtonRect = ui::place(kSongListRect, 186.0f, 45.0f,
                                                                   ui::anchor::top_right, ui::anchor::top_right,
-                                                                  {-16.0f, 10.0f});
-inline constexpr Rectangle kSongListImportSongButtonRect = ui::place(kSongListNewSongButtonRect, 152.0f, 30.0f,
+                                                                  {-24.0f, 15.0f});
+inline constexpr Rectangle kSongListImportSongButtonRect = ui::place(kSongListNewSongButtonRect, 228.0f, 45.0f,
                                                                      ui::anchor::top_left, ui::anchor::top_right,
-                                                                     {-10.0f, 0.0f});
-inline constexpr float kSongListHeaderHeight = 48.0f;
-inline constexpr float kSongListBottomPadding = 12.0f;
-inline constexpr float kSongListTopPadding = 10.0f;
+                                                                     {-15.0f, 0.0f});
+inline constexpr float kSongListHeaderHeight = 72.0f;
+inline constexpr float kSongListBottomPadding = 18.0f;
+inline constexpr float kSongListTopPadding = 15.0f;
 inline constexpr Rectangle kSongListViewRect = ui::scroll_view(kSongListRect, kSongListHeaderHeight, kSongListBottomPadding);
-inline constexpr Rectangle kSongListScrollbarTrackRect = ui::place(kSongListViewRect, 6.0f, kSongListViewRect.height,
+inline constexpr Rectangle kSongListScrollbarTrackRect = ui::place(kSongListViewRect, 9.0f, kSongListViewRect.height,
                                                                    ui::anchor::top_right, ui::anchor::top_right,
-                                                                   {-8.0f, 0.0f});
+                                                                   {-12.0f, 0.0f});
 inline constexpr ui::draw_layer kContextMenuLayer = ui::draw_layer::overlay;
 inline constexpr ui::draw_layer kModalLayer = ui::draw_layer::modal;
-inline constexpr float kContextMenuWidth = 220.0f;
-inline constexpr float kContextMenuItemHeight = 30.0f;
-inline constexpr float kContextMenuItemSpacing = 4.0f;
-inline constexpr Rectangle kConfirmDialogRect = ui::place(kScreenRect, 480.0f, 208.0f,
+inline constexpr float kContextMenuWidth = 330.0f;
+inline constexpr float kContextMenuItemHeight = 45.0f;
+inline constexpr float kContextMenuItemSpacing = 6.0f;
+inline constexpr Rectangle kConfirmDialogRect = ui::place(kScreenRect, 720.0f, 312.0f,
                                                           ui::anchor::center, ui::anchor::center);
-inline constexpr Rectangle kLoginDialogRect = ui::place(kScreenRect, 760.0f, 560.0f,
+inline constexpr Rectangle kLoginDialogRect = ui::place(kScreenRect, 1140.0f, 840.0f,
                                                         ui::anchor::center, ui::anchor::center,
-                                                        {0.0f, 12.0f});
+                                                        {0.0f, 18.0f});
 
 inline Rectangle make_context_menu_rect(Vector2 anchor, int item_count) {
-    const float height = 12.0f + static_cast<float>(item_count) * kContextMenuItemHeight +
+    const float height = kContextMenuTopPadding + static_cast<float>(item_count) * kContextMenuItemHeight +
                          static_cast<float>(std::max(0, item_count - 1)) * kContextMenuItemSpacing;
     Rectangle rect = {anchor.x, anchor.y, kContextMenuWidth, height};
-    rect.x = std::clamp(rect.x, 12.0f, kScreenRect.width - rect.width - 12.0f);
-    rect.y = std::clamp(rect.y, 12.0f, kScreenRect.height - rect.height - 12.0f);
+    rect.x = std::clamp(rect.x, kPanelEdgeMargin, kScreenRect.width - rect.width - kPanelEdgeMargin);
+    rect.y = std::clamp(rect.y, kPanelEdgeMargin, kScreenRect.height - rect.height - kPanelEdgeMargin);
     return rect;
 }
 
 inline Rectangle ranking_source_dropdown_menu_rect() {
     return {
         kRankingSourceDropdownRect.x,
-        kRankingSourceDropdownRect.y + kRankingSourceDropdownRect.height + 6.0f,
+        kRankingSourceDropdownRect.y + kRankingSourceDropdownRect.height + kRankingDropdownGap,
         kRankingSourceDropdownRect.width,
-        76.0f
+        kRankingDropdownMenuHeight
     };
 }
 
 inline Rectangle local_offset_double_left_rect() {
     const Rectangle area = {
-        kLocalOffsetControlsRect.x + 104.0f,
+        kLocalOffsetControlsRect.x + kLocalOffsetButtonsOffsetX,
         kLocalOffsetControlsRect.y,
-        kOffsetAdjustButtonSize * 4.0f + 10.0f * 3.0f,
+        kOffsetAdjustButtonSize * 4.0f + kButtonGap * 3.0f,
         kOffsetAdjustButtonSize
     };
     return {area.x, area.y, kOffsetAdjustButtonSize, kOffsetAdjustButtonSize};
@@ -110,22 +127,22 @@ inline Rectangle local_offset_double_left_rect() {
 
 inline Rectangle local_offset_left_rect() {
     const Rectangle left = local_offset_double_left_rect();
-    return {left.x + left.width + 10.0f, left.y, left.width, left.height};
+    return {left.x + left.width + kButtonGap, left.y, left.width, left.height};
 }
 
 inline Rectangle local_offset_right_rect() {
     const Rectangle left = local_offset_left_rect();
-    return {left.x + left.width + 10.0f, left.y, left.width, left.height};
+    return {left.x + left.width + kButtonGap, left.y, left.width, left.height};
 }
 
 inline Rectangle local_offset_double_right_rect() {
     const Rectangle left = local_offset_right_rect();
-    return {left.x + left.width + 10.0f, left.y, left.width, left.height};
+    return {left.x + left.width + kButtonGap, left.y, left.width, left.height};
 }
 
 inline Rectangle auto_apply_button_rect() {
     return {
-        kLocalOffsetControlsRect.x + kLocalOffsetControlsRect.width - kAutoApplyButtonWidth - 16.0f,
+        kLocalOffsetControlsRect.x + kLocalOffsetControlsRect.width - kAutoApplyButtonWidth - kAutoApplyRightInset,
         kLocalOffsetControlsRect.y,
         kAutoApplyButtonWidth,
         kOffsetAdjustButtonSize

--- a/src/scenes/song_select/song_select_list_view.cpp
+++ b/src/scenes/song_select/song_select_list_view.cpp
@@ -95,8 +95,8 @@ void draw_chart_rows(const song_select::state& state,
                               child_selected ? theme.text_secondary : theme.text_muted, ui::text_align::left);
         draw_marquee_text(chart.meta.chart_author.c_str(), author_rect, 14, theme.text_muted, now);
         if (chart.best_local_rank.has_value()) {
-            DrawRectangleRec(rank_rect, theme.section);
-            DrawRectangleLinesEx(rank_rect, 1.5f, theme.border_light);
+            ui::draw_rect_f(rank_rect, theme.section);
+            ui::draw_rect_lines(rank_rect, 1.5f, theme.border_light);
             ui::draw_text_in_rect(rank_label(*chart.best_local_rank), 14, rank_rect,
                                   rank_color(*chart.best_local_rank), ui::text_align::center);
         } else {

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -7,23 +7,42 @@
 
 namespace {
 
-constexpr float kDialogWidth = 360.0f;
-constexpr float kLoginDialogHeight = 308.0f;
-constexpr float kAccountDialogHeight = 258.0f;
-constexpr float kDialogOffsetY = 18.0f;
-constexpr float kDialogPaddingX = 18.0f;
-constexpr float kTitleHeight = 26.0f;
-constexpr float kSubtitleHeight = 18.0f;
-constexpr float kHeaderTop = 18.0f;
-constexpr float kHeaderGap = 6.0f;
-constexpr float kBodyTop = 86.0f;
-constexpr float kRowHeight = 36.0f;
-constexpr float kRowGap = 8.0f;
-constexpr float kButtonHeight = 36.0f;
-constexpr float kButtonGap = 8.0f;
-constexpr float kPrimaryButtonWidth = 128.0f;
-constexpr float kSecondaryButtonWidth = 164.0f;
-constexpr float kHelperTextHeight = 18.0f;
+constexpr float kDialogWidth = 540.0f;
+constexpr float kLoginDialogHeight = 462.0f;
+constexpr float kAccountDialogHeight = 387.0f;
+constexpr float kDialogOffsetY = 27.0f;
+constexpr float kDialogPaddingX = 27.0f;
+constexpr float kTitleHeight = 39.0f;
+constexpr float kSubtitleHeight = 27.0f;
+constexpr float kHeaderTop = 27.0f;
+constexpr float kHeaderGap = 9.0f;
+constexpr float kBodyTop = 129.0f;
+constexpr float kRowHeight = 54.0f;
+constexpr float kRowGap = 12.0f;
+constexpr float kButtonHeight = 54.0f;
+constexpr float kButtonGap = 12.0f;
+constexpr float kPrimaryButtonWidth = 192.0f;
+constexpr float kSecondaryButtonWidth = 246.0f;
+constexpr float kHelperTextHeight = 27.0f;
+constexpr float kScreenEdgeMargin = 18.0f;
+constexpr float kOpenAnimOffsetY = 27.0f;
+constexpr float kFooterMarginBottom = 27.0f;
+constexpr float kSignedInLineHeight = 33.0f;
+constexpr float kDisplayNameOffsetY = 42.0f;
+constexpr float kDisplayNameHeight = 30.0f;
+constexpr float kEmailOffsetY = 78.0f;
+constexpr float kEmailLineHeight = 24.0f;
+constexpr float kVerifyOffsetY = 111.0f;
+constexpr float kVerifyLineHeight = 24.0f;
+constexpr float kAccountButtonWidth = 138.0f;
+constexpr float kStatusOffsetAboveFooter = 42.0f;
+constexpr float kStatusLineHeight = 30.0f;
+constexpr float kTextInputLabelWidth = 135.0f;
+constexpr float kLoginActionTop = 249.0f;
+constexpr float kMessageHeight = 27.0f;
+constexpr float kLoginButtonOffsetY = 42.0f;
+constexpr float kHelperOffsetY = 108.0f;
+constexpr float kWebButtonOffsetY = 141.0f;
 
 Rectangle dialog_rect_for(const song_select::state& state) {
     const float dialog_height = state.auth.logged_in
@@ -35,10 +54,12 @@ Rectangle dialog_rect_for(const song_select::state& state) {
         kDialogWidth,
         dialog_height
     };
-    rect.x = std::clamp(rect.x, 12.0f, song_select::layout::kScreenRect.width - rect.width - 12.0f);
-    rect.y = std::clamp(rect.y, 12.0f, song_select::layout::kScreenRect.height - rect.height - 12.0f);
+    rect.x = std::clamp(rect.x, kScreenEdgeMargin,
+                        song_select::layout::kScreenRect.width - rect.width - kScreenEdgeMargin);
+    rect.y = std::clamp(rect.y, kScreenEdgeMargin,
+                        song_select::layout::kScreenRect.height - rect.height - kScreenEdgeMargin);
     const float anim_t = tween::ease_out_cubic(state.login_dialog.open_anim);
-    rect.y -= (1.0f - anim_t) * 18.0f;
+    rect.y -= (1.0f - anim_t) * kOpenAnimOffsetY;
     return rect;
 }
 
@@ -55,10 +76,10 @@ Rectangle dialog_rect_for(const song_select::auth_state& auth_state,
         kDialogWidth,
         dialog_height
     };
-    rect.x = std::clamp(rect.x, 12.0f, screen_rect.width - rect.width - 12.0f);
-    rect.y = std::clamp(rect.y, 12.0f, screen_rect.height - rect.height - 12.0f);
+    rect.x = std::clamp(rect.x, kScreenEdgeMargin, screen_rect.width - rect.width - kScreenEdgeMargin);
+    rect.y = std::clamp(rect.y, kScreenEdgeMargin, screen_rect.height - rect.height - kScreenEdgeMargin);
     const float anim_t = tween::ease_out_cubic(dialog_state.open_anim);
-    rect.y -= (1.0f - anim_t) * 18.0f;
+    rect.y -= (1.0f - anim_t) * kOpenAnimOffsetY;
     return rect;
 }
 
@@ -104,7 +125,7 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
     const Rectangle dialog_rect = dialog_rect_for(auth_state, dialog_state, anchor_rect, screen_rect);
     const float form_x = dialog_rect.x + kDialogPaddingX;
     const float form_width = dialog_rect.width - kDialogPaddingX * 2.0f;
-    const float footer_y = dialog_rect.y + dialog_rect.height - 18.0f - kButtonHeight;
+    const float footer_y = dialog_rect.y + dialog_rect.height - kFooterMarginBottom - kButtonHeight;
 
     ui::draw_panel(dialog_rect);
     ui::draw_text_in_rect("Account", 24,
@@ -117,14 +138,23 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                           theme.text_secondary, ui::text_align::left);
 
     if (auth_state.logged_in) {
-        const Rectangle signed_in_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 22.0f};
-        const Rectangle display_name_rect = {form_x, dialog_rect.y + kBodyTop + 28.0f, form_width, 20.0f};
-        const Rectangle email_rect = {form_x, dialog_rect.y + kBodyTop + 52.0f, form_width, 16.0f};
-        const Rectangle verify_rect = {form_x, dialog_rect.y + kBodyTop + 74.0f, form_width, 16.0f};
+        const Rectangle signed_in_rect = {form_x, dialog_rect.y + kBodyTop, form_width, kSignedInLineHeight};
+        const Rectangle display_name_rect = {
+            form_x, dialog_rect.y + kBodyTop + kDisplayNameOffsetY, form_width, kDisplayNameHeight
+        };
+        const Rectangle email_rect = {
+            form_x, dialog_rect.y + kBodyTop + kEmailOffsetY, form_width, kEmailLineHeight
+        };
+        const Rectangle verify_rect = {
+            form_x, dialog_rect.y + kBodyTop + kVerifyOffsetY, form_width, kVerifyLineHeight
+        };
         const Rectangle button_row = {form_x, footer_y, form_width, kButtonHeight};
-        constexpr float kButtonWidth = 92.0f;
-        const Rectangle logout_rect = {button_row.x + button_row.width - kButtonWidth, button_row.y, kButtonWidth, kButtonHeight};
-        const Rectangle refresh_rect = {logout_rect.x - kButtonWidth - kButtonGap, button_row.y, kButtonWidth, kButtonHeight};
+        const Rectangle logout_rect = {
+            button_row.x + button_row.width - kAccountButtonWidth, button_row.y, kAccountButtonWidth, kButtonHeight
+        };
+        const Rectangle refresh_rect = {
+            logout_rect.x - kAccountButtonWidth - kButtonGap, button_row.y, kAccountButtonWidth, kButtonHeight
+        };
 
         ui::draw_text_in_rect("Signed in", 20, signed_in_rect, theme.success, ui::text_align::left);
         ui::draw_text_in_rect(auth_state.display_name.empty() ? auth_state.email.c_str() : auth_state.display_name.c_str(),
@@ -147,7 +177,7 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
 
         if (!dialog_state.status_message.empty()) {
             ui::draw_text_in_rect(dialog_state.status_message.c_str(), 13,
-                                  {form_x, footer_y - 28.0f, form_width, 20.0f},
+                                  {form_x, footer_y - kStatusOffsetAboveFooter, form_width, kStatusLineHeight},
                                   dialog_state.status_message_is_error ? theme.error : theme.success,
                                   ui::text_align::left);
         }
@@ -164,17 +194,17 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
     int row = 0;
     const ui::text_input_result email_result = ui::draw_text_input(
         make_row(dialog_rect, row++), dialog_state.email_input, "Email", "name@example.com",
-        nullptr, layer, 15, 64, printable_filter, 90.0f);
+        nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth);
 
     const ui::text_input_result password_result = ui::draw_text_input(
-        make_row(dialog_rect, row++), dialog_state.password_input, "Pass", "At least 8 characters",
-        nullptr, layer, 15, 64, printable_filter, 90.0f);
+        make_row(dialog_rect, row++), dialog_state.password_input, "Pass", "Password",
+        nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth);
 
-    const float action_top = dialog_rect.y + 166.0f;
-    const Rectangle message_rect = {form_x, action_top, form_width, 18.0f};
-    const Rectangle login_button_row = {form_x, action_top + 28.0f, form_width, kButtonHeight};
-    const Rectangle helper_rect = {form_x, action_top + 72.0f, form_width, kHelperTextHeight};
-    const Rectangle web_button_row = {form_x, action_top + 94.0f, form_width, kButtonHeight};
+    const float action_top = dialog_rect.y + kLoginActionTop;
+    const Rectangle message_rect = {form_x, action_top, form_width, kMessageHeight};
+    const Rectangle login_button_row = {form_x, action_top + kLoginButtonOffsetY, form_width, kButtonHeight};
+    const Rectangle helper_rect = {form_x, action_top + kHelperOffsetY, form_width, kHelperTextHeight};
+    const Rectangle web_button_row = {form_x, action_top + kWebButtonOffsetY, form_width, kButtonHeight};
     const Rectangle primary_rect = ui::place(login_button_row, kPrimaryButtonWidth, kButtonHeight,
                                              ui::anchor::center, ui::anchor::center);
     const Rectangle web_button_rect = ui::place(web_button_row, kSecondaryButtonWidth, kButtonHeight,

--- a/src/scenes/song_select/song_select_ranking_view.cpp
+++ b/src/scenes/song_select/song_select_ranking_view.cpp
@@ -191,8 +191,8 @@ void draw_ranking_row(const ranking_service::entry& entry, float y, float offset
     const Rectangle recorded_at_rect = {content.x + 350.0f, content.y + 20.0f, 92.0f, 16.0f};
     const Rectangle score_rect = {content.x + 446.0f, content.y, content.width - 446.0f, content.height};
 
-    DrawRectangleRec(rank_rect, with_alpha(theme.section, alpha));
-    DrawRectangleLinesEx(rank_rect, 1.5f, with_alpha(theme.border_light, alpha));
+    ui::draw_rect_f(rank_rect, with_alpha(theme.section, alpha));
+    ui::draw_rect_lines(rank_rect, 1.5f, with_alpha(theme.border_light, alpha));
 
     ui::draw_text_in_rect(TextFormat("%02d", entry.placement), 18, placement_rect, with_alpha(theme.text, alpha), ui::text_align::center);
     ui::draw_text_in_rect(rank_label(entry.clear_rank()), 17, rank_rect, with_alpha(rank_color(entry.clear_rank()), alpha), ui::text_align::center);

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -651,7 +651,7 @@ void song_select_scene::update(float dt) {
 
 void song_select_scene::draw() {
     const auto& theme = *g_theme;
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(theme.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, theme.bg, theme.bg_alt);
     ui::begin_draw_queue();

--- a/src/scenes/title/center_panel_view.cpp
+++ b/src/scenes/title/center_panel_view.cpp
@@ -11,8 +11,40 @@
 
 namespace {
 
-constexpr float kChartButtonHeight = 54.0f;
-constexpr float kChartButtonGap = 8.0f;
+constexpr float kChartButtonHeight = 81.0f;
+constexpr float kChartButtonGap = 12.0f;
+constexpr float kEmptyMessageOffsetY = 180.0f;
+constexpr float kEmptyMessageHeight = 60.0f;
+constexpr float kJacketFramePadding = 12.0f;
+constexpr float kJacketInnerPadding = 3.0f;
+constexpr float kJacketBorderWidth = 2.25f;
+constexpr float kHeaderPaddingX = 18.0f;
+constexpr float kTitleOffsetY = 18.0f;
+constexpr float kTitleHeight = 45.0f;
+constexpr float kArtistOffsetY = 72.0f;
+constexpr float kArtistHeight = 33.0f;
+constexpr float kChartDifficultyOffsetY = 6.0f;
+constexpr float kChartDifficultyHeight = 30.0f;
+constexpr float kChartNotesOffsetY = 48.0f;
+constexpr float kChartNotesHeight = 27.0f;
+constexpr float kChartBpmOffsetY = 81.0f;
+constexpr float kChartBpmHeight = 27.0f;
+constexpr float kChartAuthorOffsetY = 114.0f;
+constexpr float kChartAuthorHeight = 24.0f;
+constexpr float kClipSlack = 6.0f;
+constexpr float kChartRowBorderWidth = 1.5f;
+constexpr float kChartTextPaddingX = 18.0f;
+constexpr float kChartRightReserved = 84.0f;
+constexpr float kChartTitleOffsetY = 13.5f;
+constexpr float kChartTitleHeight = 27.0f;
+constexpr float kChartLevelOffsetY = 45.0f;
+constexpr float kChartLevelHeight = 24.0f;
+constexpr float kChartBadgeRightInset = 57.0f;
+constexpr float kChartBadgeOffsetY = 15.0f;
+constexpr float kChartBadgeWidth = 39.0f;
+constexpr float kChartBadgeHeight = 24.0f;
+constexpr float kChartRankOffsetY = 45.0f;
+constexpr float kChartRankHeight = 21.0f;
 
 const char* rank_label(rank value) {
     switch (value) {
@@ -109,27 +141,27 @@ void draw(const song_select::state& state,
             return;
         }
         ui::draw_text_in_rect("No songs found yet.", 34,
-                              {config.main_column_rect.x, config.main_column_rect.y + 120.0f,
-                               config.main_column_rect.width, 40.0f},
+                              {config.main_column_rect.x, config.main_column_rect.y + kEmptyMessageOffsetY,
+                               config.main_column_rect.width, kEmptyMessageHeight},
                               with_alpha(t.text, config.alpha));
         return;
     }
 
     const Rectangle jacket_frame = {
-        config.jacket_rect.x - 8.0f,
-        config.jacket_rect.y - 8.0f,
-        config.jacket_rect.width + 16.0f,
-        config.jacket_rect.height + 16.0f
+        config.jacket_rect.x - kJacketFramePadding,
+        config.jacket_rect.y - kJacketFramePadding,
+        config.jacket_rect.width + kJacketFramePadding * 2.0f,
+        config.jacket_rect.height + kJacketFramePadding * 2.0f
     };
     const Rectangle jacket_inner = {
-        config.jacket_rect.x + 2.0f,
-        config.jacket_rect.y + 2.0f,
-        config.jacket_rect.width - 4.0f,
-        config.jacket_rect.height - 4.0f
+        config.jacket_rect.x + kJacketInnerPadding,
+        config.jacket_rect.y + kJacketInnerPadding,
+        config.jacket_rect.width - kJacketInnerPadding * 2.0f,
+        config.jacket_rect.height - kJacketInnerPadding * 2.0f
     };
 
-    DrawRectangleLinesEx(jacket_frame, 1.5f,
-                         with_alpha(t.border_image, static_cast<unsigned char>(190.0f * config.play_t)));
+    ui::draw_rect_lines(jacket_frame, kJacketBorderWidth,
+                        with_alpha(t.border_image, static_cast<unsigned char>(190.0f * config.play_t)));
     if (preview_controller.jacket_loaded()) {
         const Texture2D& jacket = preview_controller.jacket_texture();
         DrawTexturePro(jacket,
@@ -141,16 +173,16 @@ void draw(const song_select::state& state,
     }
 
     const Rectangle title_rect = {
-        config.main_column_rect.x + 12.0f,
-        config.main_column_rect.y + 14.0f,
-        config.main_column_rect.width - 24.0f,
-        26.0f
+        config.main_column_rect.x + kHeaderPaddingX,
+        config.main_column_rect.y + kTitleOffsetY,
+        config.main_column_rect.width - kHeaderPaddingX * 2.0f,
+        kTitleHeight
     };
     const Rectangle artist_rect = {
-        config.main_column_rect.x + 12.0f,
-        config.main_column_rect.y + 46.0f,
-        config.main_column_rect.width - 24.0f,
-        20.0f
+        config.main_column_rect.x + kHeaderPaddingX,
+        config.main_column_rect.y + kArtistOffsetY,
+        config.main_column_rect.width - kHeaderPaddingX * 2.0f,
+        kArtistHeight
     };
     draw_marquee_text(song->song.meta.title.c_str(),
                       title_rect,
@@ -161,23 +193,23 @@ void draw(const song_select::state& state,
     if (chart != nullptr) {
         ui::draw_text_in_rect(TextFormat("%s  Lv.%.1f", chart->meta.difficulty.c_str(), chart->meta.level),
                               18,
-                              {config.chart_detail_rect.x, config.chart_detail_rect.y + 4.0f,
-                               config.chart_detail_rect.width, 18.0f},
+                              {config.chart_detail_rect.x, config.chart_detail_rect.y + kChartDifficultyOffsetY,
+                               config.chart_detail_rect.width, kChartDifficultyHeight},
                               with_alpha(t.text, config.alpha), ui::text_align::left);
         ui::draw_text_in_rect(TextFormat("%s   %d Notes", key_mode_label(chart->meta.key_count).c_str(),
                                          chart->note_count),
                               14,
-                              {config.chart_detail_rect.x, config.chart_detail_rect.y + 32.0f,
-                               config.chart_detail_rect.width, 16.0f},
+                              {config.chart_detail_rect.x, config.chart_detail_rect.y + kChartNotesOffsetY,
+                               config.chart_detail_rect.width, kChartNotesHeight},
                               with_alpha(t.text_secondary, config.alpha), ui::text_align::left);
         ui::draw_text_in_rect(TextFormat("BPM %s", format_bpm_range(chart->min_bpm, chart->max_bpm).c_str()),
                               14,
-                              {config.chart_detail_rect.x, config.chart_detail_rect.y + 54.0f,
-                               config.chart_detail_rect.width, 16.0f},
+                              {config.chart_detail_rect.x, config.chart_detail_rect.y + kChartBpmOffsetY,
+                               config.chart_detail_rect.width, kChartBpmHeight},
                               with_alpha(t.text_muted, config.alpha), ui::text_align::left);
         draw_marquee_text(chart->meta.chart_author.c_str(),
-                          {config.chart_detail_rect.x, config.chart_detail_rect.y + 76.0f,
-                           config.chart_detail_rect.width, 14.0f},
+                          {config.chart_detail_rect.x, config.chart_detail_rect.y + kChartAuthorOffsetY,
+                           config.chart_detail_rect.width, kChartAuthorHeight},
                           14, with_alpha(t.text_muted, config.alpha), config.now);
     }
 
@@ -185,8 +217,8 @@ void draw(const song_select::state& state,
     for (int i = 0; i < static_cast<int>(filtered.size()); ++i) {
         const song_select::chart_option& item = *filtered[static_cast<size_t>(i)];
         const Rectangle row = chart_button_rect(config.chart_buttons_rect, i, state.chart_scroll_y);
-        if (row.y + row.height < config.chart_buttons_rect.y - 4.0f ||
-            row.y > config.chart_buttons_rect.y + config.chart_buttons_rect.height + 4.0f) {
+        if (row.y + row.height < config.chart_buttons_rect.y - kClipSlack ||
+            row.y > config.chart_buttons_rect.y + config.chart_buttons_rect.height + kClipSlack) {
             continue;
         }
 
@@ -195,22 +227,26 @@ void draw(const song_select::state& state,
         const unsigned char row_alpha = selected ? config.selected_row_alpha
             : hovered ? config.hover_row_alpha
                       : config.normal_row_alpha;
-        DrawRectangleRec(row, with_alpha(selected ? config.button_selected : config.button_base, row_alpha));
-        DrawRectangleLinesEx(
-            row, 1.0f,
+        ui::draw_rect_f(row, with_alpha(selected ? config.button_selected : config.button_base, row_alpha));
+        ui::draw_rect_lines(
+            row, kChartRowBorderWidth,
             with_alpha(t.border_light, static_cast<unsigned char>(130.0f * config.play_t)));
         ui::draw_text_in_rect(item.meta.difficulty.c_str(), 16,
-                              {row.x + 12.0f, row.y + 9.0f, row.width - 56.0f, 16.0f},
+                              {row.x + kChartTextPaddingX, row.y + kChartTitleOffsetY,
+                               row.width - kChartRightReserved, kChartTitleHeight},
                               with_alpha(t.text, config.alpha), ui::text_align::left);
         ui::draw_text_in_rect(TextFormat("Lv.%.1f", item.meta.level), 13,
-                              {row.x + 12.0f, row.y + 28.0f, row.width - 56.0f, 14.0f},
+                              {row.x + kChartTextPaddingX, row.y + kChartLevelOffsetY,
+                               row.width - kChartRightReserved, kChartLevelHeight},
                               with_alpha(t.text_muted, config.alpha), ui::text_align::left);
         ui::draw_text_in_rect(key_mode_label(item.meta.key_count).c_str(), 13,
-                              {row.x + row.width - 34.0f, row.y + 10.0f, 22.0f, 14.0f},
+                              {row.x + row.width - kChartBadgeRightInset, row.y + kChartBadgeOffsetY,
+                               kChartBadgeWidth, kChartBadgeHeight},
                               with_alpha(key_mode_color(item.meta.key_count), config.alpha), ui::text_align::right);
         if (item.best_local_rank.has_value()) {
             ui::draw_text_in_rect(rank_label(*item.best_local_rank), 12,
-                                  {row.x + row.width - 34.0f, row.y + 28.0f, 22.0f, 12.0f},
+                                  {row.x + row.width - kChartBadgeRightInset, row.y + kChartRankOffsetY,
+                                   kChartBadgeWidth, kChartRankHeight},
                                   with_alpha(rank_color(*item.best_local_rank), config.alpha), ui::text_align::right);
         }
     }

--- a/src/scenes/title/home_menu_view.cpp
+++ b/src/scenes/title/home_menu_view.cpp
@@ -10,11 +10,21 @@
 
 namespace {
 
-constexpr float kHomeButtonWidth = 232.0f;
-constexpr float kHomeButtonHeight = 78.0f;
-constexpr float kHomeButtonGap = 18.0f;
-constexpr float kHomeButtonRowY = 376.0f;
-constexpr float kHomeButtonIntroOffsetY = 24.0f;
+constexpr float kHomeButtonWidth = 348.0f;
+constexpr float kHomeButtonHeight = 117.0f;
+constexpr float kHomeButtonGap = 27.0f;
+constexpr float kHomeButtonRowY = 564.0f;
+constexpr float kHomeButtonIntroOffsetY = 36.0f;
+constexpr float kPlayTransitionOffsetY = 51.0f;
+constexpr float kButtonBorderWidth = 2.7f;
+constexpr float kTitlePaddingX = 21.0f;
+constexpr float kTitleOffsetY = 18.0f;
+constexpr float kTitleHeight = 36.0f;
+constexpr float kDetailPaddingX = 24.0f;
+constexpr float kDetailOffsetY = 63.0f;
+constexpr float kDetailHeight = 27.0f;
+constexpr float kStatusOffsetY = 33.0f;
+constexpr float kStatusHeight = 27.0f;
 
 constexpr std::array<title_home_view::entry, 4> kHomeEntries = {{
     {"PLAY", "Solo song select.", true, title_home_view::action::play},
@@ -65,7 +75,7 @@ void draw(float menu_anim_t, float play_anim_t, int selected_index, std::string_
     for (int index = 0; index < static_cast<int>(kHomeEntries.size()); ++index) {
         const entry& current = kHomeEntries[static_cast<std::size_t>(index)];
         const Rectangle raw_rect = button_rect(index, menu_anim_t);
-        const Rectangle rect = translate_rect(raw_rect, 0.0f, -34.0f * play_anim_t);
+        const Rectangle rect = translate_rect(raw_rect, 0.0f, -kPlayTransitionOffsetY * play_anim_t);
         const bool selected = index == selected_index;
         const float button_fade = (1.0f - play_anim_t) * menu_t;
         const Color button_base = t.row_soft;
@@ -85,22 +95,24 @@ void draw(float menu_anim_t, float play_anim_t, int selected_index, std::string_
         if (button_fade <= 0.01f) {
             continue;
         }
-        DrawRectangleRec(rect, bg);
-        DrawRectangleLinesEx(rect, 1.8f, border);
+        ui::draw_rect_f(rect, bg);
+        ui::draw_rect_lines(rect, kButtonBorderWidth, border);
         ui::draw_text_in_rect(current.label, 24,
-                              {rect.x + 14.0f, rect.y + 12.0f, rect.width - 28.0f, 24.0f},
+                              {rect.x + kTitlePaddingX, rect.y + kTitleOffsetY,
+                               rect.width - kTitlePaddingX * 2.0f, kTitleHeight},
                               with_alpha(current.enabled ? t.text : t.text_muted, static_cast<unsigned char>(255.0f * button_fade)),
                               ui::text_align::center);
         ui::draw_text_in_rect(current.detail, 13,
-                              {rect.x + 16.0f, rect.y + 42.0f, rect.width - 32.0f, 18.0f},
+                              {rect.x + kDetailPaddingX, rect.y + kDetailOffsetY,
+                               rect.width - kDetailPaddingX * 2.0f, kDetailHeight},
                               with_alpha(current.enabled ? t.text_muted : t.text_hint, static_cast<unsigned char>(220.0f * button_fade)),
                               ui::text_align::center);
     }
 
     if (!status_message.empty() && (1.0f - play_anim_t) > 0.01f) {
         ui::draw_text_in_rect(status_message.data(), 16,
-                              {0.0f, kHomeButtonRowY + kHomeButtonHeight + 22.0f,
-                               static_cast<float>(kScreenWidth), 18.0f},
+                              {0.0f, kHomeButtonRowY + kHomeButtonHeight + kStatusOffsetY,
+                               static_cast<float>(kScreenWidth), kStatusHeight},
                               with_alpha(t.text_muted, static_cast<unsigned char>(230.0f * menu_t * (1.0f - play_anim_t))),
                               ui::text_align::center);
     }

--- a/src/scenes/title/online_download_layout.cpp
+++ b/src/scenes/title/online_download_layout.cpp
@@ -5,22 +5,38 @@
 #include "scene_common.h"
 #include "title/title_layout.h"
 #include "tween.h"
+#include "ui_layout.h"
 
 namespace title_online_view {
 namespace {
 
-constexpr Rectangle kBackRect = {48.0f, 38.0f, 98.0f, 38.0f};
-constexpr Rectangle kOfficialTabRect = {186.0f, 40.0f, 128.0f, 38.0f};
-constexpr Rectangle kCommunityTabRect = {322.0f, 40.0f, 146.0f, 38.0f};
-constexpr Rectangle kOwnedTabRect = {476.0f, 40.0f, 108.0f, 38.0f};
-constexpr Rectangle kContentRect = {60.0f, 98.0f, 1160.0f, 568.0f};
-constexpr Rectangle kDetailLeftRect = {72.0f, 108.0f, 336.0f, 548.0f};
-constexpr Rectangle kDetailRightRect = {470.0f, 108.0f, 738.0f, 548.0f};
-constexpr Rectangle kHeroJacketRect = {92.0f, 174.0f, 270.0f, 270.0f};
-constexpr Rectangle kPreviewBarRect = {92.0f, 505.0f, 270.0f, 8.0f};
-constexpr Rectangle kPreviewPlayRect = {92.0f, 529.0f, 126.0f, 40.0f};
-constexpr Rectangle kPrimaryActionRect = {92.0f, 577.0f, 126.0f, 40.0f};
-constexpr Rectangle kChartListRect = {500.0f, 136.0f, 680.0f, 488.0f};
+constexpr Rectangle kBackRect = {72.0f, 57.0f, 147.0f, 57.0f};
+constexpr Rectangle kOfficialTabRect = {279.0f, 60.0f, 192.0f, 57.0f};
+constexpr Rectangle kCommunityTabRect = {483.0f, 60.0f, 219.0f, 57.0f};
+constexpr Rectangle kOwnedTabRect = {714.0f, 60.0f, 162.0f, 57.0f};
+constexpr Rectangle kContentRect = {90.0f, 147.0f, 1740.0f, 852.0f};
+constexpr Rectangle kDetailLeftRect = {108.0f, 162.0f, 504.0f, 822.0f};
+constexpr Rectangle kDetailRightRect = {705.0f, 162.0f, 1107.0f, 822.0f};
+constexpr Rectangle kHeroJacketRect = {138.0f, 261.0f, 405.0f, 405.0f};
+constexpr Rectangle kPreviewBarRect = {138.0f, 757.5f, 405.0f, 12.0f};
+constexpr Rectangle kPreviewPlayRect = {138.0f, 793.5f, 189.0f, 60.0f};
+constexpr Rectangle kPrimaryActionRect = {138.0f, 865.5f, 189.0f, 60.0f};
+constexpr Rectangle kChartListRect = {750.0f, 204.0f, 1020.0f, 732.0f};
+constexpr Rectangle kFallbackOriginRect = {1140.0f, 564.0f, 240.0f, 90.0f};
+constexpr float kSearchLeftGap = 36.0f;
+constexpr float kSearchRightGap = 27.0f;
+constexpr float kSearchY = 60.0f;
+constexpr float kSearchMinWidth = 330.0f;
+constexpr float kSearchHeight = 57.0f;
+constexpr Vector2 kSeedBackOffset = {-672.0f, -297.0f};
+constexpr Vector2 kSeedOfficialTabOffset = {-414.0f, -291.0f};
+constexpr Vector2 kSeedCommunityTabOffset = {-198.0f, -291.0f};
+constexpr Vector2 kSeedOwnedTabOffset = {18.0f, -291.0f};
+constexpr Vector2 kSeedSearchOffset = {477.0f, -288.0f};
+constexpr Vector2 kSeedContentOffset = {144.0f, 72.0f};
+constexpr Vector2 kSeedDetailLeftOffset = {-357.0f, 99.0f};
+constexpr Vector2 kSeedDetailRightOffset = {279.0f, 99.0f};
+constexpr Vector2 kSeedChartListOffset = {297.0f, 66.0f};
 
 constexpr float kPreviewBarBottomInset = (kContentRect.y + kContentRect.height) - kPreviewBarRect.y;
 constexpr float kPreviewButtonBottomInset = (kContentRect.y + kContentRect.height) - kPreviewPlayRect.y;
@@ -42,12 +58,7 @@ Rectangle centered_scaled_rect(Rectangle anchor, Rectangle target, float scale, 
 }
 
 Rectangle fallback_origin_rect() {
-    return {
-        static_cast<float>(kScreenWidth) * 0.5f + 120.0f,
-        376.0f,
-        160.0f,
-        60.0f,
-    };
+    return kFallbackOriginRect;
 }
 
 Rectangle resolve_origin_rect(Rectangle origin_rect) {
@@ -89,13 +100,13 @@ Rectangle left_pane_full_width_button_rect(Rectangle content_rect,
 
 Rectangle browse_search_rect() {
     const Rectangle account_rect = title_layout::account_chip_rect();
-    const float left = kOwnedTabRect.x + kOwnedTabRect.width + 24.0f;
-    const float right = account_rect.x - 18.0f;
+    const float left = kOwnedTabRect.x + kOwnedTabRect.width + kSearchLeftGap;
+    const float right = account_rect.x - kSearchRightGap;
     return {
         left,
-        40.0f,
-        std::max(220.0f, right - left),
-        38.0f,
+        kSearchY,
+        std::max(kSearchMinWidth, right - left),
+        kSearchHeight,
     };
 }
 
@@ -106,15 +117,15 @@ layout make_layout(float anim_t, Rectangle origin_rect) {
     const Rectangle origin = resolve_origin_rect(origin_rect);
     const Rectangle search_rect = browse_search_rect();
 
-    const Rectangle seed_back = centered_scaled_rect(origin, kBackRect, 0.9f, {-448.0f, -198.0f});
-    const Rectangle seed_official_tab = centered_scaled_rect(origin, kOfficialTabRect, 0.84f, {-276.0f, -194.0f});
-    const Rectangle seed_community_tab = centered_scaled_rect(origin, kCommunityTabRect, 0.84f, {-132.0f, -194.0f});
-    const Rectangle seed_owned_tab = centered_scaled_rect(origin, kOwnedTabRect, 0.84f, {12.0f, -194.0f});
-    const Rectangle seed_search = centered_scaled_rect(origin, search_rect, 0.86f, {318.0f, -192.0f});
-    const Rectangle seed_content = centered_scaled_rect(origin, kContentRect, 0.84f, {96.0f, 48.0f});
-    const Rectangle seed_detail_left = centered_scaled_rect(origin, kDetailLeftRect, 0.78f, {-238.0f, 66.0f});
-    const Rectangle seed_detail_right = centered_scaled_rect(origin, kDetailRightRect, 0.8f, {186.0f, 66.0f});
-    const Rectangle seed_chart_list = centered_scaled_rect(origin, kChartListRect, 0.84f, {198.0f, 44.0f});
+    const Rectangle seed_back = centered_scaled_rect(origin, kBackRect, 0.9f, kSeedBackOffset);
+    const Rectangle seed_official_tab = centered_scaled_rect(origin, kOfficialTabRect, 0.84f, kSeedOfficialTabOffset);
+    const Rectangle seed_community_tab = centered_scaled_rect(origin, kCommunityTabRect, 0.84f, kSeedCommunityTabOffset);
+    const Rectangle seed_owned_tab = centered_scaled_rect(origin, kOwnedTabRect, 0.84f, kSeedOwnedTabOffset);
+    const Rectangle seed_search = centered_scaled_rect(origin, search_rect, 0.86f, kSeedSearchOffset);
+    const Rectangle seed_content = centered_scaled_rect(origin, kContentRect, 0.84f, kSeedContentOffset);
+    const Rectangle seed_detail_left = centered_scaled_rect(origin, kDetailLeftRect, 0.78f, kSeedDetailLeftOffset);
+    const Rectangle seed_detail_right = centered_scaled_rect(origin, kDetailRightRect, 0.8f, kSeedDetailRightOffset);
+    const Rectangle seed_chart_list = centered_scaled_rect(origin, kChartListRect, 0.84f, kSeedChartListOffset);
     const Rectangle current_content = tween::lerp(seed_content, kContentRect, t);
     const Rectangle current_detail_left = tween::lerp(seed_detail_left, kDetailLeftRect, t);
     const Rectangle current_detail_right = tween::lerp(seed_detail_right, kDetailRightRect, t);

--- a/src/scenes/title/online_download_render.cpp
+++ b/src/scenes/title/online_download_render.cpp
@@ -15,10 +15,10 @@ namespace title_online_view {
 namespace {
 
 Rectangle song_card_jacket_rect(Rectangle card) {
-    const float jacket_size = std::min(card.width - 34.0f, 92.0f);
+    const float jacket_size = std::min(card.width - 34.0f, 120.0f);
     return {
         card.x + (card.width - jacket_size) * 0.5f,
-        card.y + 16.0f,
+        card.y + 18.0f,
         jacket_size,
         jacket_size,
     };
@@ -53,17 +53,18 @@ ui::text_input_result draw_song_search_input(Rectangle rect, ui::text_input_stat
     const unsigned char row_alpha = state.active ? selected_row_alpha
         : hovered ? hover_row_alpha
                   : normal_row_alpha;
-    DrawRectangleRec(visual, with_alpha(state.active ? button_selected : button_base, row_alpha));
-    DrawRectangleLinesEx(visual, 1.2f,
-                         with_alpha(state.active ? t.border_active : t.border_light, alpha));
+    ui::draw_rect_f(visual, with_alpha(state.active ? button_selected : button_base, row_alpha));
+    ui::draw_rect_lines(visual, 1.2f,
+                        with_alpha(state.active ? t.border_active : t.border_light, alpha));
 
     const Rectangle content_rect = ui::inset(visual, ui::edge_insets::symmetric(0.0f, 14.0f));
-    constexpr float kLabelWidth = 82.0f;
+    constexpr float kLabelWidth = 108.0f;
+    constexpr float kLabelGap = 14.0f;
     const Rectangle label_rect = {content_rect.x, content_rect.y, kLabelWidth, content_rect.height};
     const Rectangle text_rect = {
-        content_rect.x + kLabelWidth,
+        content_rect.x + kLabelWidth + kLabelGap,
         content_rect.y,
-        std::max(0.0f, content_rect.width - kLabelWidth),
+        std::max(0.0f, content_rect.width - kLabelWidth - kLabelGap),
         content_rect.height,
     };
 
@@ -210,19 +211,18 @@ ui::text_input_result draw_song_search_input(Rectangle rect, ui::text_input_stat
     }
 
     const Color text_color = with_alpha(state.value.empty() && !state.active ? t.text_hint : t.text, alpha);
-    const float text_y = text_rect.y + (text_rect.height - static_cast<float>(font_size)) * 0.5f + 1.5f;
-    const float selection_y = text_y - 1.0f;
-    const float selection_height = static_cast<float>(font_size) + 4.0f;
-    const float cursor_y = text_y + 1.0f;
-    const float cursor_height = std::max(12.0f, static_cast<float>(font_size) - 3.0f);
+    const float layout_font_size = ui::text_layout_font_size(static_cast<float>(font_size));
+    const float text_y = text_rect.y + (text_rect.height - layout_font_size) * 0.5f + 2.0f;
+    const float selection_y = text_rect.y + 7.0f;
+    const float selection_height = text_rect.height - 14.0f;
+    const float cursor_y = text_rect.y + 8.0f;
+    const float cursor_height = text_rect.height - 16.0f;
 
     if (!state.active && !state.value.empty()) {
         draw_marquee_text(display_value.c_str(), text_rect.x, text_y, font_size, text_color,
                           text_rect.width, GetTime());
     } else if (!state.active) {
-        ui::draw_text_in_rect(display_value.c_str(), font_size,
-                              {text_rect.x, text_rect.y + 1.5f, text_rect.width, text_rect.height},
-                              text_color, ui::text_align::left);
+        ui::draw_text_f(display_value.c_str(), text_rect.x, text_y, font_size, text_color);
     } else {
         ui::begin_scissor_rect(text_rect);
 
@@ -269,8 +269,8 @@ void draw_transport_toggle_button(Rectangle rect, bool playing, unsigned char al
         const float total_width = bar_width * 2.0f + gap;
         const float x = visual.x + (visual.width - total_width) * 0.5f;
         const float y = visual.y + (visual.height - bar_height) * 0.5f;
-        DrawRectangleRec({x, y, bar_width, bar_height}, icon);
-        DrawRectangleRec({x + bar_width + gap, y, bar_width, bar_height}, icon);
+        ui::draw_rect_f({x, y, bar_width, bar_height}, icon);
+        ui::draw_rect_f({x + bar_width + gap, y, bar_width, bar_height}, icon);
     } else {
         const float tri_width = 18.0f;
         const float tri_height = 20.0f;
@@ -353,8 +353,8 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
                            normal_row_alpha, hover_row_alpha, selected_row_alpha,
                            alpha);
 
-    DrawRectangleRec(current.content_rect, with_alpha(t.section, static_cast<unsigned char>(normal_row_alpha / 2)));
-    DrawRectangleLinesEx(current.content_rect, 1.2f, with_alpha(t.border_light, alpha));
+    ui::draw_rect_f(current.content_rect, with_alpha(t.section, static_cast<unsigned char>(normal_row_alpha / 2)));
+    ui::draw_rect_lines(current.content_rect, 1.2f, with_alpha(t.border_light, alpha));
     ui::draw_text_in_rect(caption, 17,
                           {current.content_rect.x + 12.0f, current.content_rect.y + 6.0f,
                            current.content_rect.width * 0.52f, 20.0f},
@@ -380,8 +380,8 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
             current.song_grid_rect.width - 192.0f,
             84.0f,
         };
-        DrawRectangleRec(placeholder, with_alpha(button_base, static_cast<unsigned char>(selected_row_alpha * grid_fade_t)));
-        DrawRectangleLinesEx(placeholder, 1.5f, with_alpha(t.border_light, grid_alpha));
+        ui::draw_rect_f(placeholder, with_alpha(button_base, static_cast<unsigned char>(selected_row_alpha * grid_fade_t)));
+        ui::draw_rect_lines(placeholder, 1.5f, with_alpha(t.border_light, grid_alpha));
         const char* empty_title = loading
             ? "Loading..."
             : (state.mode == catalog_mode::owned && state.owned_loading)
@@ -420,9 +420,9 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
         const unsigned char row_alpha = static_cast<unsigned char>((selected ? selected_row_alpha
             : hovered ? hover_row_alpha
                       : normal_row_alpha) * grid_fade_t);
-        DrawRectangleRec(card, with_alpha(selected ? button_selected : button_base, row_alpha));
-        DrawRectangleLinesEx(card, 1.15f,
-                             with_alpha(selected ? t.border_active : t.border_light, grid_alpha));
+        ui::draw_rect_f(card, with_alpha(selected ? button_selected : button_base, row_alpha));
+        ui::draw_rect_lines(card, 1.15f,
+                            with_alpha(selected ? t.border_active : t.border_light, grid_alpha));
 
         const Rectangle jacket_rect = song_card_jacket_rect(card);
         if (selected) {
@@ -441,11 +441,11 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
                     : 1.0f;
                 const unsigned char placeholder_alpha =
                     static_cast<unsigned char>(static_cast<float>(grid_alpha) * selected_placeholder_t);
-                DrawRectangleRec(jacket_rect, with_alpha(t.bg_alt, row_alpha));
+                ui::draw_rect_f(jacket_rect, with_alpha(t.bg_alt, row_alpha));
                 ui::draw_text_in_rect("JACKET", 18, jacket_rect, with_alpha(t.text_muted, placeholder_alpha),
                                       ui::text_align::center);
             }
-            DrawRectangleLinesEx(jacket_rect, 1.0f, with_alpha(t.border_image, grid_alpha));
+            ui::draw_rect_lines(jacket_rect, 1.0f, with_alpha(t.border_image, grid_alpha));
         }
 
         const std::string badge_label = detail::song_status_label(song);
@@ -456,10 +456,10 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
         }
 
         draw_marquee_text(song.song.song.meta.title.c_str(),
-                          {card.x + 14.0f, card.y + 118.0f, card.width - 28.0f, 18.0f},
+                          {card.x + 14.0f, card.y + 154.0f, card.width - 28.0f, 30.0f},
                           18, with_alpha(t.text, grid_alpha), now);
         draw_marquee_text(song.song.song.meta.artist.c_str(),
-                          {card.x + 14.0f, card.y + 138.0f, card.width - 28.0f, 16.0f},
+                          {card.x + 14.0f, card.y + 184.0f, card.width - 28.0f, 22.0f},
                           13, with_alpha(t.text_muted, grid_alpha), now);
     }
 
@@ -483,9 +483,9 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
 
     const float detail_left_right = current.detail_left_rect.x + current.detail_left_rect.width;
     const float separator_x = detail_left_right + (current.detail_right_rect.x - detail_left_right) * 0.5f;
-    DrawLineEx({separator_x, current.detail_left_rect.y + 8.0f},
-               {separator_x, current.detail_left_rect.y + current.detail_left_rect.height - 8.0f},
-               1.4f, with_alpha(t.border_light, static_cast<unsigned char>(170.0f * detail_content_t)));
+    ui::draw_line_ex({separator_x, current.detail_left_rect.y + 8.0f},
+                     {separator_x, current.detail_left_rect.y + current.detail_left_rect.height - 8.0f},
+                     1.4f, with_alpha(t.border_light, static_cast<unsigned char>(170.0f * detail_content_t)));
 
     if (detail_t > 0.001f) {
         if (const Texture2D* hero_jacket = state.jackets.get(song->song.song)) {
@@ -498,13 +498,13 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
                 : tween::smoothstep(tween::remap_clamped(detail_t, 0.90f, 1.0f));
             const unsigned char placeholder_alpha =
                 static_cast<unsigned char>(static_cast<float>(alpha) * hero_placeholder_t);
-            DrawRectangleRec(animated_jacket_rect, with_alpha(t.bg_alt, selected_row_alpha));
+            ui::draw_rect_f(animated_jacket_rect, with_alpha(t.bg_alt, selected_row_alpha));
             if (placeholder_alpha > 0) {
                 ui::draw_text_in_rect("JACKET", 26, animated_jacket_rect,
                                       with_alpha(t.text_muted, placeholder_alpha), ui::text_align::center);
             }
         }
-        DrawRectangleLinesEx(animated_jacket_rect, 1.5f, with_alpha(t.border_image, alpha));
+        ui::draw_rect_lines(animated_jacket_rect, 1.5f, with_alpha(t.border_image, alpha));
     }
 
     if (detail_alpha == 0) {
@@ -517,13 +517,13 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
         current.detail_left_rect.x + 12.0f,
         current.hero_jacket_rect.y + current.hero_jacket_rect.height + 12.0f,
         current.detail_left_rect.width - 24.0f,
-        28.0f
+        42.0f
     };
     const Rectangle artist_rect = {
         title_rect.x,
-        title_rect.y + 32.0f,
+        title_rect.y + 40.0f,
         title_rect.width,
-        18.0f
+        27.0f
     };
     draw_marquee_text(song->song.song.meta.title.c_str(), title_rect, 28, with_alpha(t.text, detail_alpha), now);
     draw_marquee_text(song->song.song.meta.artist.c_str(), artist_rect, 17,
@@ -534,11 +534,11 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
     const double preview_position = audio.get_preview_position_seconds();
     const float preview_ratio =
         preview_length > 0.0 ? std::clamp(static_cast<float>(preview_position / preview_length), 0.0f, 1.0f) : 0.0f;
-    DrawRectangleRec(current.preview_bar_rect, with_alpha(t.bg_alt, static_cast<unsigned char>(normal_row_alpha * detail_content_t)));
-    DrawRectangleRec({current.preview_bar_rect.x, current.preview_bar_rect.y,
-                      current.preview_bar_rect.width * preview_ratio, current.preview_bar_rect.height},
-                     with_alpha(t.accent, detail_alpha));
-    DrawRectangleLinesEx(current.preview_bar_rect, 1.0f, with_alpha(t.border_light, detail_alpha));
+    ui::draw_rect_f(current.preview_bar_rect, with_alpha(t.bg_alt, static_cast<unsigned char>(normal_row_alpha * detail_content_t)));
+    ui::draw_rect_f({current.preview_bar_rect.x, current.preview_bar_rect.y,
+                     current.preview_bar_rect.width * preview_ratio, current.preview_bar_rect.height},
+                    with_alpha(t.accent, detail_alpha));
+    ui::draw_rect_lines(current.preview_bar_rect, 1.0f, with_alpha(t.border_light, detail_alpha));
     ui::draw_text_in_rect(
         TextFormat("%s / %s",
                    detail::format_time_label(preview_position).c_str(),
@@ -572,11 +572,11 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
             current.primary_action_rect.width,
             8.0f,
         };
-        DrawRectangleRec(progress_rect,
-                         with_alpha(t.bg_alt, static_cast<unsigned char>(normal_row_alpha * detail_content_t)));
-        DrawRectangleRec({progress_rect.x, progress_rect.y, progress_rect.width * progress_ratio, progress_rect.height},
-                         with_alpha(t.accent, detail_alpha));
-        DrawRectangleLinesEx(progress_rect, 1.0f, with_alpha(t.border_light, detail_alpha));
+        ui::draw_rect_f(progress_rect,
+                        with_alpha(t.bg_alt, static_cast<unsigned char>(normal_row_alpha * detail_content_t)));
+        ui::draw_rect_f({progress_rect.x, progress_rect.y, progress_rect.width * progress_ratio, progress_rect.height},
+                        with_alpha(t.accent, detail_alpha));
+        ui::draw_rect_lines(progress_rect, 1.0f, with_alpha(t.border_light, detail_alpha));
         ui::draw_text_in_rect(TextFormat("%d%%", static_cast<int>(std::round(progress_ratio * 100.0f))),
                               12,
                               {progress_rect.x, progress_rect.y - 16.0f, progress_rect.width, 14.0f},
@@ -589,10 +589,6 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
                                        download_ready ? hover_row_alpha : hover_row_alpha),
                             with_alpha(download_ready ? t.text : t.text_secondary, detail_alpha), 1.5f);
 
-    ui::draw_text_in_rect("CHARTS", 19,
-                          {current.chart_list_rect.x, current.chart_list_rect.y - 28.0f,
-                           current.chart_list_rect.width * 0.45f, 18.0f},
-                          with_alpha(t.text, detail_alpha), ui::text_align::left);
     ui::draw_text_in_rect(TextFormat("%d items", static_cast<int>(song->charts.size())), 14,
                           {current.chart_list_rect.x + current.chart_list_rect.width * 0.46f, current.chart_list_rect.y - 26.0f,
                            current.chart_list_rect.width * 0.54f, 16.0f},
@@ -606,8 +602,8 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
             current.chart_list_rect.width - 128.0f,
             72.0f,
         };
-        DrawRectangleRec(placeholder, with_alpha(button_base, static_cast<unsigned char>(selected_row_alpha * detail_content_t)));
-        DrawRectangleLinesEx(placeholder, 1.5f, with_alpha(t.border_light, detail_alpha));
+        ui::draw_rect_f(placeholder, with_alpha(button_base, static_cast<unsigned char>(selected_row_alpha * detail_content_t)));
+        ui::draw_rect_lines(placeholder, 1.5f, with_alpha(t.border_light, detail_alpha));
         const char* chart_empty = song->charts_loading ? "Loading charts..."
             : (song->charts_failed ? "Could not load charts."
                                    : "No charts found.");
@@ -627,9 +623,9 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
         const unsigned char row_alpha = static_cast<unsigned char>((selected ? selected_row_alpha
             : hovered ? hover_row_alpha
                       : normal_row_alpha) * detail_content_t);
-        DrawRectangleRec(card, with_alpha(selected ? button_selected : button_base, row_alpha));
-        DrawRectangleLinesEx(card, 1.0f,
-                             with_alpha(selected ? t.border_active : t.border_light, detail_alpha));
+        ui::draw_rect_f(card, with_alpha(selected ? button_selected : button_base, row_alpha));
+        ui::draw_rect_lines(card, 1.0f,
+                            with_alpha(selected ? t.border_active : t.border_light, detail_alpha));
 
         ui::draw_text_in_rect(
             TextFormat("%s  %s", detail::key_mode_label(item.chart.meta.key_count).c_str(),

--- a/src/scenes/title/online_download_state.cpp
+++ b/src/scenes/title/online_download_state.cpp
@@ -12,9 +12,9 @@
 namespace title_online_view {
 namespace {
 
-constexpr float kSongCardHeight = 164.0f;
+constexpr float kSongCardHeight = 256.0f;
 constexpr float kSongGridGapX = 18.0f;
-constexpr float kSongGridGapY = 18.0f;
+constexpr float kSongGridGapY = 19.0f;
 constexpr float kChartCardHeight = 92.0f;
 constexpr float kChartGridGapX = 22.0f;
 constexpr float kChartGridGapY = 18.0f;

--- a/src/scenes/title/ranking_panel_view.cpp
+++ b/src/scenes/title/ranking_panel_view.cpp
@@ -15,7 +15,35 @@
 
 namespace {
 
-constexpr float kRankingRowHeight = 58.0f;
+constexpr float kRankingRowHeight = 90.0f;
+constexpr float kScrollPadding = 12.0f;
+constexpr float kEmptyMessageOffsetY = 60.0f;
+constexpr float kEmptyMessageHeight = 42.0f;
+constexpr float kRowGap = 6.0f;
+constexpr float kRevealOffsetX = 66.0f;
+constexpr float kClipSlack = 6.0f;
+constexpr float kRowBorderWidth = 1.5f;
+constexpr float kTopLineOffsetY = 12.0f;
+constexpr float kStatLabelOffsetY = 40.5f;
+constexpr float kStatValueOffsetY = 54.0f;
+constexpr float kPlacementOffsetX = 12.0f;
+constexpr float kPlacementOffsetY = 9.0f;
+constexpr float kPlacementWidth = 66.0f;
+constexpr float kPlacementVerticalInset = 18.0f;
+constexpr float kRankRightInset = 72.0f;
+constexpr float kRankOffsetY = 13.5f;
+constexpr float kRankWidth = 60.0f;
+constexpr float kRankVerticalInset = 27.0f;
+constexpr float kScoreOffsetFromRank = 144.0f;
+constexpr float kScoreOffsetY = 19.5f;
+constexpr float kScoreWidth = 126.0f;
+constexpr float kScoreHeight = 39.0f;
+constexpr float kDetailsOffsetX = 96.0f;
+constexpr float kDetailsScoreGap = 4.5f;
+constexpr float kTimeWidth = 33.0f;
+constexpr float kNameTimeGap = 1.5f;
+constexpr float kStatColumnGap = 27.0f;
+constexpr float kComboMaxWidth = 114.0f;
 
 const char* rank_label(rank value) {
     switch (value) {
@@ -121,7 +149,7 @@ float content_height(const ranking_service::listing& listing) {
 }
 
 float max_scroll(Rectangle list_rect, const ranking_service::listing& listing) {
-    return std::max(0.0f, content_height(listing) - list_rect.height + 8.0f);
+    return std::max(0.0f, content_height(listing) - list_rect.height + kScrollPadding);
 }
 
 std::optional<ranking_service::source> hit_test_source(const draw_config& config, Vector2 point) {
@@ -159,7 +187,8 @@ void draw(const song_select::ranking_panel_state& panel, const draw_config& conf
             ? std::string("No ") + (panel.selected_source == ranking_service::source::local ? "local" : "online") + " entries yet."
             : panel.listing.message;
         ui::draw_text_in_rect(message.c_str(), 20,
-                              {config.list_rect.x, config.list_rect.y + 40.0f, config.list_rect.width, 28.0f},
+                              {config.list_rect.x, config.list_rect.y + kEmptyMessageOffsetY,
+                               config.list_rect.width, kEmptyMessageHeight},
                               with_alpha(t.text_muted, config.alpha), ui::text_align::left);
         return;
     }
@@ -176,53 +205,113 @@ void draw(const song_select::ranking_panel_state& panel, const draw_config& conf
             config.list_rect.x,
             base_y + static_cast<float>(i) * kRankingRowHeight,
             config.list_rect.width,
-            kRankingRowHeight - 4.0f
+            kRankingRowHeight - kRowGap
         };
         const Rectangle row = {
-            base_row.x + (1.0f - row_reveal_t) * 44.0f,
+            base_row.x + (1.0f - row_reveal_t) * kRevealOffsetX,
             base_row.y,
             base_row.width,
             base_row.height
         };
-        if (row.y + row.height < config.list_rect.y - 4.0f || row.y > config.list_rect.y + config.list_rect.height + 4.0f) {
+        if (row.y + row.height < config.list_rect.y - kClipSlack ||
+            row.y > config.list_rect.y + config.list_rect.height + kClipSlack) {
             continue;
         }
 
         const unsigned char row_alpha = static_cast<unsigned char>(config.normal_row_alpha * row_reveal_t);
         const unsigned char content_alpha = static_cast<unsigned char>(config.alpha * row_reveal_t);
-        DrawRectangleRec(row, with_alpha(config.button_base, row_alpha));
-        DrawRectangleLinesEx(row, 1.0f, with_alpha(t.border_light, static_cast<unsigned char>(130.0f * config.play_t * row_reveal_t)));
+        ui::draw_rect_f(row, with_alpha(config.button_base, row_alpha));
+        ui::draw_rect_lines(row, kRowBorderWidth,
+                            with_alpha(t.border_light,
+                                       static_cast<unsigned char>(130.0f * config.play_t * row_reveal_t)));
 
-        const Rectangle placement_rect = {row.x + 4.0f, row.y + 7.0f, 46.0f, row.height - 14.0f};
-        const Rectangle rank_rect = {row.x + row.width - 34.0f, row.y + 7.0f, 24.0f, row.height - 14.0f};
-        const Rectangle score_rect = {row.x + row.width - 148.0f, row.y + 17.0f, 104.0f, 24.0f};
-        const Rectangle middle_rect = {
-            row.x + 56.0f,
-            row.y + 6.0f,
-            score_rect.x - (row.x + 56.0f) - 8.0f,
-            row.height - 12.0f
+        constexpr int kNameFontSize = 13;
+        constexpr int kTimeFontSize = 12;
+        constexpr int kStatLabelFontSize = 10;
+        constexpr int kStatValueFontSize = 12;
+        const float top_line_y = row.y + kTopLineOffsetY;
+        const float stat_label_y = row.y + kStatLabelOffsetY;
+        const float stat_value_y = row.y + kStatValueOffsetY;
+        const Rectangle placement_rect = {
+            row.x + kPlacementOffsetX,
+            row.y + kPlacementOffsetY,
+            kPlacementWidth,
+            row.height - kPlacementVerticalInset
         };
-        const Rectangle time_rect = {score_rect.x - 22.0f, middle_rect.y + 1.0f, 16.0f, 14.0f};
-        const Rectangle name_rect = {middle_rect.x, middle_rect.y, time_rect.x - middle_rect.x - 6.0f, 18.0f};
+        const Rectangle rank_rect = {
+            row.x + row.width - kRankRightInset,
+            row.y + kRankOffsetY,
+            kRankWidth,
+            row.height - kRankVerticalInset
+        };
+        const Rectangle score_rect = {
+            rank_rect.x - kScoreOffsetFromRank,
+            row.y + kScoreOffsetY,
+            kScoreWidth,
+            kScoreHeight
+        };
+        const float details_x = row.x + kDetailsOffsetX;
+        const float details_right = std::max(details_x, score_rect.x - kDetailsScoreGap);
+        const Rectangle time_rect = {
+            details_right - kTimeWidth,
+            top_line_y,
+            kTimeWidth,
+            ui::text_layout_font_size(static_cast<float>(kTimeFontSize))
+        };
+        const Rectangle name_rect = {
+            details_x,
+            top_line_y,
+            std::max(0.0f, time_rect.x - details_x - kNameTimeGap),
+            ui::text_layout_font_size(static_cast<float>(kNameFontSize))
+        };
+        const float combo_width = std::min(kComboMaxWidth,
+                                           std::max(0.0f, (details_right - details_x - kStatColumnGap) * 0.5f));
+        const float accuracy_x = details_x + combo_width + kStatColumnGap;
+        const float accuracy_width = std::max(0.0f, details_right - accuracy_x);
+        const Rectangle combo_label_rect = {
+            details_x,
+            stat_label_y,
+            combo_width,
+            ui::text_layout_font_size(static_cast<float>(kStatLabelFontSize))
+        };
+        const Rectangle combo_value_rect = {
+            details_x,
+            stat_value_y,
+            combo_width,
+            ui::text_layout_font_size(static_cast<float>(kStatValueFontSize))
+        };
+        const Rectangle accuracy_label_rect = {
+            accuracy_x,
+            stat_label_y,
+            accuracy_width,
+            ui::text_layout_font_size(static_cast<float>(kStatLabelFontSize))
+        };
+        const Rectangle accuracy_value_rect = {
+            accuracy_x,
+            stat_value_y,
+            accuracy_width,
+            ui::text_layout_font_size(static_cast<float>(kStatValueFontSize))
+        };
 
         ui::draw_text_in_rect(TextFormat("#%d", i + 1), 18, placement_rect,
                               with_alpha(t.text_secondary, content_alpha), ui::text_align::center);
         draw_marquee_text(entry.player_display_name.empty() ? "Unknown Player" : entry.player_display_name.c_str(),
-                          name_rect, 15, with_alpha(t.text, content_alpha), GetTime());
-        ui::draw_text_in_rect(format_relative_recorded_at(entry.recorded_at).c_str(), 12,
+                          name_rect, kNameFontSize, with_alpha(t.text, content_alpha), GetTime());
+        ui::draw_text_in_rect(format_relative_recorded_at(entry.recorded_at).c_str(), kTimeFontSize,
                               time_rect,
                               with_alpha(t.text_muted, content_alpha), ui::text_align::right);
-        ui::draw_text_in_rect("Max Combo", 11,
-                              {middle_rect.x, middle_rect.y + 20.0f, 78.0f, 12.0f},
+        ui::draw_text_in_rect("Max Combo", kStatLabelFontSize,
+                              combo_label_rect,
                               with_alpha(t.text_muted, content_alpha), ui::text_align::left);
-        ui::draw_text_in_rect(TextFormat("%dx", entry.max_combo), 13,
-                              {middle_rect.x, middle_rect.y + 31.0f, 78.0f, 14.0f},
-                              with_alpha(entry.is_full_combo ? t.success : t.text, content_alpha), ui::text_align::left);
-        ui::draw_text_in_rect("Accuracy", 11,
-                              {middle_rect.x + 94.0f, middle_rect.y + 20.0f, middle_rect.width - 94.0f, 12.0f},
+        ui::draw_text_in_rect(TextFormat("%dx", entry.max_combo), kStatValueFontSize,
+                              combo_value_rect,
+                              with_alpha(entry.is_full_combo ? t.success : t.text, content_alpha),
+                              ui::text_align::left);
+        ui::draw_text_in_rect("Accuracy", kStatLabelFontSize,
+                              accuracy_label_rect,
                               with_alpha(t.text_muted, content_alpha), ui::text_align::left);
-        ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), 13,
-                              {middle_rect.x + 94.0f, middle_rect.y + 31.0f, middle_rect.width - 94.0f, 14.0f},
+        ui::draw_text_in_rect(TextFormat("%.2f%%", entry.accuracy), kStatValueFontSize,
+                              accuracy_value_rect,
                               with_alpha(t.text, content_alpha), ui::text_align::left);
         ui::draw_text_in_rect(format_score(entry.score).c_str(), 18,
                               score_rect,

--- a/src/scenes/title/seamless_song_select_view.cpp
+++ b/src/scenes/title/seamless_song_select_view.cpp
@@ -19,21 +19,36 @@
 namespace title_play_view {
 namespace {
 
-constexpr Rectangle kPlayBackButtonRect = {48.0f, 38.0f, 98.0f, 38.0f};
-constexpr Rectangle kPlaySongColumnRect = {66.0f, 108.0f, 338.0f, 504.0f};
-constexpr Rectangle kPlayMainColumnRect = {438.0f, 100.0f, 402.0f, 520.0f};
-constexpr Rectangle kPlayRankingColumnRect = {878.0f, 102.0f, 338.0f, 516.0f};
-constexpr Rectangle kPlayJacketRect = {456.0f, 182.0f, 188.0f, 188.0f};
-constexpr Rectangle kPlayChartDetailRect = {668.0f, 182.0f, 172.0f, 90.0f};
-constexpr Rectangle kPlayMetaRect = {456.0f, 388.0f, 384.0f, 60.0f};
-constexpr Rectangle kPlayChartButtonsRect = {456.0f, 400.0f, 384.0f, 218.0f};
-constexpr Rectangle kPlayRankingHeaderRect = {878.0f, 102.0f, 338.0f, 36.0f};
-constexpr Rectangle kPlayRankingSourceLocalRect = {1034.0f, 98.0f, 86.0f, 34.0f};
-constexpr Rectangle kPlayRankingSourceOnlineRect = {1126.0f, 98.0f, 90.0f, 34.0f};
-constexpr Rectangle kPlayRankingListRect = {878.0f, 150.0f, 338.0f, 468.0f};
-constexpr float kCreateToolButtonHeight = 48.0f;
-constexpr float kCreateToolButtonGap = 8.0f;
-constexpr float kCreateToolColumnGap = 8.0f;
+constexpr Rectangle kPlayBackButtonRect = {72.0f, 57.0f, 147.0f, 57.0f};
+constexpr Rectangle kPlaySongColumnRect = {99.0f, 162.0f, 507.0f, 756.0f};
+constexpr Rectangle kPlayMainColumnRect = {657.0f, 150.0f, 603.0f, 780.0f};
+constexpr Rectangle kPlayRankingColumnRect = {1317.0f, 153.0f, 507.0f, 774.0f};
+constexpr Rectangle kPlayJacketRect = {684.0f, 273.0f, 282.0f, 282.0f};
+constexpr Rectangle kPlayChartDetailRect = {1002.0f, 273.0f, 258.0f, 135.0f};
+constexpr Rectangle kPlayMetaRect = {684.0f, 582.0f, 576.0f, 90.0f};
+constexpr Rectangle kPlayChartButtonsRect = {684.0f, 600.0f, 576.0f, 327.0f};
+constexpr Rectangle kPlayRankingHeaderRect = {1317.0f, 153.0f, 507.0f, 54.0f};
+constexpr Rectangle kPlayRankingSourceLocalRect = {1551.0f, 147.0f, 129.0f, 51.0f};
+constexpr Rectangle kPlayRankingSourceOnlineRect = {1689.0f, 147.0f, 135.0f, 51.0f};
+constexpr Rectangle kPlayRankingListRect = {1317.0f, 225.0f, 507.0f, 702.0f};
+constexpr float kCreateToolButtonHeight = 72.0f;
+constexpr float kCreateToolButtonGap = 12.0f;
+constexpr float kCreateToolColumnGap = 12.0f;
+constexpr float kDeleteMenuInset = 9.0f;
+constexpr Rectangle kFallbackOriginRect = {840.0f, 564.0f, 240.0f, 90.0f};
+constexpr Vector2 kSeedSongOffset = {-495.0f, 33.0f};
+constexpr Vector2 kSeedMainOffset = {0.0f, 9.0f};
+constexpr Vector2 kSeedRankingOffset = {495.0f, 39.0f};
+constexpr Vector2 kSeedBackOffset = {-642.0f, -291.0f};
+constexpr Vector2 kSeedJacketOffset = {-102.0f, -39.0f};
+constexpr Vector2 kSeedMetaOffset = {15.0f, 138.0f};
+constexpr Vector2 kSeedChartDetailOffset = {228.0f, -15.0f};
+constexpr Vector2 kSeedChartButtonsOffset = {81.0f, 240.0f};
+constexpr Vector2 kSeedRankingHeaderOffset = {522.0f, -276.0f};
+constexpr Vector2 kSeedRankingSourceLocalOffset = {627.0f, -285.0f};
+constexpr Vector2 kSeedRankingSourceOnlineOffset = {768.0f, -285.0f};
+constexpr Vector2 kSeedRankingListOffset = {522.0f, 30.0f};
+constexpr float kWheelScrollStep = 63.0f;
 constexpr int kPlaySongContextMenuItemCount = 1;
 
 enum class create_tool_action {
@@ -92,9 +107,9 @@ Rectangle create_tool_rect(Rectangle list_rect, int index) {
 
 Rectangle delete_song_menu_item_rect(Rectangle menu_rect) {
     return {
-        menu_rect.x + 6.0f,
-        menu_rect.y + 6.0f,
-        menu_rect.width - 12.0f,
+        menu_rect.x + kDeleteMenuInset,
+        menu_rect.y + kDeleteMenuInset,
+        menu_rect.width - kDeleteMenuInset * 2.0f,
         song_select::layout::kContextMenuItemHeight
     };
 }
@@ -115,12 +130,7 @@ Rectangle centered_scaled_rect(Rectangle anchor, Rectangle target, float scale, 
 }
 
 Rectangle fallback_origin_rect() {
-    return {
-        static_cast<float>(kScreenWidth) * 0.5f - 80.0f,
-        376.0f,
-        160.0f,
-        60.0f,
-    };
+    return kFallbackOriginRect;
 }
 
 Rectangle resolve_origin_rect(Rectangle origin_rect) {
@@ -132,18 +142,18 @@ layout make_layout(float anim_t, Rectangle origin_rect) {
     const float t = tween::ease_out_cubic(anim_t);
     const Rectangle origin = resolve_origin_rect(origin_rect);
 
-    const Rectangle seed_song = centered_scaled_rect(origin, kPlaySongColumnRect, 0.68f, {-330.0f, 22.0f});
-    const Rectangle seed_main = centered_scaled_rect(origin, kPlayMainColumnRect, 0.74f, {0.0f, 6.0f});
-    const Rectangle seed_ranking = centered_scaled_rect(origin, kPlayRankingColumnRect, 0.68f, {330.0f, 26.0f});
-    const Rectangle seed_back = centered_scaled_rect(origin, kPlayBackButtonRect, 0.9f, {-428.0f, -194.0f});
-    const Rectangle seed_jacket = centered_scaled_rect(origin, kPlayJacketRect, 0.82f, {-68.0f, -26.0f});
-    const Rectangle seed_meta = centered_scaled_rect(origin, kPlayMetaRect, 0.8f, {10.0f, 92.0f});
-    const Rectangle seed_chart_detail = centered_scaled_rect(origin, kPlayChartDetailRect, 0.76f, {152.0f, -10.0f});
-    const Rectangle seed_chart_buttons = centered_scaled_rect(origin, kPlayChartButtonsRect, 0.88f, {54.0f, 160.0f});
-    const Rectangle seed_ranking_header = centered_scaled_rect(origin, kPlayRankingHeaderRect, 0.7f, {348.0f, -184.0f});
-    const Rectangle seed_ranking_source_local = centered_scaled_rect(origin, kPlayRankingSourceLocalRect, 0.8f, {418.0f, -190.0f});
-    const Rectangle seed_ranking_source_online = centered_scaled_rect(origin, kPlayRankingSourceOnlineRect, 0.8f, {512.0f, -190.0f});
-    const Rectangle seed_ranking_list = centered_scaled_rect(origin, kPlayRankingListRect, 0.7f, {348.0f, 20.0f});
+    const Rectangle seed_song = centered_scaled_rect(origin, kPlaySongColumnRect, 0.68f, kSeedSongOffset);
+    const Rectangle seed_main = centered_scaled_rect(origin, kPlayMainColumnRect, 0.74f, kSeedMainOffset);
+    const Rectangle seed_ranking = centered_scaled_rect(origin, kPlayRankingColumnRect, 0.68f, kSeedRankingOffset);
+    const Rectangle seed_back = centered_scaled_rect(origin, kPlayBackButtonRect, 0.9f, kSeedBackOffset);
+    const Rectangle seed_jacket = centered_scaled_rect(origin, kPlayJacketRect, 0.82f, kSeedJacketOffset);
+    const Rectangle seed_meta = centered_scaled_rect(origin, kPlayMetaRect, 0.8f, kSeedMetaOffset);
+    const Rectangle seed_chart_detail = centered_scaled_rect(origin, kPlayChartDetailRect, 0.76f, kSeedChartDetailOffset);
+    const Rectangle seed_chart_buttons = centered_scaled_rect(origin, kPlayChartButtonsRect, 0.88f, kSeedChartButtonsOffset);
+    const Rectangle seed_ranking_header = centered_scaled_rect(origin, kPlayRankingHeaderRect, 0.7f, kSeedRankingHeaderOffset);
+    const Rectangle seed_ranking_source_local = centered_scaled_rect(origin, kPlayRankingSourceLocalRect, 0.8f, kSeedRankingSourceLocalOffset);
+    const Rectangle seed_ranking_source_online = centered_scaled_rect(origin, kPlayRankingSourceOnlineRect, 0.8f, kSeedRankingSourceOnlineOffset);
+    const Rectangle seed_ranking_list = centered_scaled_rect(origin, kPlayRankingListRect, 0.7f, kSeedRankingListOffset);
 
     return {
         tween::lerp(seed_back, kPlayBackButtonRect, t),
@@ -328,11 +338,11 @@ update_result update(song_select::state& state, mode view_mode, float anim_t, Re
     }
 
     if (CheckCollisionPointRec(mouse, current.song_column) && wheel != 0.0f) {
-        state.scroll_y_target -= wheel * 42.0f;
+        state.scroll_y_target -= wheel * kWheelScrollStep;
     } else if (CheckCollisionPointRec(mouse, current.chart_buttons_rect) && wheel != 0.0f) {
-        state.chart_scroll_y_target -= wheel * 42.0f;
+        state.chart_scroll_y_target -= wheel * kWheelScrollStep;
     } else if (view_mode == mode::play && CheckCollisionPointRec(mouse, current.ranking_list_rect) && wheel != 0.0f) {
-        state.ranking_panel.scroll_y_target -= wheel * 42.0f;
+        state.ranking_panel.scroll_y_target -= wheel * kWheelScrollStep;
     }
 
     state.scroll_y_target = std::clamp(
@@ -388,12 +398,12 @@ void draw(const song_select::state& state,
     ui::draw_button_colored(current.back_rect, "HOME", 16,
                             with_alpha(button_base, normal_row_alpha), with_alpha(button_hover, hover_row_alpha), with_alpha(t.text, alpha), 1.5f);
 
-    DrawLineEx({current.song_column.x + current.song_column.width + 22.0f, current.song_column.y + 18.0f},
-               {current.song_column.x + current.song_column.width + 22.0f, current.song_column.y + current.song_column.height - 18.0f},
-               1.2f, with_alpha(t.border_light, static_cast<unsigned char>(170.0f * play_t)));
-    DrawLineEx({current.ranking_column.x - 24.0f, current.ranking_column.y + 24.0f},
-               {current.ranking_column.x - 24.0f, current.ranking_column.y + current.ranking_column.height - 20.0f},
-               1.2f, with_alpha(t.border_light, static_cast<unsigned char>(170.0f * play_t)));
+    ui::draw_line_ex({current.song_column.x + current.song_column.width + 22.0f, current.song_column.y + 18.0f},
+                     {current.song_column.x + current.song_column.width + 22.0f, current.song_column.y + current.song_column.height - 18.0f},
+                     1.2f, with_alpha(t.border_light, static_cast<unsigned char>(170.0f * play_t)));
+    ui::draw_line_ex({current.ranking_column.x - 24.0f, current.ranking_column.y + 24.0f},
+                     {current.ranking_column.x - 24.0f, current.ranking_column.y + current.ranking_column.height - 20.0f},
+                     1.2f, with_alpha(t.border_light, static_cast<unsigned char>(170.0f * play_t)));
 
     if (!hide_unloaded_content) {
         title_song_list_view::draw(state, {
@@ -456,8 +466,8 @@ void draw(const song_select::state& state,
             const Rectangle rect = create_tool_rect(current.ranking_list_rect, i);
             const bool hovered = CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), rect);
             const unsigned char row_alpha = hovered ? hover_row_alpha : normal_row_alpha;
-            DrawRectangleRec(rect, with_alpha(button_base, row_alpha));
-            DrawRectangleLinesEx(rect, 1.2f, with_alpha(t.border, row_alpha));
+            ui::draw_rect_f(rect, with_alpha(button_base, row_alpha));
+            ui::draw_rect_lines(rect, 1.2f, with_alpha(t.border, row_alpha));
             ui::draw_text_in_rect(kCreateToolEntries[i].title, 14,
                                   {rect.x + 10.0f, rect.y + 6.0f, rect.width - 20.0f, 18.0f},
                                   with_alpha(t.text, alpha), ui::text_align::left);

--- a/src/scenes/title/song_list_view.cpp
+++ b/src/scenes/title/song_list_view.cpp
@@ -8,8 +8,19 @@
 
 namespace {
 
-constexpr float kSongRowHeight = 68.0f;
-constexpr float kSongRowGap = 10.0f;
+constexpr float kSongRowHeight = 102.0f;
+constexpr float kSongRowGap = 15.0f;
+constexpr float kScrollPadding = 36.0f;
+constexpr float kInitialRowOffsetY = 18.0f;
+constexpr float kSongCountOffsetY = 36.0f;
+constexpr float kSongCountHeight = 27.0f;
+constexpr float kClipSlack = 6.0f;
+constexpr float kRowBorderWidth = 1.5f;
+constexpr float kTextPaddingX = 21.0f;
+constexpr float kTitleOffsetY = 15.0f;
+constexpr float kTitleHeight = 36.0f;
+constexpr float kArtistOffsetY = 60.0f;
+constexpr float kArtistHeight = 27.0f;
 
 }  // namespace
 
@@ -23,13 +34,13 @@ float content_height(int count) {
 }
 
 float max_scroll(Rectangle area, int count) {
-    return std::max(0.0f, content_height(count) - area.height + 24.0f);
+    return std::max(0.0f, content_height(count) - area.height + kScrollPadding);
 }
 
 Rectangle row_rect(Rectangle area, int index, float scroll_y) {
     return {
         area.x,
-        area.y + 12.0f + static_cast<float>(index) * (kSongRowHeight + kSongRowGap) - scroll_y,
+        area.y + kInitialRowOffsetY + static_cast<float>(index) * (kSongRowHeight + kSongRowGap) - scroll_y,
         area.width,
         kSongRowHeight
     };
@@ -56,15 +67,16 @@ void draw(const song_select::state& state, const draw_config& config) {
     }
 
     ui::draw_text_in_rect(TextFormat("%d songs", static_cast<int>(state.songs.size())), 16,
-                          {config.column_rect.x, config.column_rect.y - 24.0f, config.column_rect.width, 18.0f},
+                          {config.column_rect.x, config.column_rect.y - kSongCountOffsetY,
+                           config.column_rect.width, kSongCountHeight},
                           with_alpha(t.text_muted, config.alpha), ui::text_align::left);
 
     ui::scoped_clip_rect clip(config.column_rect);
     for (int i = 0; i < static_cast<int>(state.songs.size()); ++i) {
         const song_select::song_entry& song = state.songs[static_cast<size_t>(i)];
         const Rectangle row = row_rect(config.column_rect, i, state.scroll_y);
-        if (row.y + row.height < config.column_rect.y - 4.0f ||
-            row.y > config.column_rect.y + config.column_rect.height + 4.0f) {
+        if (row.y + row.height < config.column_rect.y - kClipSlack ||
+            row.y > config.column_rect.y + config.column_rect.height + kClipSlack) {
             continue;
         }
 
@@ -74,15 +86,17 @@ void draw(const song_select::state& state, const draw_config& config) {
             : hovered ? config.hover_row_alpha
                       : config.normal_row_alpha;
 
-        DrawRectangleRec(row, with_alpha(selected ? config.button_selected : config.button_base, row_alpha));
-        DrawRectangleLinesEx(
-            row, 1.0f,
+        ui::draw_rect_f(row, with_alpha(selected ? config.button_selected : config.button_base, row_alpha));
+        ui::draw_rect_lines(
+            row, kRowBorderWidth,
             with_alpha(t.border_light, static_cast<unsigned char>(130.0f * config.play_t)));
         draw_marquee_text(song.song.meta.title.c_str(),
-                          {row.x + 14.0f, row.y + 10.0f, row.width - 26.0f, 22.0f},
+                          {row.x + kTextPaddingX, row.y + kTitleOffsetY,
+                           row.width - kTextPaddingX * 2.0f, kTitleHeight},
                           20, with_alpha(t.text, config.alpha), config.now);
         draw_marquee_text(song.song.meta.artist.c_str(),
-                          {row.x + 14.0f, row.y + 38.0f, row.width - 26.0f, 16.0f},
+                          {row.x + kTextPaddingX, row.y + kArtistOffsetY,
+                           row.width - kTextPaddingX * 2.0f, kArtistHeight},
                           14, with_alpha(t.text_muted, config.alpha), config.now);
     }
 }

--- a/src/scenes/title/title_header_view.cpp
+++ b/src/scenes/title/title_header_view.cpp
@@ -7,6 +7,36 @@
 #include "tween.h"
 #include "ui_draw.h"
 
+namespace {
+
+constexpr float kClosedTitleHeight = 186.0f;
+constexpr float kOpenTitleHeight = 186.0f;
+constexpr float kPlayTitleHeight = 162.0f;
+constexpr float kSubtitleInsetX = 15.0f;
+constexpr float kClosedSubtitleOffsetY = 192.0f;
+constexpr float kOpenSubtitleOffsetY = 192.0f;
+constexpr float kSubtitleHeight = 45.0f;
+constexpr float kPlaySubtitleInsetX = 12.0f;
+constexpr float kPlaySubtitleOffsetY = 153.0f;
+constexpr float kPlaySubtitleHeight = 36.0f;
+constexpr float kAccountBorderWidth = 3.0f;
+constexpr float kAvatarOffsetX = 18.0f;
+constexpr float kAvatarOffsetY = 13.5f;
+constexpr float kAvatarSize = 60.0f;
+constexpr float kAvatarRadius = 30.0f;
+constexpr float kAccountTextOffsetX = 96.0f;
+constexpr float kAccountTextRightReserved = 132.0f;
+constexpr float kAccountNameOffsetY = 12.0f;
+constexpr float kAccountNameHeight = 33.0f;
+constexpr float kAccountStatusOffsetY = 45.0f;
+constexpr float kAccountStatusHeight = 24.0f;
+constexpr float kAccountArrowRightInset = 36.0f;
+constexpr float kAccountArrowOffsetY = 18.0f;
+constexpr float kAccountArrowWidth = 18.0f;
+constexpr float kAccountArrowHeight = 36.0f;
+
+}  // namespace
+
 namespace title_header_view {
 
 void draw(const draw_config& config) {
@@ -14,31 +44,37 @@ void draw(const draw_config& config) {
 
     const Vector2 closed_title_pos = ui::text_position("raythm", 124,
                                                        {config.closed_header_rect.x, config.closed_header_rect.y,
-                                                        config.closed_header_rect.width, 124.0f},
+                                                        config.closed_header_rect.width, kClosedTitleHeight},
                                                        ui::text_align::center);
     const Rectangle title_play_header_rect = title_layout::play_header_rect();
     const Vector2 home_title_pos = ui::text_position("raythm", 124,
                                                      {config.open_header_rect.x, config.open_header_rect.y,
-                                                      config.open_header_rect.width, 124.0f},
+                                                      config.open_header_rect.width, kOpenTitleHeight},
                                                      ui::text_align::left);
     const Vector2 play_title_pos = ui::text_position("raythm", 108,
                                                      {title_play_header_rect.x, title_play_header_rect.y,
-                                                      title_play_header_rect.width, 108.0f},
+                                                      title_play_header_rect.width, kPlayTitleHeight},
                                                      ui::text_align::left);
     const Vector2 title_pos =
         tween::lerp(tween::lerp(closed_title_pos, home_title_pos, config.menu_t), play_title_pos, config.play_t);
 
     const Vector2 closed_subtitle_pos = ui::text_position("trace the line before the beat disappears", 30,
-                                                          {config.closed_header_rect.x + 10.0f, config.closed_header_rect.y + 128.0f,
-                                                           config.closed_header_rect.width - 10.0f, 30.0f},
+                                                          {config.closed_header_rect.x + kSubtitleInsetX,
+                                                           config.closed_header_rect.y + kClosedSubtitleOffsetY,
+                                                           config.closed_header_rect.width - kSubtitleInsetX,
+                                                           kSubtitleHeight},
                                                           ui::text_align::center);
     const Vector2 home_subtitle_pos = ui::text_position("trace the line before the beat disappears", 30,
-                                                        {config.open_header_rect.x + 10.0f, config.open_header_rect.y + 128.0f,
-                                                         config.open_header_rect.width - 10.0f, 30.0f},
+                                                        {config.open_header_rect.x + kSubtitleInsetX,
+                                                         config.open_header_rect.y + kOpenSubtitleOffsetY,
+                                                         config.open_header_rect.width - kSubtitleInsetX,
+                                                         kSubtitleHeight},
                                                         ui::text_align::left);
     const Vector2 play_subtitle_pos = ui::text_position("trace the line before the beat disappears", 24,
-                                                        {title_play_header_rect.x + 8.0f, title_play_header_rect.y + 102.0f,
-                                                         title_play_header_rect.width - 8.0f, 24.0f},
+                                                        {title_play_header_rect.x + kPlaySubtitleInsetX,
+                                                         title_play_header_rect.y + kPlaySubtitleOffsetY,
+                                                         title_play_header_rect.width - kPlaySubtitleInsetX,
+                                                         kPlaySubtitleHeight},
                                                         ui::text_align::left);
     const Vector2 subtitle_pos =
         tween::lerp(tween::lerp(closed_subtitle_pos, home_subtitle_pos, config.menu_t), play_subtitle_pos, config.play_t);
@@ -56,26 +92,30 @@ void draw(const draw_config& config) {
     }
 
     const unsigned char account_alpha = static_cast<unsigned char>(255.0f * std::max(config.menu_t, config.play_t));
-    DrawRectangleRec(config.account_chip_rect, with_alpha(t.panel, account_alpha));
-    DrawRectangleLinesEx(config.account_chip_rect, 2.0f, with_alpha(t.border, account_alpha));
-    const Rectangle avatar_rect = {config.account_chip_rect.x + 12.0f, config.account_chip_rect.y + 9.0f, 40.0f, 40.0f};
+    ui::draw_rect_f(config.account_chip_rect, with_alpha(t.panel, account_alpha));
+    ui::draw_rect_lines(config.account_chip_rect, kAccountBorderWidth, with_alpha(t.border, account_alpha));
+    const Rectangle avatar_rect = {config.account_chip_rect.x + kAvatarOffsetX,
+                                   config.account_chip_rect.y + kAvatarOffsetY,
+                                   kAvatarSize, kAvatarSize};
     const Vector2 avatar_center = {avatar_rect.x + avatar_rect.width * 0.5f, avatar_rect.y + avatar_rect.height * 0.5f};
-    DrawCircleV(avatar_center, 20.0f, with_alpha(config.logged_in ? t.accent : t.row_selected, account_alpha));
+    DrawCircleV(avatar_center, kAvatarRadius, with_alpha(config.logged_in ? t.accent : t.row_selected, account_alpha));
     ui::draw_text_in_rect(std::string(config.avatar_label).c_str(), 18, avatar_rect,
                           with_alpha(config.logged_in ? t.panel : t.text, account_alpha), ui::text_align::center);
     const Rectangle account_name_rect = {
-        config.account_chip_rect.x + 64.0f, config.account_chip_rect.y + 8.0f, config.account_chip_rect.width - 88.0f, 22.0f
+        config.account_chip_rect.x + kAccountTextOffsetX, config.account_chip_rect.y + kAccountNameOffsetY,
+        config.account_chip_rect.width - kAccountTextRightReserved, kAccountNameHeight
     };
     draw_marquee_text(std::string(config.account_name).c_str(), account_name_rect, 18,
                       with_alpha(t.text, account_alpha), config.now);
     ui::draw_text_in_rect(std::string(config.account_status).c_str(),
                           13,
-                          {config.account_chip_rect.x + 64.0f, config.account_chip_rect.y + 30.0f,
-                           config.account_chip_rect.width - 88.0f, 16.0f},
+                          {config.account_chip_rect.x + kAccountTextOffsetX, config.account_chip_rect.y + kAccountStatusOffsetY,
+                           config.account_chip_rect.width - kAccountTextRightReserved, kAccountStatusHeight},
                           with_alpha(config.logged_in && !config.email_verified ? t.error : t.text_muted, account_alpha),
                           ui::text_align::left);
     ui::draw_text_in_rect(">", 18,
-                          {config.account_chip_rect.x + config.account_chip_rect.width - 24.0f, config.account_chip_rect.y + 12.0f, 12.0f, 24.0f},
+                          {config.account_chip_rect.x + config.account_chip_rect.width - kAccountArrowRightInset,
+                           config.account_chip_rect.y + kAccountArrowOffsetY, kAccountArrowWidth, kAccountArrowHeight},
                           with_alpha(t.text_muted, account_alpha), ui::text_align::center);
 }
 

--- a/src/scenes/title/title_layout.cpp
+++ b/src/scenes/title/title_layout.cpp
@@ -5,42 +5,58 @@
 
 namespace title_layout {
 
+namespace {
+
+constexpr float kClosedHeaderWidth = 1290.0f;
+constexpr float kClosedHeaderHeight = 273.0f;
+constexpr Vector2 kClosedHeaderOffset = {0.0f, -81.0f};
+constexpr float kOpenHeaderWidth = 1140.0f;
+constexpr float kOpenHeaderHeight = 255.0f;
+constexpr Vector2 kOpenHeaderOffset = {108.0f, 126.0f};
+constexpr float kPlayHeaderY = 78.0f;
+constexpr float kSpectrumHeight = 498.0f;
+constexpr float kAccountChipWidth = 396.0f;
+constexpr float kAccountChipHeight = 87.0f;
+constexpr Vector2 kAccountChipOffset = {-42.0f, 30.0f};
+
+}  // namespace
+
 Rectangle screen_rect() {
     return {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
 }
 
 Rectangle closed_header_rect() {
-    return ui::place(screen_rect(), 860.0f, 182.0f,
+    return ui::place(screen_rect(), kClosedHeaderWidth, kClosedHeaderHeight,
                      ui::anchor::center, ui::anchor::center,
-                     {0.0f, -54.0f});
+                     kClosedHeaderOffset);
 }
 
 Rectangle open_header_rect() {
-    return ui::place(screen_rect(), 760.0f, 170.0f,
+    return ui::place(screen_rect(), kOpenHeaderWidth, kOpenHeaderHeight,
                      ui::anchor::top_left, ui::anchor::top_left,
-                     {72.0f, 84.0f});
+                     kOpenHeaderOffset);
 }
 
 Rectangle play_header_rect() {
     const Rectangle open = open_header_rect();
     return {
         open.x,
-        52.0f,
+        kPlayHeaderY,
         open.width,
         open.height
     };
 }
 
 Rectangle spectrum_rect() {
-    return ui::place(screen_rect(), static_cast<float>(kScreenWidth), 332.0f,
+    return ui::place(screen_rect(), static_cast<float>(kScreenWidth), kSpectrumHeight,
                      ui::anchor::bottom_center, ui::anchor::bottom_center,
                      {0.0f, 0.0f});
 }
 
 Rectangle account_chip_rect() {
-    return ui::place(screen_rect(), 264.0f, 58.0f,
+    return ui::place(screen_rect(), kAccountChipWidth, kAccountChipHeight,
                      ui::anchor::top_right, ui::anchor::top_right,
-                     {-28.0f, 20.0f});
+                     kAccountChipOffset);
 }
 
 }  // namespace title_layout

--- a/src/scenes/title/title_spectrum_visualizer.cpp
+++ b/src/scenes/title/title_spectrum_visualizer.cpp
@@ -6,6 +6,7 @@
 #include <cmath>
 
 #include "audio_manager.h"
+#include "ui_coord.h"
 
 namespace {
 
@@ -176,8 +177,8 @@ void title_spectrum_visualizer::draw(const Rectangle& rect, float alpha_scale) c
         (rect.width - gap * static_cast<float>(kBarCount - 1)) / static_cast<float>(kBarCount);
     const float baseline = rect.y + rect.height;
     const float max_height = rect.height * 1.0f;
-    const float block_height = 5.0f;
-    const float block_gap = 2.0f;
+    const float block_height = 8.0f;
+    const float block_gap = 4.0f;
     const float block_step = block_height + block_gap;
     const Color base_low = with_alpha_scale({107, 33, 168, 255}, clamped_alpha * (128.0f / 255.0f));
     const Color base_mid = with_alpha_scale({168, 85, 247, 255}, clamped_alpha * (178.0f / 255.0f));
@@ -199,13 +200,13 @@ void title_spectrum_visualizer::draw(const Rectangle& rect, float alpha_scale) c
                         color_t < 0.6f
                             ? lerp_color(base_low, base_mid, color_t / 0.6f)
                             : lerp_color(base_mid, base_top, (color_t - 0.6f) / 0.4f);
-                    DrawRectangleRec({x, block_top, bar_width, segment_height}, block_color);
+                    ui::draw_rect_f({x, block_top, bar_width, segment_height}, block_color);
                 }
             }
         }
 
         const float peak_y = baseline - std::clamp(peaks_[static_cast<size_t>(i)], 0.0f, 1.0f) * max_height - 2.0f;
-        DrawRectangleRec({x, peak_y - 1.0f, bar_width, 4.0f}, peak_glow);
-        DrawRectangleRec({x, peak_y, bar_width, 2.0f}, peak_color);
+        ui::draw_rect_f({x, peak_y - 1.0f, bar_width, 4.0f}, peak_glow);
+        ui::draw_rect_f({x, peak_y, bar_width, 2.0f}, peak_color);
     }
 }

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -1077,7 +1077,7 @@ void title_scene::draw() {
     const Rectangle screen_rect = title_layout::screen_rect();
     const Rectangle spectrum_rect = title_layout::spectrum_rect();
     const Rectangle account_chip_rect = title_layout::account_chip_rect();
-    virtual_screen::begin();
+    virtual_screen::begin_ui();
     ClearBackground(t.bg);
     DrawRectangleGradientV(0, 0, kScreenWidth, kScreenHeight, t.bg, t.bg_alt);
     ui::begin_draw_queue();

--- a/src/scenes/virtual_screen.cpp
+++ b/src/scenes/virtual_screen.cpp
@@ -1,54 +1,101 @@
 #include "virtual_screen.h"
 
+#include <cmath>
+
 namespace {
 RenderTexture2D render_target_{};
+RenderTexture2D ui_render_target_{};
 bool initialized_ = false;
+
+enum class render_mode {
+    none,
+    standard,
+    ui_highres,
+};
+
+render_mode active_mode_ = render_mode::none;
+render_mode present_mode_ = render_mode::standard;
+
+Camera2D make_ui_camera() {
+    Camera2D camera = {};
+    camera.offset = {0.0f, 0.0f};
+    camera.target = {0.0f, 0.0f};
+    camera.rotation = 0.0f;
+    camera.zoom = static_cast<float>(virtual_screen::kUiRenderScale);
+    return camera;
+}
+
+const RenderTexture2D& current_target(render_mode mode) {
+    return mode == render_mode::ui_highres ? ui_render_target_ : render_target_;
+}
 }  // namespace
 
 namespace virtual_screen {
 
 void init() {
     render_target_ = LoadRenderTexture(kDesignWidth, kDesignHeight);
+    ui_render_target_ = LoadRenderTexture(kDesignWidth * kUiRenderScale, kDesignHeight * kUiRenderScale);
+    SetTextureFilter(render_target_.texture, TEXTURE_FILTER_POINT);
+    SetTextureFilter(ui_render_target_.texture, TEXTURE_FILTER_POINT);
+    active_mode_ = render_mode::none;
+    present_mode_ = render_mode::standard;
     initialized_ = true;
 }
 
 void cleanup() {
     if (initialized_) {
         UnloadRenderTexture(render_target_);
+        UnloadRenderTexture(ui_render_target_);
         initialized_ = false;
+        active_mode_ = render_mode::none;
+        present_mode_ = render_mode::standard;
     }
 }
 
 void begin() {
     BeginTextureMode(render_target_);
+    active_mode_ = render_mode::standard;
+    present_mode_ = render_mode::standard;
+}
+
+void begin_ui() {
+    BeginTextureMode(ui_render_target_);
+    BeginMode2D(make_ui_camera());
+    active_mode_ = render_mode::ui_highres;
+    present_mode_ = render_mode::ui_highres;
 }
 
 void end() {
+    if (active_mode_ == render_mode::ui_highres) {
+        EndMode2D();
+    }
     EndTextureMode();
+    active_mode_ = render_mode::none;
 }
 
 void draw_to_screen(bool use_alpha) {
     const float screen_w = static_cast<float>(GetScreenWidth());
     const float screen_h = static_cast<float>(GetScreenHeight());
+    const RenderTexture2D& target = current_target(present_mode_);
+    const float source_w = static_cast<float>(target.texture.width);
+    const float source_h = static_cast<float>(target.texture.height);
 
     // 16:9 を前提としてウィンドウ全体にフィットさせる
-    const float scale_x = screen_w / static_cast<float>(kDesignWidth);
-    const float scale_y = screen_h / static_cast<float>(kDesignHeight);
+    const float scale_x = screen_w / source_w;
+    const float scale_y = screen_h / source_h;
     const float scale = (scale_x < scale_y) ? scale_x : scale_y;
 
-    const float dest_w = static_cast<float>(kDesignWidth) * scale;
-    const float dest_h = static_cast<float>(kDesignHeight) * scale;
-    const float offset_x = (screen_w - dest_w) * 0.5f;
-    const float offset_y = (screen_h - dest_h) * 0.5f;
+    const float dest_w = std::round(source_w * scale);
+    const float dest_h = std::round(source_h * scale);
+    const float offset_x = std::round((screen_w - dest_w) * 0.5f);
+    const float offset_y = std::round((screen_h - dest_h) * 0.5f);
 
     // RenderTexture は OpenGL 座標系で上下反転しているため source.height を負にする
-    const Rectangle source = {0.0f, 0.0f,
-                               static_cast<float>(kDesignWidth),
-                               -static_cast<float>(kDesignHeight)};
+    const Rectangle source = {0.0f, 0.0f, source_w, -source_h};
     const Rectangle dest = {offset_x, offset_y, dest_w, dest_h};
 
     const Color tint = use_alpha ? WHITE : WHITE;
-    DrawTexturePro(render_target_.texture, source, dest, {0.0f, 0.0f}, 0.0f, tint);
+    DrawTexturePro(target.texture, source, dest, {0.0f, 0.0f}, 0.0f, tint);
 }
 
 Vector2 get_virtual_mouse() {
@@ -56,19 +103,45 @@ Vector2 get_virtual_mouse() {
     const float screen_w = static_cast<float>(GetScreenWidth());
     const float screen_h = static_cast<float>(GetScreenHeight());
 
-    const float scale_x = screen_w / static_cast<float>(kDesignWidth);
-    const float scale_y = screen_h / static_cast<float>(kDesignHeight);
+    const float source_w = static_cast<float>(current_target(present_mode_).texture.width);
+    const float source_h = static_cast<float>(current_target(present_mode_).texture.height);
+    const float scale_x = screen_w / source_w;
+    const float scale_y = screen_h / source_h;
     const float scale = (scale_x < scale_y) ? scale_x : scale_y;
 
-    const float dest_w = static_cast<float>(kDesignWidth) * scale;
-    const float dest_h = static_cast<float>(kDesignHeight) * scale;
-    const float offset_x = (screen_w - dest_w) * 0.5f;
-    const float offset_y = (screen_h - dest_h) * 0.5f;
+    const float dest_w = std::round(source_w * scale);
+    const float dest_h = std::round(source_h * scale);
+    const float offset_x = std::round((screen_w - dest_w) * 0.5f);
+    const float offset_y = std::round((screen_h - dest_h) * 0.5f);
 
+    const float normalized_x = (physical.x - offset_x) / dest_w;
+    const float normalized_y = (physical.y - offset_y) / dest_h;
     return {
-        (physical.x - offset_x) / scale,
-        (physical.y - offset_y) / scale,
+        normalized_x * static_cast<float>(kDesignWidth),
+        normalized_y * static_cast<float>(kDesignHeight),
     };
+}
+
+float design_to_screen_scale() {
+    const float screen_w = static_cast<float>(GetScreenWidth());
+    const float screen_h = static_cast<float>(GetScreenHeight());
+    const float scale_x = screen_w / static_cast<float>(kDesignWidth);
+    const float scale_y = screen_h / static_cast<float>(kDesignHeight);
+    return (scale_x < scale_y) ? scale_x : scale_y;
+}
+
+float current_render_scale() {
+    return active_mode_ == render_mode::ui_highres ? static_cast<float>(kUiRenderScale) : 1.0f;
+}
+
+int current_render_width() {
+    const RenderTexture2D& target = current_target(active_mode_ == render_mode::none ? present_mode_ : active_mode_);
+    return target.texture.width;
+}
+
+int current_render_height() {
+    const RenderTexture2D& target = current_target(active_mode_ == render_mode::none ? present_mode_ : active_mode_);
+    return target.texture.height;
 }
 
 }  // namespace virtual_screen

--- a/src/scenes/virtual_screen.h
+++ b/src/scenes/virtual_screen.h
@@ -2,12 +2,13 @@
 
 #include "raylib.h"
 
-// 仮想解像度（1280x720）で描画し、実際のウィンドウサイズにスケーリングする。
+// 仮想解像度（1920x1080）で描画し、実際のウィンドウサイズにスケーリングする。
 // メニューシーンなど2D UIはすべてこの仮想座標系で描画する。
 namespace virtual_screen {
 
-constexpr int kDesignWidth = 1280;
-constexpr int kDesignHeight = 720;
+constexpr int kDesignWidth = 1920;
+constexpr int kDesignHeight = 1080;
+constexpr int kUiRenderScale = 2;
 
 // InitWindow() の後に呼ぶ。RenderTexture を確保する。
 void init();
@@ -18,6 +19,10 @@ void cleanup();
 // 仮想スクリーンへの描画を開始する。以降の Draw 呼び出しは RenderTexture に書き込まれる。
 void begin();
 
+// UI 品質優先の高解像度仮想スクリーンへの描画を開始する。
+// 論理座標は 1920x1080 のまま維持しつつ、内部では高解像度 RT に描画する。
+void begin_ui();
+
 // 仮想スクリーンへの描画を終了する。
 void end();
 
@@ -27,5 +32,15 @@ void draw_to_screen(bool use_alpha = false);
 
 // 物理スクリーンのマウス座標を仮想座標に変換する。
 Vector2 get_virtual_mouse();
+
+// 1920x1080 の論理座標が、実画面へどれだけ拡大されているかを返す。
+float design_to_screen_scale();
+
+// 現在の仮想スクリーン描画倍率を返す。通常描画は 1、高品質 UI 描画は 2。
+float current_render_scale();
+
+// 現在の描画先 RenderTexture の実ピクセルサイズを返す。
+int current_render_width();
+int current_render_height();
 
 }  // namespace virtual_screen

--- a/src/ui/ui_coord.h
+++ b/src/ui/ui_coord.h
@@ -5,6 +5,7 @@
 
 #include "raylib.h"
 #include "ui_font.h"
+#include "virtual_screen.h"
 
 // 描画境界の座標変換ヘルパー。
 // float → int の static_cast を一元管理し、呼び出し側の記述を簡潔にする。
@@ -31,6 +32,23 @@ inline ipoint to_point(Vector2 v) {
     return {static_cast<int>(v.x), static_cast<int>(v.y)};
 }
 
+// 1920x1080 の論理ピクセル境界に揃える。
+inline float snap_pixel(float value) {
+    return std::round(value);
+}
+
+inline float snap_stroke_width(float width) {
+    return std::max(1.0f, std::round(width));
+}
+
+inline Rectangle snap_rect(Rectangle rect) {
+    const float x = snap_pixel(rect.x);
+    const float y = snap_pixel(rect.y);
+    const float right = snap_pixel(rect.x + rect.width);
+    const float bottom = snap_pixel(rect.y + rect.height);
+    return {x, y, std::max(1.0f, right - x), std::max(1.0f, bottom - y)};
+}
+
 // float 座標で DrawText を呼び出す。
 inline void draw_text_f(const char* text, float x, float y, int font_size, Color color) {
     if (text == nullptr || *text == '\0') {
@@ -44,14 +62,25 @@ inline void draw_line_f(float x1, float y1, float x2, float y2, Color color) {
     DrawLine(to_i(x1), to_i(y1), to_i(x2), to_i(y2), color);
 }
 
+inline void draw_line_ex(Vector2 start, Vector2 end, float thick, Color color) {
+    DrawLineEx({snap_pixel(start.x), snap_pixel(start.y)},
+               {snap_pixel(end.x), snap_pixel(end.y)},
+               snap_stroke_width(thick), color);
+}
+
 // float 座標で DrawRectangle を呼び出す。
 inline void draw_rect_f(float x, float y, float w, float h, Color color) {
-    DrawRectangle(to_i(x), to_i(y), to_i(w), to_i(h), color);
+    const Rectangle rect = snap_rect({x, y, w, h});
+    DrawRectangleRec(rect, color);
 }
 
 // Rectangle で DrawRectangle を呼び出す。
 inline void draw_rect_f(Rectangle rect, Color color) {
-    DrawRectangle(to_i(rect.x), to_i(rect.y), to_i(rect.width), to_i(rect.height), color);
+    DrawRectangleRec(snap_rect(rect), color);
+}
+
+inline void draw_rect_lines(Rectangle rect, float line_thick, Color color) {
+    DrawRectangleLinesEx(snap_rect(rect), snap_stroke_width(line_thick), color);
 }
 
 // 位置は floor、右端と下端は ceil で広めに取りたい矩形描画用。
@@ -67,14 +96,21 @@ inline void draw_rect_span(Rectangle rect, Color color) {
 // floor/ceil で端数を広めに取り、空矩形は画面外 1px に逃がして描画を無効化する。
 inline void begin_scissor_rect(Rectangle rect) {
     if (rect.width <= 0.0f || rect.height <= 0.0f) {
-        BeginScissorMode(GetRenderWidth(), GetRenderHeight(), 1, 1);
+        BeginScissorMode(virtual_screen::current_render_width(), virtual_screen::current_render_height(), 1, 1);
         return;
     }
 
-    const int sx = static_cast<int>(std::floor(rect.x));
-    const int sy = static_cast<int>(std::floor(rect.y));
-    const int sw = std::max(1, static_cast<int>(std::ceil(rect.x + rect.width) - std::floor(rect.x)));
-    const int sh = std::max(1, static_cast<int>(std::ceil(rect.y + rect.height) - std::floor(rect.y)));
+    const float render_scale = virtual_screen::current_render_scale();
+    const Rectangle scaled = {
+        rect.x * render_scale,
+        rect.y * render_scale,
+        rect.width * render_scale,
+        rect.height * render_scale,
+    };
+    const int sx = static_cast<int>(std::floor(scaled.x));
+    const int sy = static_cast<int>(std::floor(scaled.y));
+    const int sw = std::max(1, static_cast<int>(std::ceil(scaled.x + scaled.width) - std::floor(scaled.x)));
+    const int sh = std::max(1, static_cast<int>(std::ceil(scaled.y + scaled.height) - std::floor(scaled.y)));
     BeginScissorMode(sx, sy, sw, sh);
 }
 

--- a/src/ui/ui_draw.h
+++ b/src/ui/ui_draw.h
@@ -74,16 +74,16 @@ inline void draw_button_visual(Rectangle rect, bool hovered, bool pressed, const
                                float border_width) {
     const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
     const Color fill = lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f);
-    DrawRectangleRec(visual, fill);
-    DrawRectangleLinesEx(visual, border_width, with_alpha(g_theme->border, fill.a));
+    draw_rect_f(visual, fill);
+    draw_rect_lines(visual, border_width, with_alpha(g_theme->border, fill.a));
     draw_text_in_rect(label, font_size, visual, text_color);
 }
 
 inline void draw_row_visual(Rectangle rect, bool hovered, bool pressed, Color bg, Color bg_hover,
                             Color border_color, float border_width) {
     const Rectangle visual = pressed ? inset(rect, 1.5f) : rect;
-    DrawRectangleRec(visual, lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f));
-    DrawRectangleLinesEx(visual, border_width, border_color);
+    draw_rect_f(visual, lerp_color(bg, bg_hover, hovered ? 1.0f : 0.0f));
+    draw_rect_lines(visual, border_width, border_color);
 }
 
 }  // namespace detail
@@ -223,8 +223,8 @@ inline row_state enqueue_row(Rectangle rect, Color bg, Color bg_hover, Color bor
 
 // メインパネル（panel 背景 + border ボーダー、2px）。
 inline void draw_panel(Rectangle rect) {
-    DrawRectangleRec(rect, g_theme->panel);
-    DrawRectangleLinesEx(rect, 2.0f, g_theme->border);
+    draw_rect_f(rect, g_theme->panel);
+    draw_rect_lines(rect, 2.0f, g_theme->border);
 }
 
 inline void enqueue_panel(Rectangle rect, draw_layer layer = draw_layer::base) {
@@ -235,8 +235,8 @@ inline void enqueue_panel(Rectangle rect, draw_layer layer = draw_layer::base) {
 
 // セクションパネル（section 背景 + border_light ボーダー、1.5px）。
 inline void draw_section(Rectangle rect) {
-    DrawRectangleRec(rect, g_theme->section);
-    DrawRectangleLinesEx(rect, 1.5f, g_theme->border_light);
+    draw_rect_f(rect, g_theme->section);
+    draw_rect_lines(rect, 1.5f, g_theme->border_light);
 }
 
 inline void enqueue_section(Rectangle rect, draw_layer layer = draw_layer::base) {
@@ -544,13 +544,13 @@ inline context_menu_state enqueue_context_menu(Rectangle menu_rect,
                 const Rectangle text_rect = inset(draw_item_rect, edge_insets::symmetric(0.0f, 12.0f));
                 draw_text_in_rect(item_labels[static_cast<size_t>(i)].c_str(), std::max(12, font_size - 2),
                                   text_rect, g_theme->text_muted, text_align::left);
-                DrawLineEx({draw_item_rect.x + 10.0f, draw_item_rect.y + draw_item_rect.height - 3.0f},
-                           {draw_item_rect.x + draw_item_rect.width - 10.0f, draw_item_rect.y + draw_item_rect.height - 3.0f},
-                           1.0f, g_theme->border_light);
+                draw_line_ex({draw_item_rect.x + 10.0f, draw_item_rect.y + draw_item_rect.height - 3.0f},
+                             {draw_item_rect.x + draw_item_rect.width - 10.0f, draw_item_rect.y + draw_item_rect.height - 3.0f},
+                             1.0f, g_theme->border_light);
             } else if (kind == context_menu_item::kind::separator) {
-                DrawLineEx({draw_item_rect.x + 8.0f, draw_item_rect.y + draw_item_rect.height * 0.5f},
-                           {draw_item_rect.x + draw_item_rect.width - 8.0f, draw_item_rect.y + draw_item_rect.height * 0.5f},
-                           1.0f, g_theme->border_light);
+                draw_line_ex({draw_item_rect.x + 8.0f, draw_item_rect.y + draw_item_rect.height * 0.5f},
+                             {draw_item_rect.x + draw_item_rect.width - 8.0f, draw_item_rect.y + draw_item_rect.height * 0.5f},
+                             1.0f, g_theme->border_light);
             } else {
                 detail::draw_row_visual(draw_item_rect, state.hovered, state.pressed,
                                         enabled ? g_theme->row : with_alpha(g_theme->row, 180),
@@ -583,8 +583,8 @@ inline void draw_header_block(Rectangle rect, const char* title, const char* sub
 inline void draw_progress_bar(Rectangle rect, float ratio,
                               Color bg, Color fill, Color border_color,
                               float border_width = 3.0f, float bar_inset = 4.0f) {
-    DrawRectangleRec(rect, bg);
-    DrawRectangleLinesEx(rect, border_width, border_color);
+    draw_rect_f(rect, bg);
+    draw_rect_lines(rect, border_width, border_color);
 
     if (ratio > 0.0f) {
         const Rectangle fill_area = inset(rect, bar_inset);
@@ -619,8 +619,8 @@ inline float draw_slider(Rectangle row_rect, const char* label, const char* valu
                          float ratio, float track_left, float track_width,
                          int font_size = 22, float track_top_offset = 26.0f) {
     // 行背景
-    DrawRectangleRec(row_rect, g_theme->row);
-    DrawRectangleLinesEx(row_rect, 2.0f, g_theme->border);
+    draw_rect_f(row_rect, g_theme->row);
+    draw_rect_lines(row_rect, 2.0f, g_theme->border);
 
     // ラベル（左寄せ）
     const Rectangle label_rect = {row_rect.x + 18.0f, row_rect.y, 200.0f, row_rect.height};
@@ -629,7 +629,7 @@ inline float draw_slider(Rectangle row_rect, const char* label, const char* valu
     // トラック
     const Rectangle track = {track_left, row_rect.y + track_top_offset, track_width, 6.0f};
     const float clamped = std::clamp(ratio, 0.0f, 1.0f);
-    DrawRectangleRec(track, g_theme->slider_track);
+    draw_rect_f(track, g_theme->slider_track);
     draw_rect_f(track.x, track.y, track.width * clamped, track.height, g_theme->slider_fill);
 
     // つまみ
@@ -653,15 +653,15 @@ inline float draw_slider(Rectangle row_rect, const char* label, const char* valu
 inline float draw_slider(Rectangle row_rect, const char* label, const char* value_text,
                          float ratio, float track_left, float track_width, draw_layer layer,
                          int font_size = 22, float track_top_offset = 26.0f) {
-    DrawRectangleRec(row_rect, g_theme->row);
-    DrawRectangleLinesEx(row_rect, 2.0f, g_theme->border);
+    draw_rect_f(row_rect, g_theme->row);
+    draw_rect_lines(row_rect, 2.0f, g_theme->border);
 
     const Rectangle label_rect = {row_rect.x + 18.0f, row_rect.y, 200.0f, row_rect.height};
     draw_text_in_rect(label, font_size, label_rect, g_theme->text, text_align::left);
 
     const Rectangle track = {track_left, row_rect.y + track_top_offset, track_width, 6.0f};
     const float clamped = std::clamp(ratio, 0.0f, 1.0f);
-    DrawRectangleRec(track, g_theme->slider_track);
+    draw_rect_f(track, g_theme->slider_track);
     draw_rect_f(track.x, track.y, track.width * clamped, track.height, g_theme->slider_fill);
 
     const float knob_x = track.x + track.width * clamped;
@@ -688,7 +688,7 @@ inline float draw_slider_relative(Rectangle row_rect, const char* label, const c
     const float clamped = std::clamp(ratio, 0.0f, 1.0f);
 
     draw_text_in_rect(label, font_size, layout.label_rect, g_theme->text, text_align::left);
-    DrawRectangleRec(layout.track_rect, g_theme->slider_track);
+    draw_rect_f(layout.track_rect, g_theme->slider_track);
     draw_rect_f(layout.track_rect.x, layout.track_rect.y,
                 layout.track_rect.width * clamped, layout.track_rect.height, g_theme->slider_fill);
 
@@ -718,7 +718,7 @@ inline float draw_slider_relative(Rectangle row_rect, const char* label, const c
     const float clamped = std::clamp(ratio, 0.0f, 1.0f);
 
     draw_text_in_rect(label, font_size, layout.label_rect, g_theme->text, text_align::left);
-    DrawRectangleRec(layout.track_rect, g_theme->slider_track);
+    draw_rect_f(layout.track_rect, g_theme->slider_track);
     draw_rect_f(layout.track_rect.x, layout.track_rect.y,
                 layout.track_rect.width * clamped, layout.track_rect.height, g_theme->slider_fill);
 
@@ -740,8 +740,8 @@ inline void draw_scrollbar(Rectangle track_rect, float content_height, float scr
         return;
     }
 
-    DrawRectangleRec(track_rect, track_color);
-    DrawRectangleRec(metrics.thumb_rect, thumb_color);
+    draw_rect_f(track_rect, track_color);
+    draw_rect_f(metrics.thumb_rect, thumb_color);
 }
 
 inline scrollbar_interaction update_vertical_scrollbar(Rectangle track_rect, float content_height, float scroll_offset,
@@ -828,7 +828,7 @@ inline scrollbar_interaction update_vertical_scrollbar(Rectangle track_rect, flo
 
 // 画面全体を覆う半透明オーバーレイ。ポーズ画面やフェードイン/アウトに使用する。
 inline void draw_fullscreen_overlay(Color color) {
-    DrawRectangle(0, 0, 1280, 720, color);
+    DrawRectangle(0, 0, kScreenWidth, kScreenHeight, color);
 }
 
 inline void enqueue_fullscreen_overlay(Color color, draw_layer layer = draw_layer::overlay) {

--- a/src/ui/ui_font.cpp
+++ b/src/ui/ui_font.cpp
@@ -10,6 +10,7 @@
 
 #include "core/app_paths.h"
 #include "core/path_utils.h"
+#include "virtual_screen.h"
 
 namespace ui {
 
@@ -18,6 +19,7 @@ namespace {
 constexpr int kFontBaseSize = 48;
 constexpr float kCustomFontSizeScale = 0.8f;
 constexpr float kCustomFontSpacingOffset = 2.0f;
+constexpr float kUiAuthoringScale1080p = 1920.0f / 1280.0f;
 
 std::string g_font_path;
 Font g_font = {};
@@ -29,6 +31,18 @@ float snap_custom_font_size(float font_size) {
 }
 
 float snap_custom_coordinate(float value) {
+    return std::round(value);
+}
+
+float current_ui_authoring_scale() {
+    return virtual_screen::current_render_scale() > 1.0f ? kUiAuthoringScale1080p : 1.0f;
+}
+
+float snap_default_font_size(float font_size) {
+    return std::max(1.0f, std::round(font_size));
+}
+
+float snap_default_coordinate(float value) {
     return std::round(value);
 }
 
@@ -141,11 +155,16 @@ Font text_font_for_text(const char* text) {
     return GetFontDefault();
 }
 
+float text_layout_font_size(float font_size) {
+    return font_size * current_ui_authoring_scale();
+}
+
 float text_font_size_for_text(const char* text, float font_size) {
+    const float scaled_font_size = text_layout_font_size(font_size);
     if (g_font_loaded && contains_non_ascii_bytes(text)) {
-        return snap_custom_font_size(font_size * kCustomFontSizeScale);
+        return snap_custom_font_size(scaled_font_size * kCustomFontSizeScale);
     }
-    return font_size;
+    return snap_default_font_size(scaled_font_size);
 }
 
 float text_spacing_for_text(const char* text, float font_size, float spacing) {
@@ -154,12 +173,12 @@ float text_spacing_for_text(const char* text, float font_size, float spacing) {
     }
 
     if (spacing != 0.0f) {
-        return spacing;
+        return snap_default_font_size(text_layout_font_size(spacing));
     }
 
     const Font font = text_font_for_text(text);
     if (font.texture.id == GetFontDefault().texture.id && font.baseSize > 0) {
-        return font_size / static_cast<float>(font.baseSize);
+        return snap_default_font_size(font_size) / static_cast<float>(font.baseSize);
     }
     return 0.0f;
 }
@@ -210,7 +229,7 @@ void draw_text_auto(const char* text, Vector2 position, float font_size, float s
     const bool uses_custom_font = g_font_loaded && contains_non_ascii_bytes(text);
     const Vector2 draw_position = uses_custom_font
                                       ? Vector2{snap_custom_coordinate(position.x), snap_custom_coordinate(position.y)}
-                                      : position;
+                                      : Vector2{snap_default_coordinate(position.x), snap_default_coordinate(position.y)};
     DrawTextEx(text_font_for_text(text), text, draw_position, adjusted_font_size,
                text_spacing_for_text(text, adjusted_font_size, spacing), color);
 }

--- a/src/ui/ui_font.h
+++ b/src/ui/ui_font.h
@@ -11,6 +11,7 @@ void shutdown_text_font();
 
 Font text_font();
 Font text_font_for_text(const char* text);
+float text_layout_font_size(float font_size);
 float text_font_size_for_text(const char* text, float font_size);
 float text_spacing_for_text(const char* text, float font_size, float spacing = 0.0f);
 void ensure_text_glyphs(const char* text);

--- a/src/ui/ui_notice.h
+++ b/src/ui/ui_notice.h
@@ -80,16 +80,17 @@ inline unsigned char notice_alpha(const notice_entry& notice) {
 }
 
 inline void draw_notice_queue_bottom_right(const notice_queue& queue, Rectangle bounds,
-                                           float right_margin = 24.0f, float bottom_margin = 16.0f,
-                                           float max_width = 460.0f, float min_width = 140.0f,
-                                           float vertical_gap = 10.0f) {
+                                           float right_margin = 36.0f, float bottom_margin = 24.0f,
+                                           float max_width = 690.0f, float min_width = 210.0f,
+                                           float vertical_gap = 15.0f) {
     if (queue.items.empty()) {
         return;
     }
 
-    constexpr float kHorizontalPadding = 12.0f;
-    constexpr float kVerticalPadding = 6.0f;
+    constexpr float kHorizontalPadding = 18.0f;
+    constexpr float kVerticalPadding = 10.5f;
     constexpr int kFontSize = 18;
+    const float line_height = text_layout_font_size(static_cast<float>(kFontSize));
     float bottom_y = bounds.y + bounds.height - bottom_margin;
 
     for (auto it = queue.items.rbegin(); it != queue.items.rend(); ++it) {
@@ -98,7 +99,8 @@ inline void draw_notice_queue_bottom_right(const notice_queue& queue, Rectangle 
         const unsigned char alpha = notice_alpha(notice);
         const Vector2 measured = measure_text_size(notice.message, static_cast<float>(kFontSize));
         const float width = std::clamp(measured.x + kHorizontalPadding * 2.0f, min_width, max_width);
-        const float height = std::max(30.0f, measured.y + kVerticalPadding * 2.0f);
+        const float height = std::max(45.0f,
+                                      std::max(measured.y, line_height) + kVerticalPadding * 2.0f);
         const Rectangle rect = {
             bounds.x + bounds.width - right_margin - width,
             bottom_y - height,
@@ -110,8 +112,8 @@ inline void draw_notice_queue_bottom_right(const notice_queue& queue, Rectangle 
         const Color border = with_alpha(lerp_color(g_theme->border, tone, 0.45f), alpha);
         const Color text_color = with_alpha(tone, alpha);
 
-        DrawRectangleRec(rect, background);
-        DrawRectangleLinesEx(rect, 2.0f, border);
+        draw_rect_f(rect, background);
+        draw_rect_lines(rect, 2.0f, border);
         draw_text_in_rect(notice.message.c_str(), kFontSize,
                           inset(rect, edge_insets::symmetric(kVerticalPadding, kHorizontalPadding)),
                           text_color, text_align::right);

--- a/src/ui/ui_text.h
+++ b/src/ui/ui_text.h
@@ -13,6 +13,7 @@ namespace ui {
 // 水平方向は align に従い、垂直方向は中央揃え。
 inline Vector2 text_position(const char* text, int font_size, Rectangle rect,
                              text_align align = text_align::center) {
+    const float layout_font_size = text_layout_font_size(static_cast<float>(font_size));
     const float text_width = measure_text_size(text, static_cast<float>(font_size), 0.0f).x;
     float x;
     switch (align) {
@@ -26,7 +27,7 @@ inline Vector2 text_position(const char* text, int font_size, Rectangle rect,
             x = rect.x + rect.width - text_width;
             break;
     }
-    const float y = rect.y + (rect.height - static_cast<float>(font_size)) * 0.5f;
+    const float y = rect.y + (rect.height - layout_font_size) * 0.5f;
     return {x, y};
 }
 

--- a/src/ui/ui_text_editor.cpp
+++ b/src/ui/ui_text_editor.cpp
@@ -15,7 +15,8 @@ namespace ui {
 
 namespace {
 
-constexpr float kGutterPadding = 6.0f;
+constexpr float kEditorUiScale = 1.5f;
+constexpr float kGutterPadding = 9.0f;
 constexpr float kScrollbarWidth = 8.0f;
 constexpr float kTextPadLeft = 4.0f;
 constexpr size_t kMaxUndoSnapshots = 100;
@@ -403,7 +404,7 @@ bool draw_color_picker(Rectangle picker_rect, text_editor_state& state, text_edi
         draw_text_auto(TextFormat("%c", channel_labels[channel]),
                        {row_rect.x, row_rect.y + 4.0f}, 13.0f, 0.5f, g_theme->text_secondary);
 
-        DrawRectangleRec(track_rect, g_theme->slider_track);
+        draw_rect_f(track_rect, g_theme->slider_track);
         const float ratio = static_cast<float>(*channel_ptrs[channel]) / 255.0f;
         draw_rect_f(track_rect.x, track_rect.y, track_rect.width * ratio, track_rect.height, channel_colors[channel]);
         const float knob_x = track_rect.x + track_rect.width * ratio;
@@ -447,7 +448,7 @@ void draw_squiggly_line(float x0, float x1, float y, Color color) {
         float nx = std::min(x + wave_width * 0.5f, x1);
         float y0 = y;
         float y1 = y + ((static_cast<int>((x - x0) / (wave_width * 0.5f)) % 2 == 0) ? wave_height : -wave_height);
-        DrawLineEx({x, y0}, {nx, y1}, 1.5f, color);
+        draw_line_ex({x, y0}, {nx, y1}, 1.5f, color);
         x = nx;
     }
 }
@@ -688,13 +689,14 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                                     text_editor_completer completer) {
     text_editor_result result;
     bool should_ensure_cursor_visible = false;
-    const float line_height = static_cast<float>(style.font_size) + style.line_spacing;
-    const float gutter_width = measure_text_width("000", style) + kGutterPadding * 2;
+    const float scaled_line_spacing = style.line_spacing * kEditorUiScale;
+    const float line_height = text_layout_font_size(static_cast<float>(style.font_size)) + scaled_line_spacing;
+    const float gutter_width = measure_text_width("000", style) + kGutterPadding * 2.0f;
     constexpr int kMaxCompletionItems = 8;
-    constexpr float kCompletionRowHeight = 26.0f;
-    constexpr float kCompletionPadX = 8.0f;
-    constexpr float kCompletionMinWidth = 180.0f;
-    constexpr float kCompletionOffsetX = 18.0f;
+    constexpr float kCompletionRowHeight = 39.0f;
+    constexpr float kCompletionPadX = 12.0f;
+    constexpr float kCompletionMinWidth = 270.0f;
+    constexpr float kCompletionOffsetX = 27.0f;
     const float completion_font_size = static_cast<float>(std::max(style.font_size - 2, 12));
     const float completion_letter_spacing = std::max(style.letter_spacing, 1.0f);
 
@@ -1112,12 +1114,12 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
     begin_scissor_rect(rect);
 
     // Background
-    DrawRectangleRec(rect, g_theme->section);
-    DrawRectangleLinesEx(rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
+    draw_rect_f(rect, g_theme->section);
+    draw_rect_lines(rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
 
     // Gutter background
     Rectangle gutter_bg = {rect.x + 1.5f, rect.y + 1.5f, gutter_width - 1.5f, rect.height - 3.0f};
-    DrawRectangleRec(gutter_bg, with_alpha(g_theme->panel, 200));
+    draw_rect_f(gutter_bg, with_alpha(g_theme->panel, 200));
 
     // Visible line range
     int first_visible = std::max(0, static_cast<int>(state.scroll_offset / line_height));
@@ -1148,9 +1150,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
                 x1 += measure_text_width(" ", style);  // extend past line end
             }
             if (x1 > x0) {
-                DrawRectangle(static_cast<int>(x0), static_cast<int>(y),
-                              static_cast<int>(x1 - x0), static_cast<int>(line_height),
-                              Color{60, 120, 220, 80});
+                draw_rect_f({x0, y, x1 - x0, line_height}, Color{60, 120, 220, 80});
             }
         }
 
@@ -1227,8 +1227,7 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
             float cursor_x = text_rect.x + kTextPadLeft +
                             measure_line_prefix_width(cur_line, state.cursor_col, style, highlighter);
             float cursor_y = rect.y + state.cursor_line * line_height - state.scroll_offset;
-            DrawRectangle(static_cast<int>(cursor_x), static_cast<int>(cursor_y + 1),
-                          2, static_cast<int>(line_height - 2), g_theme->text);
+            draw_rect_f({cursor_x, cursor_y + 1.0f, 2.0f, line_height - 2.0f}, g_theme->text);
         }
     }
 
@@ -1263,8 +1262,8 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
             menu_rect.y = rect.y + 4.0f;
         }
 
-        DrawRectangleRec(menu_rect, with_alpha(g_theme->panel, 245));
-        DrawRectangleLinesEx(menu_rect, 1.0f, g_theme->border_light);
+        draw_rect_f(menu_rect, with_alpha(g_theme->panel, 245));
+        draw_rect_lines(menu_rect, 1.0f, g_theme->border_light);
 
         for (int i = 0; i < visible_items; ++i) {
             Rectangle item_rect = {
@@ -1275,9 +1274,9 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
             };
             const bool hovered_item = CheckCollisionPointRec(mouse, item_rect);
             const bool selected_item = i == state.completion_index;
-            DrawRectangleRec(item_rect,
-                             selected_item ? g_theme->row_selected :
-                             (hovered_item ? g_theme->row_hover : BLANK));
+            draw_rect_f(item_rect,
+                        selected_item ? g_theme->row_selected :
+                        (hovered_item ? g_theme->row_hover : BLANK));
             draw_text_auto(completion.items[static_cast<size_t>(i)].label.c_str(),
                            {item_rect.x + kCompletionPadX, item_rect.y + 4.0f},
                            completion_font_size, completion_letter_spacing,

--- a/src/ui/ui_text_input.h
+++ b/src/ui/ui_text_input.h
@@ -11,6 +11,11 @@
 
 namespace ui {
 
+inline constexpr float kTextInputBaselineNudge = 2.25f;
+inline constexpr float kTextInputSelectionInsetY = 7.5f;
+inline constexpr float kTextInputSelectionInsetTotalY = 15.0f;
+inline constexpr float kTextInputCursorWidth = 2.25f;
+
 using text_input_filter = bool (*)(int codepoint, const std::string& current_value);
 
 struct text_input_state {
@@ -464,8 +469,8 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
 
     update_text_input_scroll(state, text_rect.width, font_size);
 
-    DrawRectangleRec(input_rect, state.active ? with_alpha(g_theme->panel, 255) : with_alpha(g_theme->section, 255));
-    DrawRectangleLinesEx(input_rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
+    draw_rect_f(input_rect, state.active ? with_alpha(g_theme->panel, 255) : with_alpha(g_theme->section, 255));
+    draw_rect_lines(input_rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
     draw_text_in_rect(label, font_size, label_rect,
                       state.active ? g_theme->text : g_theme->text_secondary, text_align::left);
 
@@ -475,14 +480,15 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
     }
 
     const Color text_color = state.value.empty() && !state.active ? g_theme->text_hint : g_theme->text;
-    const float text_y = text_rect.y + (text_rect.height - static_cast<float>(font_size)) * 0.5f + 1.5f;
+    const float layout_font_size = text_layout_font_size(static_cast<float>(font_size));
+    const float text_y = text_rect.y + (text_rect.height - layout_font_size) * 0.5f + kTextInputBaselineNudge;
 
     if (!state.active && !state.value.empty()) {
         draw_marquee_text(display_value.c_str(), text_rect.x, text_y, font_size, text_color,
                           text_rect.width, GetTime());
     } else if (!state.active) {
         draw_text_in_rect(display_value.c_str(), font_size,
-                          {text_rect.x, text_rect.y + 1.5f, text_rect.width, text_rect.height},
+                          {text_rect.x, text_rect.y + kTextInputBaselineNudge, text_rect.width, text_rect.height},
                           text_color, text_align::left);
     } else {
         begin_scissor_rect(input_rect);
@@ -495,8 +501,8 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
             const float selection_end_x = text_rect.x +
                                           text_input_prefix_width(state.value, selection_end, font_size) -
                                           state.scroll_x;
-            draw_rect_span({selection_x, input_rect.y + 5.0f,
-                            selection_end_x - selection_x, input_rect.height - 10.0f},
+            draw_rect_span({selection_x, input_rect.y + kTextInputSelectionInsetY,
+                            selection_end_x - selection_x, input_rect.height - kTextInputSelectionInsetTotalY},
                            with_alpha(g_theme->row_selected, 255));
         }
 
@@ -507,7 +513,8 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
             const float cursor_x = text_rect.x +
                                    text_input_prefix_width(state.value, state.cursor, font_size) -
                                    state.scroll_x;
-            draw_rect_span({cursor_x, input_rect.y + 5.0f, 1.5f, input_rect.height - 10.0f},
+            draw_rect_span({cursor_x, input_rect.y + kTextInputSelectionInsetY, kTextInputCursorWidth,
+                            input_rect.height - kTextInputSelectionInsetTotalY},
                            g_theme->text);
         }
 


### PR DESCRIPTION
## 概要
- UI の仮想解像度を 1920x1080 前提に再調整
- タイトル、ランキング、オンラインカタログ、ログイン、リザルト、設定、エディタ等のレイアウトを 1080p 向けに整理
- `ui::from_720p()` を全使用箇所から削除し、描画スナップと高解像 UI RenderTexture を追加
- 文字見切れ、ランキング表示、オンラインカタログカード、検索バー、スペクトラム等の表示崩れを調整

## 確認
- `git diff --check`
- `cmake --build cmake-build-codex --target raythm -j 2`

Refs #256
