### PR TITLE
[codex] 権威スコアルールセット同期を実装

### DIFF
--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -28,11 +28,8 @@
 
 namespace {
 
-constexpr std::string_view kFileHeaderV1 = "RAYTHM_LOCAL_RANKING_V1";
-constexpr std::string_view kFileHeaderV2 = "RAYTHM_LOCAL_RANKING_V2";
-constexpr std::string_view kFileHeaderV3 = "RAYTHM_LOCAL_RANKING_V3";
-constexpr std::string_view kFileHeaderV4 = "RAYTHM_LOCAL_RANKING_V4";
-constexpr std::string_view kFileHeaderV5 = "RAYTHM_LOCAL_RANKING_V5";
+constexpr char kLocalRankingFileHeader[] = "RAYTHM_LOCAL_RANKING_V6";
+constexpr char kAuthoritativeAcceptedInput[] = "note_results_v1";
 constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
 
 std::string trim(std::string_view value) {
@@ -199,6 +196,8 @@ std::optional<std::vector<note_result_entry>> parse_note_results(std::string_vie
 struct stored_local_record {
     std::string recorded_at;
     std::string player_display_name;
+    std::string scoring_ruleset_version;
+    std::string scoring_accepted_input = std::string(kAuthoritativeAcceptedInput);
     std::vector<note_result_entry> note_results;
     std::optional<ranking_service::entry> legacy_entry;
 };
@@ -230,7 +229,7 @@ ranking_service::entry resolve_record_entry(const stored_local_record& record,
 
 std::string serialize_records(const std::vector<stored_local_record>& records) {
     std::ostringstream out;
-    out << kFileHeaderV5 << '\n';
+    out << kLocalRankingFileHeader << '\n';
     for (const stored_local_record& record : records) {
         if (record.legacy_entry.has_value()) {
             const ranking_service::entry& entry = *record.legacy_entry;
@@ -248,6 +247,8 @@ std::string serialize_records(const std::vector<stored_local_record>& records) {
         out << "record" << '\t'
             << record.recorded_at << '\t'
             << sanitize_player_display_name(record.player_display_name) << '\t'
+            << record.scoring_ruleset_version << '\t'
+            << record.scoring_accepted_input << '\t'
             << serialize_note_results(record.note_results) << '\n';
     }
     return out.str();
@@ -261,7 +262,7 @@ std::vector<stored_local_record> parse_records(const std::string& content) {
         return records;
     }
     const std::string header = trim(line);
-    if (header != kFileHeaderV5) {
+    if (header != kLocalRankingFileHeader) {
         return records;
     }
 
@@ -286,10 +287,15 @@ std::vector<stored_local_record> parse_records(const std::string& content) {
             const std::string kind = trim(kind_token);
 
             if (kind == "record") {
+                std::string ruleset_version_token, accepted_input_token;
                 std::string note_results_token;
-                if (!std::getline(row, note_results_token)) {
+                if (!std::getline(row, ruleset_version_token, '\t') ||
+                    !std::getline(row, accepted_input_token, '\t') ||
+                    !std::getline(row, note_results_token)) {
                     continue;
                 }
+                record.scoring_ruleset_version = trim(ruleset_version_token);
+                record.scoring_accepted_input = trim(accepted_input_token);
                 const std::optional<std::vector<note_result_entry>> note_results =
                     parse_note_results(note_results_token);
                 if (!note_results.has_value()) {
@@ -327,6 +333,21 @@ std::vector<stored_local_record> parse_records(const std::string& content) {
     }
 
     return records;
+}
+
+bool is_authoritative_local_record(const stored_local_record& record) {
+    return !record.legacy_entry.has_value() &&
+           !record.note_results.empty() &&
+           !record.scoring_ruleset_version.empty() &&
+           record.scoring_accepted_input == kAuthoritativeAcceptedInput;
+}
+
+void retain_authoritative_local_records(std::vector<stored_local_record>& records) {
+    records.erase(
+        std::remove_if(records.begin(), records.end(), [](const stored_local_record& record) {
+            return !is_authoritative_local_record(record);
+        }),
+        records.end());
 }
 
 bool ranking_entry_better(const ranking_service::entry& left, const ranking_service::entry& right) {
@@ -855,6 +876,9 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
     const scoring_ruleset_runtime::ruleset ruleset = scoring_ruleset_runtime::current_ruleset();
     result.entries.reserve(records.size());
     for (const stored_local_record& record : records) {
+        if (!is_authoritative_local_record(record)) {
+            continue;
+        }
         result.entries.push_back(resolve_record_entry(record, ruleset));
     }
     std::sort(result.entries.begin(), result.entries.end(), ranking_entry_better);
@@ -881,6 +905,8 @@ local_submit_result submit_local_result_detailed(const chart_meta& chart, const 
     }
 
     std::vector<stored_local_record> records = load_local_records(chart.chart_id);
+    retain_authoritative_local_records(records);
+
     const scoring_ruleset_runtime::ruleset ruleset = scoring_ruleset_runtime::current_ruleset();
     std::vector<entry> entries;
     entries.reserve(records.size());
@@ -891,28 +917,23 @@ local_submit_result submit_local_result_detailed(const chart_meta& chart, const 
 
     const std::string recorded_at = current_timestamp_utc();
     const std::string player_display_name = current_local_player_display_name();
-    stored_local_record new_record{
-        .recorded_at = recorded_at,
-        .player_display_name = player_display_name,
-    };
-    entry new_entry;
-    if (!result.note_results.empty()) {
-        new_record.note_results = result.note_results;
-        new_entry = resolve_record_entry(new_record, ruleset);
-    } else {
-        new_entry = entry{
-            .placement = 0,
-            .player_display_name = player_display_name,
-            .accuracy = result.accuracy,
-            .is_full_combo = result.is_full_combo,
-            .max_combo = result.max_combo,
-            .score = result.score,
-            .recorded_at = recorded_at,
-            .verified = false,
-            .resolved_clear_rank = result.clear_rank,
-        };
-        new_record.legacy_entry = new_entry;
+    if (result.note_results.empty()) {
+        return submission;
     }
+
+    stored_local_record new_record;
+    new_record.recorded_at = recorded_at;
+    new_record.player_display_name = player_display_name;
+    new_record.scoring_ruleset_version =
+        result.scoring_ruleset_version.empty()
+            ? ruleset.ruleset_version
+            : result.scoring_ruleset_version;
+    new_record.scoring_accepted_input =
+        result.scoring_accepted_input.empty()
+            ? std::string(kAuthoritativeAcceptedInput)
+            : result.scoring_accepted_input;
+    new_record.note_results = result.note_results;
+    entry new_entry = resolve_record_entry(new_record, ruleset);
 
     submission.best_updated =
         entries.empty() || ranking_entry_better(new_entry, entries.front());
@@ -1016,8 +1037,26 @@ online_submit_result submit_online_result(const song_data& song,
     }
 
     if (!ruleset->active ||
-        ruleset->accepted_input != "note_results_v1") {
+        ruleset->accepted_input != kAuthoritativeAcceptedInput) {
         submission.message = "The server does not accept this ranking submission format.";
+        return submission;
+    }
+
+    const std::string submission_ruleset_version =
+        result.scoring_ruleset_version.empty()
+            ? ruleset->ruleset_version
+            : result.scoring_ruleset_version;
+    const std::string submission_input_format =
+        result.scoring_accepted_input.empty()
+            ? std::string(kAuthoritativeAcceptedInput)
+            : result.scoring_accepted_input;
+    if (submission_input_format != ruleset->accepted_input) {
+        submission.message = "The score input format changed. Start the chart again to submit online ranking.";
+        return submission;
+    }
+    if (submission_ruleset_version != ruleset->ruleset_version) {
+        fetch_and_cache_scoring_ruleset(stored->server_url);
+        submission.message = "The scoring ruleset changed. Start the chart again to submit online ranking.";
         return submission;
     }
 
@@ -1030,7 +1069,7 @@ online_submit_result submit_online_result(const song_data& song,
             chart.chart_id,
             result,
             recorded_at,
-            ruleset->ruleset_version);
+            submission_ruleset_version);
 
     if (request.unauthorized) {
         const auth::operation_result restored = auth::restore_saved_session();
@@ -1048,7 +1087,7 @@ online_submit_result submit_online_result(const song_data& song,
             chart.chart_id,
             result,
             recorded_at,
-            ruleset->ruleset_version);
+            submission_ruleset_version);
     }
 
     submission.success = request.success;

--- a/src/gameplay/score_system.cpp
+++ b/src/gameplay/score_system.cpp
@@ -20,15 +20,6 @@ size_t judge_index(judge_result result) {
     return 4;
 }
 
-double combo_score_multiplier(int combo, int total_notes) {
-    if (total_notes <= 0) {
-        return 1.0;
-    }
-
-    const double progress = std::clamp(static_cast<double>(combo) / static_cast<double>(total_notes), 0.0, 1.0);
-    return progress * progress;
-}
-
 double max_raw_score_for_total_notes(const scoring_ruleset_runtime::ruleset& ruleset, int total_notes) {
     if (total_notes <= 0) {
         return 0.0;
@@ -38,7 +29,7 @@ double max_raw_score_for_total_notes(const scoring_ruleset_runtime::ruleset& rul
     for (int combo = 1; combo <= total_notes; ++combo) {
         max_score += static_cast<double>(
             scoring_ruleset_runtime::judge_value_for(ruleset, judge_result::perfect)) *
-            combo_score_multiplier(combo, total_notes);
+            scoring_ruleset_runtime::score_multiplier_for(ruleset, combo, total_notes);
     }
     return max_score;
 }
@@ -85,7 +76,8 @@ void score_system::on_judge(const judge_event& event) {
     }
 
     const int raw = scoring_ruleset_runtime::judge_value_for(ruleset_, event.result);
-    raw_score_ += static_cast<double>(raw) * combo_score_multiplier(combo_, total_notes_);
+    raw_score_ += static_cast<double>(raw) *
+                  scoring_ruleset_runtime::score_multiplier_for(ruleset_, combo_, total_notes_);
 }
 
 int score_system::get_score() const {
@@ -124,6 +116,8 @@ result_data score_system::get_result_data() const {
     result.is_all_perfect = judged_notes_ > 0 &&
                             judge_counts_[judge_index(judge_result::perfect)] == judged_notes_;
     result.accuracy = get_live_accuracy();
+    result.scoring_ruleset_version = ruleset_.ruleset_version;
+    result.scoring_accepted_input = ruleset_.accepted_input;
     result.note_results = note_results_;
 
     result.clear_rank = scoring_ruleset_runtime::compute_rank_for(ruleset_, result.accuracy, result.is_full_combo);

--- a/src/gameplay/scoring_ruleset_runtime.cpp
+++ b/src/gameplay/scoring_ruleset_runtime.cpp
@@ -5,6 +5,9 @@
 
 namespace {
 
+constexpr double kComboLightBaseWeight = 0.75;
+constexpr double kComboLightProgressWeight = 0.25;
+
 size_t judge_index(judge_result result) {
     switch (result) {
         case judge_result::perfect: return 0;
@@ -60,6 +63,18 @@ int judge_value_for(const ruleset& ruleset_data, judge_result result) {
     return ruleset_data.judge_values[judge_index(result)];
 }
 
+double score_multiplier_for(const ruleset& ruleset_data, int combo, int total_notes) {
+    if (total_notes <= 0) {
+        return 1.0;
+    }
+
+    const double progress = std::clamp(static_cast<double>(combo) / static_cast<double>(total_notes), 0.0, 1.0);
+    if (ruleset_data.score_model == "combo-light-v1") {
+        return kComboLightBaseWeight + progress * progress * kComboLightProgressWeight;
+    }
+    return progress * progress;
+}
+
 rank compute_rank_for(const ruleset& ruleset_data, float accuracy, bool is_full_combo) {
     for (const rank_threshold& threshold : ruleset_data.rank_thresholds) {
         if (accuracy < threshold.min_accuracy) {
@@ -86,17 +101,10 @@ computed_result compute_result_for(const ruleset& ruleset_data,
     double raw_score = 0.0;
     const int total_notes = static_cast<int>(note_results.size());
 
-    auto combo_score_multiplier = [total_notes](int combo_value) {
-        if (total_notes <= 0) {
-            return 1.0;
-        }
-        const double progress = std::clamp(static_cast<double>(combo_value) / static_cast<double>(total_notes), 0.0, 1.0);
-        return progress * progress;
-    };
-
     double max_raw_score = 0.0;
     for (int max_combo_index = 1; max_combo_index <= total_notes; ++max_combo_index) {
-        max_raw_score += static_cast<double>(perfect_value) * combo_score_multiplier(max_combo_index);
+        max_raw_score += static_cast<double>(perfect_value) *
+                         score_multiplier_for(ruleset_data, max_combo_index, total_notes);
     }
 
     double earned_achievement_points = 0.0;
@@ -112,7 +120,8 @@ computed_result compute_result_for(const ruleset& ruleset_data,
         }
 
         const int judge_value = judge_value_for(ruleset_data, note_result.result);
-        raw_score += static_cast<double>(judge_value) * combo_score_multiplier(combo);
+        raw_score += static_cast<double>(judge_value) *
+                     score_multiplier_for(ruleset_data, combo, total_notes);
         if (note_result.result != judge_result::miss) {
             earned_achievement_points += static_cast<double>(judge_value);
         }

--- a/src/gameplay/scoring_ruleset_runtime.h
+++ b/src/gameplay/scoring_ruleset_runtime.h
@@ -38,6 +38,7 @@ ruleset current_ruleset();
 void apply_server_ruleset(const ruleset& ruleset_data);
 
 int judge_value_for(const ruleset& ruleset_data, judge_result result);
+double score_multiplier_for(const ruleset& ruleset_data, int combo, int total_notes);
 rank compute_rank_for(const ruleset& ruleset_data, float accuracy, bool is_full_combo);
 computed_result compute_result_for(const ruleset& ruleset_data,
                                    const std::vector<note_result_entry>& note_results);

--- a/src/models/data_models.h
+++ b/src/models/data_models.h
@@ -197,5 +197,7 @@ struct result_data {
     bool failed = false;
     bool is_full_combo = false;
     bool is_all_perfect = false;
+    std::string scoring_ruleset_version;
+    std::string scoring_accepted_input = "note_results_v1";
     std::vector<note_result_entry> note_results;
 };

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -12,6 +12,7 @@
 #include "player_note_offsets.h"
 #include "play_chart_filter.h"
 #include "play_speed_compensation.h"
+#include "ranking_service.h"
 
 namespace {
 
@@ -137,6 +138,9 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
     state.timing_engine.init(state.chart_data->timing_events, state.chart_data->meta.resolution, effective_offset_ms);
     state.start_ms = std::max(0.0, state.timing_engine.tick_to_ms(state.start_tick));
     state.judge_system.init(state.chart_data->notes, state.timing_engine);
+    if (!state.editor_resume_state.has_value()) {
+        ranking_service::refresh_scoring_ruleset_cache_for_chart_start(state.chart_data->meta, false);
+    }
     state.score_system.init(calculate_total_judge_points(*state.chart_data));
     state.gauge = gauge{};
 

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -942,7 +942,7 @@ void title_scene::on_enter() {
     play_state_.ranking_panel.selected_source = ranking_service::source::local;
     auth_overlay::refresh_auth_state(play_state_.auth);
     scoring_ruleset_loading_ = false;
-    request_scoring_ruleset_warm(false);
+    request_scoring_ruleset_warm(true);
     play_state_.recent_result_offset = recent_result_offset_;
     if (play_intro_fade_) {
         intro_fade_.restart(scene_fade::direction::in, 1.0f, 1.0f);

--- a/src/tests/ranking_service_smoke.cpp
+++ b/src/tests/ranking_service_smoke.cpp
@@ -1,9 +1,61 @@
 #include <cstdlib>
+#include <cstring>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "app_paths.h"
 #include "ranking_service.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#include <wincrypt.h>
+#endif
+
+namespace {
+
+bool write_local_ranking_plaintext(const std::string& chart_id, const std::string& plaintext) {
+    app_paths::ensure_directories();
+    const std::filesystem::path path = app_paths::local_ranking_path(chart_id);
+
+#ifdef _WIN32
+    constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
+    DATA_BLOB input_blob{};
+    input_blob.pbData = reinterpret_cast<BYTE*>(const_cast<char*>(plaintext.data()));
+    input_blob.cbData = static_cast<DWORD>(plaintext.size());
+
+    DATA_BLOB entropy_blob{};
+    entropy_blob.pbData = reinterpret_cast<BYTE*>(const_cast<wchar_t*>(kEntropyLabel));
+    entropy_blob.cbData = static_cast<DWORD>(sizeof(kEntropyLabel));
+
+    DATA_BLOB output_blob{};
+    if (!CryptProtectData(&input_blob, L"raythm local ranking", &entropy_blob, nullptr, nullptr, 0, &output_blob)) {
+        return false;
+    }
+
+    std::vector<std::byte> encrypted(output_blob.cbData);
+    std::memcpy(encrypted.data(), output_blob.pbData, output_blob.cbData);
+    LocalFree(output_blob.pbData);
+
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+    output.write(reinterpret_cast<const char*>(encrypted.data()), static_cast<std::streamsize>(encrypted.size()));
+    return output.good();
+#else
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << plaintext;
+    return output.good();
+#endif
+}
+
+}  // namespace
 
 int main() {
     namespace fs = std::filesystem;
@@ -84,6 +136,76 @@ int main() {
         ranking_service::load_chart_ranking(chart.chart_id, ranking_service::source::online, 50);
     if (online_listing.available || online_listing.message.empty()) {
         std::cerr << "Online unavailable listing failed\n";
+        return EXIT_FAILURE;
+    }
+
+    chart_meta legacy_chart;
+    legacy_chart.chart_id = "legacy-chart";
+    const std::string legacy_content =
+        "RAYTHM_LOCAL_RANKING_V6\n"
+        "legacy\t2026-04-20T00:00:00Z\tGuest\t100.0000\t1\t999\t999999\tss\n";
+    if (!write_local_ranking_plaintext(legacy_chart.chart_id, legacy_content)) {
+        std::cerr << "Failed to prepare legacy local ranking\n";
+        return EXIT_FAILURE;
+    }
+
+    const ranking_service::listing hidden_legacy_listing =
+        ranking_service::load_chart_ranking(legacy_chart.chart_id, ranking_service::source::local, 50);
+    if (!hidden_legacy_listing.entries.empty()) {
+        std::cerr << "Legacy local rankings should be hidden\n";
+        return EXIT_FAILURE;
+    }
+
+    result_data migrated_result;
+    migrated_result.note_results = {
+        {.event_index = 0, .result = judge_result::great, .offset_ms = 3.0},
+        {.event_index = 1, .result = judge_result::good, .offset_ms = 8.0},
+    };
+
+    const ranking_service::local_submit_result migrated_submission =
+        ranking_service::submit_local_result_detailed(legacy_chart, migrated_result);
+    if (!migrated_submission.success || !migrated_submission.best_updated) {
+        std::cerr << "Legacy local rankings should not block migrated records\n";
+        return EXIT_FAILURE;
+    }
+
+    const ranking_service::listing migrated_listing =
+        ranking_service::load_chart_ranking(legacy_chart.chart_id, ranking_service::source::local, 50);
+    if (migrated_listing.entries.size() != 1 ||
+        migrated_listing.entries.front().score == 999999) {
+        std::cerr << "Migrated local ranking listing failed\n";
+        return EXIT_FAILURE;
+    }
+
+    chart_meta old_v5_chart;
+    old_v5_chart.chart_id = "old-v5-chart";
+    const std::string old_v5_content =
+        "RAYTHM_LOCAL_RANKING_V5\n"
+        "record\t2026-04-20T00:00:00Z\tGuest\t0,perfect,0.000;1,perfect,0.000\n";
+    if (!write_local_ranking_plaintext(old_v5_chart.chart_id, old_v5_content)) {
+        std::cerr << "Failed to prepare old V5 local ranking\n";
+        return EXIT_FAILURE;
+    }
+
+    const ranking_service::listing hidden_old_v5_listing =
+        ranking_service::load_chart_ranking(old_v5_chart.chart_id, ranking_service::source::local, 50);
+    if (!hidden_old_v5_listing.entries.empty()) {
+        std::cerr << "Old V5 local rankings should be hidden\n";
+        return EXIT_FAILURE;
+    }
+
+    const ranking_service::local_submit_result old_v5_migrated_submission =
+        ranking_service::submit_local_result_detailed(old_v5_chart, migrated_result);
+    if (!old_v5_migrated_submission.success || !old_v5_migrated_submission.best_updated) {
+        std::cerr << "Old V5 local rankings should not block new V6 records\n";
+        return EXIT_FAILURE;
+    }
+
+    const ranking_service::listing old_v5_migrated_listing =
+        ranking_service::load_chart_ranking(old_v5_chart.chart_id, ranking_service::source::local, 50);
+    if (old_v5_migrated_listing.entries.size() != 1 ||
+        old_v5_migrated_listing.entries.front().score == 1000000) {
+        std::cerr << "Old V5 local ranking migration failed\n";
         return EXIT_FAILURE;
     }
 

--- a/src/tests/score_system_smoke.cpp
+++ b/src/tests/score_system_smoke.cpp
@@ -49,6 +49,46 @@ int main() {
         return EXIT_FAILURE;
     }
 
+    scoring_ruleset_runtime::ruleset custom_ruleset = scoring_ruleset_runtime::make_default_ruleset();
+    custom_ruleset.ruleset_version = "smoke-ruleset";
+    custom_ruleset.max_score = 123456;
+    scoring_ruleset_runtime::apply_server_ruleset(custom_ruleset);
+    score_system ruleset_score;
+    ruleset_score.init(1);
+    ruleset_score.on_judge({judge_result::perfect, 0.0, 0});
+    const result_data ruleset_result = ruleset_score.get_result_data();
+    if (ruleset_result.scoring_ruleset_version != "smoke-ruleset" ||
+        ruleset_result.scoring_accepted_input != "note_results_v1" ||
+        ruleset_result.score != 123456) {
+        std::cerr << "Score result should retain the ruleset used during play\n";
+        return EXIT_FAILURE;
+    }
+    scoring_ruleset_runtime::apply_server_ruleset(scoring_ruleset_runtime::make_default_ruleset());
+
+    score_system combo_heavy_score;
+    combo_heavy_score.init(4);
+    combo_heavy_score.on_judge({judge_result::perfect, 0.0, 0});
+    combo_heavy_score.on_judge({judge_result::miss, 0.0, 0});
+    combo_heavy_score.on_judge({judge_result::perfect, 0.0, 0});
+    combo_heavy_score.on_judge({judge_result::perfect, 0.0, 0});
+    const int combo_heavy_result_score = combo_heavy_score.get_score();
+
+    scoring_ruleset_runtime::ruleset combo_light_ruleset = scoring_ruleset_runtime::make_default_ruleset();
+    combo_light_ruleset.score_model = "combo-light-v1";
+    combo_light_ruleset.ruleset_version = "combo-light-smoke";
+    scoring_ruleset_runtime::apply_server_ruleset(combo_light_ruleset);
+    score_system combo_light_score;
+    combo_light_score.init(4);
+    combo_light_score.on_judge({judge_result::perfect, 0.0, 0});
+    combo_light_score.on_judge({judge_result::miss, 0.0, 0});
+    combo_light_score.on_judge({judge_result::perfect, 0.0, 0});
+    combo_light_score.on_judge({judge_result::perfect, 0.0, 0});
+    if (combo_light_score.get_score() <= combo_heavy_result_score) {
+        std::cerr << "Combo-light score model should reduce the combo break penalty\n";
+        return EXIT_FAILURE;
+    }
+    scoring_ruleset_runtime::apply_server_ruleset(scoring_ruleset_runtime::make_default_ruleset());
+
     gauge life_gauge;
     life_gauge.on_judge(judge_result::perfect);
     life_gauge.on_judge(judge_result::great);


### PR DESCRIPTION
## 概要
- 起動時と対象譜面の開始前に、サーバーのスコアルールセットを取得して適用するようにしました
- プレイ中に使った `ruleset_version` と入力形式をリザルトへ保持し、送信時にサーバー側とずれていた場合はオンラインランキング送信を止めるようにしました
- legacy / V6以前のローカルランキングを表示対象から外し、正式なローカルランキングは `note_results` ベースに統一しました
- ルールセット情報、`combo-light-v1`、legacyローカルランキング非表示の smoke テストを追加しました

## 検証
- `cmake --build cmake-build-codex --target ranking_service_smoke score_system_smoke raythm`
- `cmake-build-codex\score_system_smoke.exe`
- `cmake-build-codex\ranking_service_smoke.exe`