### PR TITLE
[codex] ACCOUNTから新規登録できるようにする

### DIFF
--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -6,13 +6,7 @@
 #include <thread>
 #include <utility>
 
-#include "core/window_dialog_support.h"
-
 namespace {
-
-std::string register_web_url() {
-    return auth::normalize_server_url(auth::kDefaultServerUrl) + "/register";
-}
 
 template <typename Fn>
 std::future<auth::operation_result> start_auth_task(Fn task) {
@@ -60,20 +54,13 @@ void start_request(controller& controller_state,
         return;
     }
 
-    if (command == song_select::login_dialog_command::open_register_web) {
-        const bool opened = window_dialog_support::open_url(register_web_url());
-        dialog_state.status_message = opened
-            ? "Opened the account page in your browser."
-            : "Failed to open the account page.";
-        dialog_state.status_message_is_error = !opened;
-        return;
-    }
-
     controller_state.request_active = true;
     dialog_state.status_message_is_error = false;
     const std::string server_url = auth::kDefaultServerUrl;
+    const std::string display_name = dialog_state.display_name_input.value;
     const std::string email = dialog_state.email_input.value;
     const std::string password = dialog_state.password_input.value;
+    const std::string password_confirmation = dialog_state.password_confirmation_input.value;
 
     switch (command) {
     case song_select::login_dialog_command::request_restore:
@@ -88,13 +75,30 @@ void start_request(controller& controller_state,
             return auth::login_user(server_url, email, password);
         });
         break;
+    case song_select::login_dialog_command::request_register:
+        if (display_name.empty() || email.empty() || password.empty()) {
+            controller_state.request_active = false;
+            dialog_state.status_message = "Name, email, and password are required.";
+            dialog_state.status_message_is_error = true;
+            break;
+        }
+        if (password != password_confirmation) {
+            controller_state.request_active = false;
+            dialog_state.status_message = "Passwords do not match.";
+            dialog_state.status_message_is_error = true;
+            break;
+        }
+        dialog_state.status_message = "Creating account...";
+        controller_state.request_future = start_auth_task([server_url, email, display_name, password]() {
+            return auth::register_user(server_url, email, display_name, password);
+        });
+        break;
     case song_select::login_dialog_command::request_logout:
         dialog_state.status_message = "Logging out...";
         controller_state.request_future = start_auth_task([]() {
             return auth::logout_saved_session();
         });
         break;
-    case song_select::login_dialog_command::open_register_web:
     case song_select::login_dialog_command::none:
     case song_select::login_dialog_command::close:
         controller_state.request_active = false;
@@ -148,6 +152,7 @@ poll_result poll_request(controller& controller_state,
     const auth::operation_result result = controller_state.request_future.get();
     refresh_auth_state(auth_state);
     dialog_state.password_input.value.clear();
+    dialog_state.password_confirmation_input.value.clear();
     dialog_state.status_message = result.message;
     dialog_state.status_message_is_error = !result.success;
 

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -1,5 +1,7 @@
 #include "song_select/song_select_login_dialog.h"
 
+#include <array>
+
 #include "song_select/song_select_layout.h"
 #include "theme.h"
 #include "tween.h"
@@ -9,6 +11,7 @@ namespace {
 
 constexpr float kDialogWidth = 540.0f;
 constexpr float kLoginDialogHeight = 462.0f;
+constexpr float kSignupDialogHeight = 594.0f;
 constexpr float kAccountDialogHeight = 387.0f;
 constexpr float kDialogOffsetY = 27.0f;
 constexpr float kDialogPaddingX = 27.0f;
@@ -16,14 +19,14 @@ constexpr float kTitleHeight = 39.0f;
 constexpr float kSubtitleHeight = 27.0f;
 constexpr float kHeaderTop = 27.0f;
 constexpr float kHeaderGap = 9.0f;
-constexpr float kBodyTop = 129.0f;
+constexpr float kTabTop = 105.0f;
+constexpr float kTabHeight = 42.0f;
+constexpr float kBodyTop = 168.0f;
 constexpr float kRowHeight = 54.0f;
 constexpr float kRowGap = 12.0f;
 constexpr float kButtonHeight = 54.0f;
 constexpr float kButtonGap = 12.0f;
 constexpr float kPrimaryButtonWidth = 192.0f;
-constexpr float kSecondaryButtonWidth = 246.0f;
-constexpr float kHelperTextHeight = 27.0f;
 constexpr float kScreenEdgeMargin = 18.0f;
 constexpr float kOpenAnimOffsetY = 27.0f;
 constexpr float kFooterMarginBottom = 27.0f;
@@ -38,16 +41,14 @@ constexpr float kAccountButtonWidth = 138.0f;
 constexpr float kStatusOffsetAboveFooter = 42.0f;
 constexpr float kStatusLineHeight = 30.0f;
 constexpr float kTextInputLabelWidth = 135.0f;
-constexpr float kLoginActionTop = 249.0f;
+constexpr float kFormMessageGap = 18.0f;
 constexpr float kMessageHeight = 27.0f;
 constexpr float kLoginButtonOffsetY = 42.0f;
-constexpr float kHelperOffsetY = 108.0f;
-constexpr float kWebButtonOffsetY = 141.0f;
 
 Rectangle dialog_rect_for(const song_select::state& state) {
-    const float dialog_height = state.auth.logged_in
-        ? kAccountDialogHeight
-        : kLoginDialogHeight;
+    const float dialog_height = state.auth.logged_in ? kAccountDialogHeight
+        : (state.login_dialog.mode == song_select::login_dialog_mode::signup ? kSignupDialogHeight
+                                                                             : kLoginDialogHeight);
     Rectangle rect = {
         song_select::layout::kLoginButtonRect.x + song_select::layout::kLoginButtonRect.width - kDialogWidth,
         song_select::layout::kLoginButtonRect.y + song_select::layout::kLoginButtonRect.height + kDialogOffsetY,
@@ -67,9 +68,9 @@ Rectangle dialog_rect_for(const song_select::auth_state& auth_state,
                           const song_select::login_dialog_state& dialog_state,
                           Rectangle anchor_rect,
                           Rectangle screen_rect) {
-    const float dialog_height = auth_state.logged_in
-        ? kAccountDialogHeight
-        : kLoginDialogHeight;
+    const float dialog_height = auth_state.logged_in ? kAccountDialogHeight
+        : (dialog_state.mode == song_select::login_dialog_mode::signup ? kSignupDialogHeight
+                                                                       : kLoginDialogHeight);
     Rectangle rect = {
         anchor_rect.x + anchor_rect.width - kDialogWidth,
         anchor_rect.y + anchor_rect.height + kDialogOffsetY,
@@ -96,17 +97,95 @@ bool printable_filter(int codepoint, const std::string&) {
     return codepoint >= 32 && codepoint != 127;
 }
 
+void deactivate_input(ui::text_input_state& input) {
+    input.active = false;
+    input.has_selection = false;
+    input.mouse_selecting = false;
+}
+
+void activate_input(ui::text_input_state& input) {
+    input.active = true;
+    input.cursor = ui::utf8_codepoint_count(input.value);
+    input.selection_anchor = input.cursor;
+    input.has_selection = false;
+    input.mouse_selecting = false;
+}
+
+void deactivate_form_inputs(song_select::login_dialog_state& dialog_state) {
+    deactivate_input(dialog_state.display_name_input);
+    deactivate_input(dialog_state.email_input);
+    deactivate_input(dialog_state.password_input);
+    deactivate_input(dialog_state.password_confirmation_input);
+}
+
+void focus_input(song_select::login_dialog_state& dialog_state, ui::text_input_state& input) {
+    deactivate_form_inputs(dialog_state);
+    activate_input(input);
+}
+
+void focus_relative_input(song_select::login_dialog_state& dialog_state, bool signup, int direction) {
+    std::array<ui::text_input_state*, 4> inputs = {
+        signup ? &dialog_state.display_name_input : &dialog_state.email_input,
+        signup ? &dialog_state.email_input : &dialog_state.password_input,
+        signup ? &dialog_state.password_input : nullptr,
+        signup ? &dialog_state.password_confirmation_input : nullptr,
+    };
+    const int count = signup ? 4 : 2;
+    int active_index = -1;
+    for (int i = 0; i < count; ++i) {
+        if (inputs[static_cast<size_t>(i)]->active) {
+            active_index = i;
+            break;
+        }
+    }
+
+    const int next_index = active_index < 0
+        ? 0
+        : (active_index + direction + count) % count;
+    focus_input(dialog_state, *inputs[static_cast<size_t>(next_index)]);
+}
+
+ui::button_state draw_tab(Rectangle rect, const char* label, bool selected, ui::draw_layer layer) {
+    const auto& theme = *g_theme;
+    const ui::row_state row = ui::enqueue_row(rect,
+                                              selected ? theme.row_selected : theme.row,
+                                              selected ? theme.row_active : theme.row_hover,
+                                              selected ? theme.border_active : theme.border,
+                                              layer, 1.5f);
+    ui::enqueue_text_in_rect(label, 15, rect, selected ? theme.text : theme.text_secondary,
+                             ui::text_align::center, layer);
+    return {row.hovered, row.pressed, row.clicked};
+}
+
+ui::button_state draw_dialog_button(Rectangle rect, const char* label, int font_size,
+                                    ui::draw_layer layer, bool enabled) {
+    if (enabled) {
+        return ui::enqueue_button(rect, label, font_size, layer, 1.5f);
+    }
+
+    const auto& theme = *g_theme;
+    ui::enqueue_row(rect, theme.section, theme.section, theme.border_light, layer, 1.5f);
+    ui::enqueue_text_in_rect(label, font_size, rect, theme.text_muted, ui::text_align::center, layer);
+    return {};
+}
+
 }  // namespace
 
 namespace song_select {
 
 void open_login_dialog(login_dialog_state& dialog_state, const auth::session_summary& summary) {
     dialog_state.open = true;
+    if (!summary.logged_in) {
+        dialog_state.mode = login_dialog_mode::login;
+    }
     dialog_state.open_anim = 0.0f;
     dialog_state.status_message.clear();
     dialog_state.status_message_is_error = false;
     dialog_state.email_input.value = summary.email;
+    dialog_state.display_name_input.value.clear();
     dialog_state.password_input.value.clear();
+    dialog_state.password_confirmation_input.value.clear();
+    deactivate_form_inputs(dialog_state);
 }
 
 Rectangle login_dialog_rect(const auth_state& auth_state, const login_dialog_state& dialog_state,
@@ -182,35 +261,69 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                                   ui::text_align::left);
         }
 
-        if (ui::enqueue_button(refresh_rect, "REFRESH", 14, layer, 1.5f).clicked && !request_active) {
+        if (draw_dialog_button(refresh_rect, "REFRESH", 14, layer, !request_active).clicked) {
             return login_dialog_command::request_restore;
         }
-        if (ui::enqueue_button(logout_rect, "LOGOUT", 14, layer, 1.5f).clicked && !request_active) {
+        if (draw_dialog_button(logout_rect, "LOGOUT", 14, layer, !request_active).clicked) {
             return login_dialog_command::request_logout;
         }
         return login_dialog_command::none;
     }
 
+    const bool signup = dialog_state.mode == login_dialog_mode::signup;
+    const Rectangle tab_row = {form_x, dialog_rect.y + kTabTop, form_width, kTabHeight};
+    const float tab_width = (tab_row.width - kButtonGap) * 0.5f;
+    const Rectangle login_tab = {tab_row.x, tab_row.y, tab_width, tab_row.height};
+    const Rectangle signup_tab = {tab_row.x + tab_width + kButtonGap, tab_row.y, tab_width, tab_row.height};
+
+    if (draw_tab(login_tab, "LOGIN", !signup, layer).clicked && !request_active) {
+        dialog_state.mode = login_dialog_mode::login;
+        dialog_state.status_message.clear();
+        deactivate_form_inputs(dialog_state);
+    }
+    if (draw_tab(signup_tab, "SIGN UP", signup, layer).clicked && !request_active) {
+        dialog_state.mode = login_dialog_mode::signup;
+        dialog_state.status_message.clear();
+        deactivate_form_inputs(dialog_state);
+    }
+
     int row = 0;
+    bool submitted = false;
+    if (signup) {
+        const ui::text_input_result display_name_result = ui::draw_text_input(
+            make_row(dialog_rect, row++), dialog_state.display_name_input, "Name", "Display name",
+            nullptr, layer, 15, 32, printable_filter, kTextInputLabelWidth);
+        submitted = submitted || display_name_result.submitted;
+    }
+
     const ui::text_input_result email_result = ui::draw_text_input(
         make_row(dialog_rect, row++), dialog_state.email_input, "Email", "name@example.com",
         nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth);
+    submitted = submitted || email_result.submitted;
 
     const ui::text_input_result password_result = ui::draw_text_input(
         make_row(dialog_rect, row++), dialog_state.password_input, "Pass", "Password",
-        nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth);
+        nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth, true);
+    submitted = submitted || password_result.submitted;
 
-    const float action_top = dialog_rect.y + kLoginActionTop;
+    if (signup) {
+        const ui::text_input_result confirm_result = ui::draw_text_input(
+            make_row(dialog_rect, row++), dialog_state.password_confirmation_input, "Confirm", "Repeat password",
+            nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth, true);
+        submitted = submitted || confirm_result.submitted;
+    }
+
+    if (IsKeyPressed(KEY_TAB) && !request_active) {
+        focus_relative_input(dialog_state, signup,
+                             IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT) ? -1 : 1);
+    }
+
+    const float action_top =
+        dialog_rect.y + kBodyTop + static_cast<float>(row) * (kRowHeight + kRowGap) + kFormMessageGap;
     const Rectangle message_rect = {form_x, action_top, form_width, kMessageHeight};
     const Rectangle login_button_row = {form_x, action_top + kLoginButtonOffsetY, form_width, kButtonHeight};
-    const Rectangle helper_rect = {form_x, action_top + kHelperOffsetY, form_width, kHelperTextHeight};
-    const Rectangle web_button_row = {form_x, action_top + kWebButtonOffsetY, form_width, kButtonHeight};
     const Rectangle primary_rect = ui::place(login_button_row, kPrimaryButtonWidth, kButtonHeight,
                                              ui::anchor::center, ui::anchor::center);
-    const Rectangle web_button_rect = ui::place(web_button_row, kSecondaryButtonWidth, kButtonHeight,
-                                                ui::anchor::center, ui::anchor::center);
-
-    const bool submitted = email_result.submitted || password_result.submitted;
 
     if (!dialog_state.status_message.empty()) {
         ui::draw_text_in_rect(dialog_state.status_message.c_str(), 16, message_rect,
@@ -218,13 +331,10 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                               ui::text_align::left);
     }
 
-    ui::enqueue_text_in_rect("New to raythm? Register on the Web.", 14, helper_rect,
-                             theme.text_muted, ui::text_align::center, layer);
-    if (ui::enqueue_button(web_button_rect, "Create", 15, layer, 1.5f).clicked && !request_active) {
-        return login_dialog_command::open_register_web;
-    }
-    if ((ui::enqueue_button(primary_rect, "LOGIN", 16, layer, 1.5f).clicked || submitted) && !request_active) {
-        return login_dialog_command::request_login;
+    const char* primary_label = signup ? "SIGN UP" : "LOGIN";
+    if ((draw_dialog_button(primary_rect, primary_label, 16, layer, !request_active).clicked || submitted) &&
+        !request_active) {
+        return signup ? login_dialog_command::request_register : login_dialog_command::request_login;
     }
 
     return login_dialog_command::none;

--- a/src/scenes/song_select/song_select_login_dialog.h
+++ b/src/scenes/song_select/song_select_login_dialog.h
@@ -10,7 +10,7 @@ enum class login_dialog_command {
     close,
     request_restore,
     request_login,
-    open_register_web,
+    request_register,
     request_logout,
 };
 

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -102,13 +102,21 @@ struct auth_state {
     bool email_verified = false;
 };
 
+enum class login_dialog_mode {
+    login,
+    signup,
+};
+
 struct login_dialog_state {
     bool open = false;
+    login_dialog_mode mode = login_dialog_mode::login;
     float open_anim = 0.0f;
     std::string status_message;
     bool status_message_is_error = false;
+    ui::text_input_state display_name_input;
     ui::text_input_state email_input;
     ui::text_input_state password_input;
+    ui::text_input_state password_confirmation_input;
 };
 
 struct state {

--- a/src/ui/ui_text_input.h
+++ b/src/ui/ui_text_input.h
@@ -245,16 +245,18 @@ inline size_t text_input_cursor_from_mouse(const std::string& value, float local
     return codepoint_count;
 }
 
-inline void update_text_input_scroll(text_input_state& state, float viewport_width, int font_size) {
+inline void update_text_input_scroll(text_input_state& state, float viewport_width, int font_size,
+                                     const std::string* visual_value = nullptr) {
     if (!state.active) {
         state.scroll_x = 0.0f;
         return;
     }
 
-    const float cursor_x = text_input_prefix_width(state.value, state.cursor, font_size);
+    const std::string& measured_value = visual_value != nullptr ? *visual_value : state.value;
+    const float cursor_x = text_input_prefix_width(measured_value, state.cursor, font_size);
     const float padding = 8.0f;
     const float max_scroll = std::max(0.0f,
-                                      measure_text_size(state.value, static_cast<float>(font_size)).x -
+                                      measure_text_size(measured_value, static_cast<float>(font_size)).x -
                                           viewport_width + padding);
 
     if (cursor_x - state.scroll_x < padding) {
@@ -295,9 +297,16 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
                                          draw_layer layer = draw_layer::base,
                                          int font_size = 16, size_t max_length = 32,
                                          text_input_filter filter = default_text_input_filter,
-                                         float label_width = 84.0f) {
+                                         float label_width = 84.0f,
+                                         bool obscure_value = false) {
     text_input_result result;
     clamp_text_input_state(state);
+    const auto visual_value_for_state = [&]() {
+        if (!obscure_value || state.value.empty()) {
+            return state.value;
+        }
+        return std::string(utf8_codepoint_count(state.value), '*');
+    };
 
     const auto apply_default_if_empty = [&]() {
         if (default_value != nullptr && state.value.empty()) {
@@ -344,7 +353,7 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
 
         if (CheckCollisionPointRec(GetMousePosition(), input_rect)) {
             const float local_x = GetMousePosition().x - text_rect.x + state.scroll_x;
-            state.cursor = text_input_cursor_from_mouse(state.value, local_x, font_size);
+            state.cursor = text_input_cursor_from_mouse(visual_value_for_state(), local_x, font_size);
             clear_text_input_selection(state);
             state.mouse_selecting = true;
         } else {
@@ -362,7 +371,7 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
     if (state.active && state.mouse_selecting && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
         const Vector2 mouse = GetMousePosition();
         const float local_x = mouse.x - text_rect.x + state.scroll_x;
-        const size_t mouse_cursor = text_input_cursor_from_mouse(state.value, local_x, font_size);
+        const size_t mouse_cursor = text_input_cursor_from_mouse(visual_value_for_state(), local_x, font_size);
         state.cursor = mouse_cursor;
         state.has_selection = state.cursor != state.selection_anchor;
     }
@@ -467,17 +476,18 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
         }
     }
 
-    update_text_input_scroll(state, text_rect.width, font_size);
-
     draw_rect_f(input_rect, state.active ? with_alpha(g_theme->panel, 255) : with_alpha(g_theme->section, 255));
     draw_rect_lines(input_rect, 1.5f, state.active ? g_theme->border_active : g_theme->border_light);
     draw_text_in_rect(label, font_size, label_rect,
                       state.active ? g_theme->text : g_theme->text_secondary, text_align::left);
 
-    std::string display_value = state.value;
+    std::string display_value = visual_value_for_state();
     if (display_value.empty() && !state.active && placeholder != nullptr) {
         display_value = placeholder;
     }
+    const std::string scroll_visual_value = visual_value_for_state();
+    update_text_input_scroll(state, text_rect.width, font_size,
+                             obscure_value ? &scroll_visual_value : nullptr);
 
     const Color text_color = state.value.empty() && !state.active ? g_theme->text_hint : g_theme->text;
     const float layout_font_size = text_layout_font_size(static_cast<float>(font_size));
@@ -496,22 +506,22 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
         if (state.has_selection) {
             const auto [selection_start, selection_end] = text_input_selection_range(state);
             const float selection_x = text_rect.x +
-                                      text_input_prefix_width(state.value, selection_start, font_size) -
+                                      text_input_prefix_width(display_value, selection_start, font_size) -
                                       state.scroll_x;
             const float selection_end_x = text_rect.x +
-                                          text_input_prefix_width(state.value, selection_end, font_size) -
+                                          text_input_prefix_width(display_value, selection_end, font_size) -
                                           state.scroll_x;
             draw_rect_span({selection_x, input_rect.y + kTextInputSelectionInsetY,
                             selection_end_x - selection_x, input_rect.height - kTextInputSelectionInsetTotalY},
                            with_alpha(g_theme->row_selected, 255));
         }
 
-        draw_text_f(state.value.c_str(), text_rect.x - state.scroll_x, text_y, font_size, g_theme->text);
+        draw_text_f(display_value.c_str(), text_rect.x - state.scroll_x, text_y, font_size, g_theme->text);
 
         const double blink = GetTime() * 1.6;
         if (std::fmod(blink, 1.0) < 0.6) {
             const float cursor_x = text_rect.x +
-                                   text_input_prefix_width(state.value, state.cursor, font_size) -
+                                   text_input_prefix_width(display_value, state.cursor, font_size) -
                                    state.scroll_x;
             draw_rect_span({cursor_x, input_rect.y + kTextInputSelectionInsetY, kTextInputCursorWidth,
                             input_rect.height - kTextInputSelectionInsetTotalY},


### PR DESCRIPTION
## 概要
- ACCOUNT ダイアログに `LOGIN` / `SIGN UP` タブを追加しました
- `SIGN UP` から display name / email / password / password confirmation を入力して、ゲーム内で `POST /auth/register` を呼べるようにしました
- password / password confirmation は伏せ字表示にしました
- `Tab` / `Shift+Tab` で認証フォームの入力欄を移動できるようにしました
- 認証リクエスト中は主要ボタンを無効表示にして、二重送信しにくくしました
- password confirmation の不一致や必須入力不足はリクエスト前にフォーム上へ表示します
- 登録成功後は既存のセッション保存・認証状態更新に乗り、ログイン済みの ACCOUNT 表示へ切り替わります
- 既存のブラウザ登録ページを開く導線は削除しました

## 補足
- server 側の Bot 連打対策は明示的な rate limit が未実装だったため、別途 raythm-Server#33 を作成しました

## 検証
- `cmake --build cmake-build-codex --target raythm`
- `cmake --build cmake-build-codex --target song_select_state_smoke`
- `cmake-build-codex\song_select_state_smoke.exe`

Closes #276