### PR TITLE
[codex] ACCOUNTにメールコード認証UIを追加する

### DIFF
--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -98,6 +98,10 @@ std::filesystem::path auth_session_path() {
     return app_data_root() / "auth_session.json";
 }
 
+std::filesystem::path auth_device_path() {
+    return app_data_root() / "auth_device.json";
+}
+
 std::filesystem::path upload_mapping_path() {
     return app_data_root() / "upload_mappings.txt";
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -44,6 +44,9 @@ std::filesystem::path chart_offsets_path();
 // AppData/Local/raythm/auth_session.json
 std::filesystem::path auth_session_path();
 
+// AppData/Local/raythm/auth_device.json
+std::filesystem::path auth_device_path();
+
 // AppData/Local/raythm/upload_mappings.txt
 std::filesystem::path upload_mapping_path();
 

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -95,6 +95,38 @@ std::optional<auth::session> parse_auth_session_response(const std::string& body
     };
 }
 
+auth::verification_purpose parse_verification_purpose(const std::string& value) {
+    if (value == "email_verification") {
+        return auth::verification_purpose::email_verification;
+    }
+    if (value == "login_verification") {
+        return auth::verification_purpose::login_verification;
+    }
+    return auth::verification_purpose::none;
+}
+
+std::optional<auth::operation_result> parse_verification_required_response(const std::string& body) {
+    if (!json::extract_bool(body, "verificationRequired").value_or(false)) {
+        return std::nullopt;
+    }
+
+    const std::string purpose_text =
+        json::extract_string(body, "verificationPurpose").value_or("email_verification");
+    const auth::verification_purpose purpose = parse_verification_purpose(purpose_text);
+    if (purpose == auth::verification_purpose::none) {
+        return std::nullopt;
+    }
+
+    return auth::operation_result{
+        .success = false,
+        .message = json::extract_string(body, "message").value_or("Verification code required."),
+        .session_data = std::nullopt,
+        .verification_required = true,
+        .verification = purpose,
+        .verification_email = json::extract_string(body, "email").value_or(""),
+    };
+}
+
 std::optional<auth::public_user> parse_me_response(const std::string& body) {
     const std::optional<std::string> user_object = json::extract_object(body, "user");
     if (!user_object.has_value()) {
@@ -126,6 +158,46 @@ bool write_session_file(const auth::session& session_data) {
     output << "    \"displayName\": \"" << json::escape_string(session_data.user.display_name) << "\",\n";
     output << "    \"emailVerified\": " << (session_data.user.email_verified ? "true" : "false") << "\n";
     output << "  }\n";
+    output << "}\n";
+    return output.good();
+}
+
+std::optional<std::string> read_trusted_device_token(const std::string& server_url, const std::string& email) {
+    const std::string content = read_file(app_paths::auth_device_path());
+    if (content.empty()) {
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> stored_server_url = json::extract_string(content, "serverUrl");
+    const std::optional<std::string> stored_email = json::extract_string(content, "email");
+    const std::optional<std::string> device_token = json::extract_string(content, "trustedDeviceToken");
+    if (!stored_server_url.has_value() || !stored_email.has_value() || !device_token.has_value()) {
+        return std::nullopt;
+    }
+
+    if (auth::normalize_server_url(*stored_server_url) != auth::normalize_server_url(server_url) ||
+        json::trim(*stored_email) != json::trim(email)) {
+        return std::nullopt;
+    }
+
+    return *device_token;
+}
+
+bool write_trusted_device_token(const std::string& server_url, const std::string& email, const std::string& token) {
+    if (token.empty()) {
+        return true;
+    }
+
+    app_paths::ensure_directories();
+    std::ofstream output(app_paths::auth_device_path(), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "{\n";
+    output << "  \"serverUrl\": \"" << json::escape_string(auth::normalize_server_url(server_url)) << "\",\n";
+    output << "  \"email\": \"" << json::escape_string(json::trim(email)) << "\",\n";
+    output << "  \"trustedDeviceToken\": \"" << json::escape_string(token) << "\"\n";
     output << "}\n";
     return output.good();
 }
@@ -321,7 +393,8 @@ auth::operation_result finish_with_session(auth::operation_result result, const 
 
 auth::operation_result parse_auth_response(const http_response& response,
                                            const std::string& server_url,
-                                           std::string success_message) {
+                                           std::string success_message,
+                                           const std::string& email_for_device = {}) {
     if (!response.error_message.empty()) {
         return {
             .success = false,
@@ -336,6 +409,11 @@ auth::operation_result parse_auth_response(const http_response& response,
             .message = parse_error_message(response.body, "Authentication request failed."),
             .session_data = std::nullopt,
         };
+    }
+
+    if (const std::optional<auth::operation_result> verification = parse_verification_required_response(response.body);
+        verification.has_value()) {
+        return *verification;
     }
 
     const std::optional<auth::session> session_data =
@@ -354,6 +432,13 @@ auth::operation_result parse_auth_response(const http_response& response,
             .message = "Authentication succeeded, but the local session could not be saved.",
             .session_data = std::nullopt,
         };
+    }
+
+    if (const std::optional<std::string> trusted_device_token =
+            json::extract_string(response.body, "trustedDeviceToken");
+        trusted_device_token.has_value()) {
+        const std::string device_email = email_for_device.empty() ? session_data->user.email : email_for_device;
+        write_trusted_device_token(server_url, device_email, *trusted_device_token);
     }
 
     return finish_with_session({
@@ -463,7 +548,7 @@ operation_result register_user(const std::string& server_url,
             {"User-Agent", "raythm/0.1"},
         });
 
-    return parse_auth_response(response, normalized_server_url, "Account created successfully.");
+    return parse_auth_response(response, normalized_server_url, "Account created successfully.", json::trim(email));
 }
 
 operation_result login_user(const std::string& server_url,
@@ -478,10 +563,15 @@ operation_result login_user(const std::string& server_url,
         };
     }
 
+    const std::optional<std::string> trusted_device_token =
+        read_trusted_device_token(normalized_server_url, json::trim(email));
     const std::string body =
         "{"
         "\"email\":\"" + json::escape_string(json::trim(email)) + "\","
         "\"password\":\"" + json::escape_string(password) + "\""
+        + (trusted_device_token.has_value()
+               ? ",\"deviceToken\":\"" + json::escape_string(*trusted_device_token) + "\""
+               : "") +
         "}";
 
     const http_response response = send_request(
@@ -494,7 +584,97 @@ operation_result login_user(const std::string& server_url,
             {"User-Agent", "raythm/0.1"},
         });
 
-    return parse_auth_response(response, normalized_server_url, "Logged in successfully.");
+    return parse_auth_response(response, normalized_server_url, "Logged in successfully.", json::trim(email));
+}
+
+operation_result verify_email_code(const std::string& server_url,
+                                   const std::string& email,
+                                   const std::string& code) {
+    const std::string normalized_server_url = normalize_server_url(server_url);
+    const std::string body =
+        "{"
+        "\"email\":\"" + json::escape_string(json::trim(email)) + "\","
+        "\"code\":\"" + json::escape_string(json::trim(code)) + "\""
+        "}";
+
+    const http_response response = send_request(
+        "POST",
+        build_auth_url(normalized_server_url, "/auth/verify-email"),
+        body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    return parse_auth_response(response, normalized_server_url, "Email verified.", json::trim(email));
+}
+
+operation_result verify_login_code(const std::string& server_url,
+                                   const std::string& email,
+                                   const std::string& code) {
+    const std::string normalized_server_url = normalize_server_url(server_url);
+    const std::string body =
+        "{"
+        "\"email\":\"" + json::escape_string(json::trim(email)) + "\","
+        "\"code\":\"" + json::escape_string(json::trim(code)) + "\""
+        "}";
+
+    const http_response response = send_request(
+        "POST",
+        build_auth_url(normalized_server_url, "/auth/verify-login"),
+        body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    return parse_auth_response(response, normalized_server_url, "Login verified.", json::trim(email));
+}
+
+operation_result resend_verification_code(const std::string& server_url,
+                                          const std::string& email,
+                                          verification_purpose purpose) {
+    const std::string normalized_server_url = normalize_server_url(server_url);
+    const char* purpose_text = purpose == verification_purpose::login_verification
+        ? "login_verification"
+        : "email_verification";
+    const std::string body =
+        "{"
+        "\"email\":\"" + json::escape_string(json::trim(email)) + "\","
+        "\"purpose\":\"" + purpose_text + "\""
+        "}";
+
+    const http_response response = send_request(
+        "POST",
+        build_auth_url(normalized_server_url, "/auth/resend-code"),
+        body,
+        {
+            {"Accept", "application/json"},
+            {"Content-Type", "application/json"},
+            {"User-Agent", "raythm/0.1"},
+        });
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+    if (response.status_code < 200 || response.status_code >= 300) {
+        return {
+            .success = false,
+            .message = parse_error_message(response.body, "Failed to resend code."),
+            .session_data = std::nullopt,
+        };
+    }
+    return {
+        .success = true,
+        .message = parse_error_message(response.body, "Verification code sent."),
+        .session_data = std::nullopt,
+    };
 }
 
 operation_result restore_saved_session() {

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -29,10 +29,19 @@ struct session_summary {
     bool email_verified = false;
 };
 
+enum class verification_purpose {
+    none,
+    email_verification,
+    login_verification,
+};
+
 struct operation_result {
     bool success = false;
     std::string message;
     std::optional<session> session_data;
+    bool verification_required = false;
+    verification_purpose verification = verification_purpose::none;
+    std::string verification_email;
 };
 
 std::string normalize_server_url(const std::string& server_url);
@@ -49,6 +58,15 @@ operation_result register_user(const std::string& server_url,
 operation_result login_user(const std::string& server_url,
                             const std::string& email,
                             const std::string& password);
+operation_result verify_email_code(const std::string& server_url,
+                                   const std::string& email,
+                                   const std::string& code);
+operation_result verify_login_code(const std::string& server_url,
+                                   const std::string& email,
+                                   const std::string& code);
+operation_result resend_verification_code(const std::string& server_url,
+                                          const std::string& email,
+                                          verification_purpose purpose);
 operation_result restore_saved_session();
 operation_result logout_saved_session();
 

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -61,6 +61,9 @@ void start_request(controller& controller_state,
     const std::string email = dialog_state.email_input.value;
     const std::string password = dialog_state.password_input.value;
     const std::string password_confirmation = dialog_state.password_confirmation_input.value;
+    const std::string verification_email = dialog_state.verification_email;
+    const std::string verification_code = dialog_state.verification_code_input.value;
+    const auth::verification_purpose verification = dialog_state.verification;
 
     switch (command) {
     case song_select::login_dialog_command::request_restore:
@@ -91,6 +94,33 @@ void start_request(controller& controller_state,
         dialog_state.status_message = "Creating account...";
         controller_state.request_future = start_auth_task([server_url, email, display_name, password]() {
             return auth::register_user(server_url, email, display_name, password);
+        });
+        break;
+    case song_select::login_dialog_command::request_verify:
+        if (verification_email.empty() || verification_code.empty()) {
+            controller_state.request_active = false;
+            dialog_state.status_message = "Verification code is required.";
+            dialog_state.status_message_is_error = true;
+            break;
+        }
+        dialog_state.status_message = "Verifying code...";
+        controller_state.request_future = start_auth_task([server_url, verification_email, verification_code, verification]() {
+            if (verification == auth::verification_purpose::login_verification) {
+                return auth::verify_login_code(server_url, verification_email, verification_code);
+            }
+            return auth::verify_email_code(server_url, verification_email, verification_code);
+        });
+        break;
+    case song_select::login_dialog_command::request_resend_code:
+        if (verification_email.empty() || verification == auth::verification_purpose::none) {
+            controller_state.request_active = false;
+            dialog_state.status_message = "No verification request is active.";
+            dialog_state.status_message_is_error = true;
+            break;
+        }
+        dialog_state.status_message = "Resending code...";
+        controller_state.request_future = start_auth_task([server_url, verification_email, verification]() {
+            return auth::resend_verification_code(server_url, verification_email, verification);
         });
         break;
     case song_select::login_dialog_command::request_logout:
@@ -153,6 +183,23 @@ poll_result poll_request(controller& controller_state,
     refresh_auth_state(auth_state);
     dialog_state.password_input.value.clear();
     dialog_state.password_confirmation_input.value.clear();
+    if (result.verification_required) {
+        dialog_state.mode = song_select::login_dialog_mode::verify;
+        dialog_state.verification = result.verification;
+        dialog_state.verification_email = result.verification_email.empty()
+            ? dialog_state.email_input.value
+            : result.verification_email;
+        dialog_state.verification_code_input.value.clear();
+        dialog_state.status_message = result.message;
+        dialog_state.status_message_is_error = false;
+        return {};
+    }
+    if (result.success) {
+        dialog_state.mode = song_select::login_dialog_mode::login;
+        dialog_state.verification = auth::verification_purpose::none;
+        dialog_state.verification_email.clear();
+        dialog_state.verification_code_input.value.clear();
+    }
     dialog_state.status_message = result.message;
     dialog_state.status_message_is_error = !result.success;
 

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -6,6 +6,8 @@
 #include <thread>
 #include <utility>
 
+#include "ui_notice.h"
+
 namespace {
 
 template <typename Fn>
@@ -26,6 +28,13 @@ std::future<auth::operation_result> start_auth_task(Fn task) {
         promise.set_value(std::move(result));
     }).detach();
     return future;
+}
+
+void notify_auth(std::string message, ui::notice_tone tone) {
+    if (message.empty()) {
+        return;
+    }
+    ui::notify(std::move(message), tone, tone == ui::notice_tone::error ? 3.2f : 2.2f);
 }
 
 }  // namespace
@@ -55,7 +64,6 @@ void start_request(controller& controller_state,
     }
 
     controller_state.request_active = true;
-    dialog_state.status_message_is_error = false;
     const std::string server_url = auth::kDefaultServerUrl;
     const std::string display_name = dialog_state.display_name_input.value;
     const std::string email = dialog_state.email_input.value;
@@ -67,13 +75,13 @@ void start_request(controller& controller_state,
 
     switch (command) {
     case song_select::login_dialog_command::request_restore:
-        dialog_state.status_message = "Restoring session...";
+        notify_auth("Restoring session...", ui::notice_tone::info);
         controller_state.request_future = start_auth_task([]() {
             return auth::restore_saved_session();
         });
         break;
     case song_select::login_dialog_command::request_login:
-        dialog_state.status_message = "Connecting to raythm-Server...";
+        notify_auth("Connecting to raythm-Server...", ui::notice_tone::info);
         controller_state.request_future = start_auth_task([server_url, email, password]() {
             return auth::login_user(server_url, email, password);
         });
@@ -81,17 +89,15 @@ void start_request(controller& controller_state,
     case song_select::login_dialog_command::request_register:
         if (display_name.empty() || email.empty() || password.empty()) {
             controller_state.request_active = false;
-            dialog_state.status_message = "Name, email, and password are required.";
-            dialog_state.status_message_is_error = true;
+            notify_auth("Name, email, and password are required.", ui::notice_tone::error);
             break;
         }
         if (password != password_confirmation) {
             controller_state.request_active = false;
-            dialog_state.status_message = "Passwords do not match.";
-            dialog_state.status_message_is_error = true;
+            notify_auth("Passwords do not match.", ui::notice_tone::error);
             break;
         }
-        dialog_state.status_message = "Creating account...";
+        notify_auth("Creating account...", ui::notice_tone::info);
         controller_state.request_future = start_auth_task([server_url, email, display_name, password]() {
             return auth::register_user(server_url, email, display_name, password);
         });
@@ -99,11 +105,10 @@ void start_request(controller& controller_state,
     case song_select::login_dialog_command::request_verify:
         if (verification_email.empty() || verification_code.empty()) {
             controller_state.request_active = false;
-            dialog_state.status_message = "Verification code is required.";
-            dialog_state.status_message_is_error = true;
+            notify_auth("Verification code is required.", ui::notice_tone::error);
             break;
         }
-        dialog_state.status_message = "Verifying code...";
+        notify_auth("Verifying code...", ui::notice_tone::info);
         controller_state.request_future = start_auth_task([server_url, verification_email, verification_code, verification]() {
             if (verification == auth::verification_purpose::login_verification) {
                 return auth::verify_login_code(server_url, verification_email, verification_code);
@@ -114,17 +119,16 @@ void start_request(controller& controller_state,
     case song_select::login_dialog_command::request_resend_code:
         if (verification_email.empty() || verification == auth::verification_purpose::none) {
             controller_state.request_active = false;
-            dialog_state.status_message = "No verification request is active.";
-            dialog_state.status_message_is_error = true;
+            notify_auth("No verification request is active.", ui::notice_tone::error);
             break;
         }
-        dialog_state.status_message = "Resending code...";
+        notify_auth("Resending code...", ui::notice_tone::info);
         controller_state.request_future = start_auth_task([server_url, verification_email, verification]() {
             return auth::resend_verification_code(server_url, verification_email, verification);
         });
         break;
     case song_select::login_dialog_command::request_logout:
-        dialog_state.status_message = "Logging out...";
+        notify_auth("Logging out...", ui::notice_tone::info);
         controller_state.request_future = start_auth_task([]() {
             return auth::logout_saved_session();
         });
@@ -136,15 +140,15 @@ void start_request(controller& controller_state,
     }
 }
 
-poll_result poll_restore(controller& controller_state,
-                         song_select::auth_state& auth_state,
-                         song_select::login_dialog_state& dialog_state) {
+void poll_restore(controller& controller_state,
+                  song_select::auth_state& auth_state,
+                  song_select::login_dialog_state&) {
     if (!controller_state.restore_active) {
-        return {};
+        return;
     }
 
     if (controller_state.restore_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
-        return {};
+        return;
     }
 
     controller_state.restore_active = false;
@@ -152,30 +156,19 @@ poll_result poll_restore(controller& controller_state,
     refresh_auth_state(auth_state);
 
     if (!result.success) {
-        if (dialog_state.open) {
-            dialog_state.status_message = result.message;
-            dialog_state.status_message_is_error = true;
-        } else {
-            return {
-                true,
-                true,
-                result.message,
-            };
-        }
+        notify_auth(result.message, ui::notice_tone::error);
     }
-
-    return {};
 }
 
-poll_result poll_request(controller& controller_state,
-                         song_select::auth_state& auth_state,
-                         song_select::login_dialog_state& dialog_state) {
+void poll_request(controller& controller_state,
+                  song_select::auth_state& auth_state,
+                  song_select::login_dialog_state& dialog_state) {
     if (!controller_state.request_active) {
-        return {};
+        return;
     }
 
     if (controller_state.request_future.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
-        return {};
+        return;
     }
 
     controller_state.request_active = false;
@@ -190,9 +183,8 @@ poll_result poll_request(controller& controller_state,
             ? dialog_state.email_input.value
             : result.verification_email;
         dialog_state.verification_code_input.value.clear();
-        dialog_state.status_message = result.message;
-        dialog_state.status_message_is_error = false;
-        return {};
+        notify_auth(result.message, ui::notice_tone::info);
+        return;
     }
     if (result.success) {
         dialog_state.mode = song_select::login_dialog_mode::login;
@@ -200,12 +192,10 @@ poll_result poll_request(controller& controller_state,
         dialog_state.verification_email.clear();
         dialog_state.verification_code_input.value.clear();
     }
-    dialog_state.status_message = result.message;
-    dialog_state.status_message_is_error = !result.success;
+    notify_auth(result.message, result.success ? ui::notice_tone::success : ui::notice_tone::error);
 
     const auth::session_summary summary = auth::load_session_summary();
     dialog_state.email_input.value = summary.email;
-    return {};
 }
 
 }  // namespace auth_overlay

--- a/src/scenes/shared/auth_overlay_controller.h
+++ b/src/scenes/shared/auth_overlay_controller.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <future>
-#include <string>
 
 #include "network/auth_client.h"
 #include "song_select/song_select_login_dialog.h"
@@ -16,22 +15,16 @@ struct controller {
     bool request_active = false;
 };
 
-struct poll_result {
-    bool should_show_notice = false;
-    bool notice_is_error = false;
-    std::string notice_message;
-};
-
 void refresh_auth_state(song_select::auth_state& auth_state);
 void start_restore(controller& controller_state, song_select::login_dialog_state& dialog_state);
 void start_request(controller& controller_state,
                    song_select::login_dialog_state& dialog_state,
                    song_select::login_dialog_command command);
-poll_result poll_restore(controller& controller_state,
-                         song_select::auth_state& auth_state,
-                         song_select::login_dialog_state& dialog_state);
-poll_result poll_request(controller& controller_state,
-                         song_select::auth_state& auth_state,
-                         song_select::login_dialog_state& dialog_state);
+void poll_restore(controller& controller_state,
+                  song_select::auth_state& auth_state,
+                  song_select::login_dialog_state& dialog_state);
+void poll_request(controller& controller_state,
+                  song_select::auth_state& auth_state,
+                  song_select::login_dialog_state& dialog_state);
 
 }  // namespace auth_overlay

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -30,7 +30,6 @@ constexpr float kButtonGap = 12.0f;
 constexpr float kPrimaryButtonWidth = 192.0f;
 constexpr float kScreenEdgeMargin = 18.0f;
 constexpr float kOpenAnimOffsetY = 27.0f;
-constexpr float kFooterMarginBottom = 27.0f;
 constexpr float kSignedInLineHeight = 33.0f;
 constexpr float kDisplayNameOffsetY = 42.0f;
 constexpr float kDisplayNameHeight = 30.0f;
@@ -94,6 +93,10 @@ Rectangle make_row(const Rectangle& dialog_rect, int index) {
 
 bool printable_filter(int codepoint, const std::string&) {
     return codepoint >= 32 && codepoint != 127;
+}
+
+float centered_footer_button_y(const Rectangle& dialog_rect, float content_bottom) {
+    return content_bottom + (dialog_rect.y + dialog_rect.height - content_bottom - kButtonHeight) * 0.5f;
 }
 
 void deactivate_input(ui::text_input_state& input) {
@@ -209,7 +212,6 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
     const Rectangle dialog_rect = dialog_rect_for(auth_state, dialog_state, anchor_rect, screen_rect);
     const float form_x = dialog_rect.x + kDialogPaddingX;
     const float form_width = dialog_rect.width - kDialogPaddingX * 2.0f;
-    const float footer_y = dialog_rect.y + dialog_rect.height - kFooterMarginBottom - kButtonHeight;
 
     ui::draw_panel(dialog_rect);
     ui::draw_text_in_rect("Account", 24,
@@ -232,7 +234,10 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         const Rectangle verify_rect = {
             form_x, dialog_rect.y + kBodyTop + kVerifyOffsetY, form_width, kVerifyLineHeight
         };
-        const Rectangle button_row = {form_x, footer_y, form_width, kButtonHeight};
+        const Rectangle button_row = {
+            form_x, centered_footer_button_y(dialog_rect, verify_rect.y + verify_rect.height),
+            form_width, kButtonHeight
+        };
         const Rectangle logout_rect = {
             button_row.x + button_row.width - kAccountButtonWidth, button_row.y, kAccountButtonWidth, kButtonHeight
         };
@@ -272,7 +277,10 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         const Rectangle title_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 30.0f};
         const Rectangle email_rect = {form_x, title_rect.y + 34.0f, form_width, 24.0f};
         const Rectangle code_rect = {form_x, email_rect.y + 42.0f, form_width, kRowHeight};
-        const Rectangle button_row = {form_x, footer_y, form_width, kButtonHeight};
+        const Rectangle button_row = {
+            form_x, centered_footer_button_y(dialog_rect, code_rect.y + code_rect.height),
+            form_width, kButtonHeight
+        };
         const Rectangle verify_rect = {
             button_row.x + button_row.width - kVerifyButtonWidth,
             button_row.y,
@@ -351,7 +359,11 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                              IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT) ? -1 : 1);
     }
 
-    const Rectangle login_button_row = {form_x, footer_y, form_width, kButtonHeight};
+    const Rectangle last_input_rect = make_row(dialog_rect, row - 1);
+    const Rectangle login_button_row = {
+        form_x, centered_footer_button_y(dialog_rect, last_input_rect.y + last_input_rect.height),
+        form_width, kButtonHeight
+    };
     const Rectangle primary_rect = ui::place(login_button_row, kPrimaryButtonWidth, kButtonHeight,
                                              ui::anchor::center, ui::anchor::center);
 

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -39,12 +39,7 @@ constexpr float kEmailLineHeight = 24.0f;
 constexpr float kVerifyOffsetY = 111.0f;
 constexpr float kVerifyLineHeight = 24.0f;
 constexpr float kAccountButtonWidth = 138.0f;
-constexpr float kStatusOffsetAboveFooter = 42.0f;
-constexpr float kStatusLineHeight = 30.0f;
 constexpr float kTextInputLabelWidth = 135.0f;
-constexpr float kFormMessageGap = 18.0f;
-constexpr float kMessageHeight = 27.0f;
-constexpr float kLoginButtonOffsetY = 42.0f;
 constexpr float kVerifyButtonWidth = 168.0f;
 
 Rectangle dialog_rect_for(const song_select::state& state) {
@@ -190,8 +185,6 @@ void open_login_dialog(login_dialog_state& dialog_state, const auth::session_sum
         dialog_state.mode = login_dialog_mode::login;
     }
     dialog_state.open_anim = 0.0f;
-    dialog_state.status_message.clear();
-    dialog_state.status_message_is_error = false;
     dialog_state.email_input.value = summary.email;
     dialog_state.display_name_input.value.clear();
     dialog_state.password_input.value.clear();
@@ -266,13 +259,6 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                               auth_state.email_verified ? theme.success : theme.error,
                               ui::text_align::left);
 
-        if (!dialog_state.status_message.empty()) {
-            ui::draw_text_in_rect(dialog_state.status_message.c_str(), 13,
-                                  {form_x, footer_y - kStatusOffsetAboveFooter, form_width, kStatusLineHeight},
-                                  dialog_state.status_message_is_error ? theme.error : theme.success,
-                                  ui::text_align::left);
-        }
-
         if (draw_dialog_button(refresh_rect, "REFRESH", 14, layer, !request_active).clicked) {
             return login_dialog_command::request_restore;
         }
@@ -286,9 +272,7 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         const Rectangle title_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 30.0f};
         const Rectangle email_rect = {form_x, title_rect.y + 34.0f, form_width, 24.0f};
         const Rectangle code_rect = {form_x, email_rect.y + 42.0f, form_width, kRowHeight};
-        const Rectangle message_rect = {form_x, code_rect.y + code_rect.height + kFormMessageGap,
-                                        form_width, kMessageHeight};
-        const Rectangle button_row = {form_x, message_rect.y + kLoginButtonOffsetY, form_width, kButtonHeight};
+        const Rectangle button_row = {form_x, footer_y, form_width, kButtonHeight};
         const Rectangle verify_rect = {
             button_row.x + button_row.width - kVerifyButtonWidth,
             button_row.y,
@@ -310,12 +294,6 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
             code_rect, dialog_state.verification_code_input, "Code", "6 digit code",
             nullptr, layer, 15, 12, printable_filter, kTextInputLabelWidth);
 
-        if (!dialog_state.status_message.empty()) {
-            ui::draw_text_in_rect(dialog_state.status_message.c_str(), 16, message_rect,
-                                  dialog_state.status_message_is_error ? theme.error : theme.success,
-                                  ui::text_align::left);
-        }
-
         if (draw_dialog_button(resend_rect, "RESEND", 15, layer, !request_active).clicked) {
             return login_dialog_command::request_resend_code;
         }
@@ -335,12 +313,10 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
 
     if (draw_tab(login_tab, "LOGIN", !signup, layer).clicked && !request_active) {
         dialog_state.mode = login_dialog_mode::login;
-        dialog_state.status_message.clear();
         deactivate_form_inputs(dialog_state);
     }
     if (draw_tab(signup_tab, "SIGN UP", signup, layer).clicked && !request_active) {
         dialog_state.mode = login_dialog_mode::signup;
-        dialog_state.status_message.clear();
         deactivate_form_inputs(dialog_state);
     }
 
@@ -375,18 +351,9 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                              IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT) ? -1 : 1);
     }
 
-    const float action_top =
-        dialog_rect.y + kBodyTop + static_cast<float>(row) * (kRowHeight + kRowGap) + kFormMessageGap;
-    const Rectangle message_rect = {form_x, action_top, form_width, kMessageHeight};
-    const Rectangle login_button_row = {form_x, action_top + kLoginButtonOffsetY, form_width, kButtonHeight};
+    const Rectangle login_button_row = {form_x, footer_y, form_width, kButtonHeight};
     const Rectangle primary_rect = ui::place(login_button_row, kPrimaryButtonWidth, kButtonHeight,
                                              ui::anchor::center, ui::anchor::center);
-
-    if (!dialog_state.status_message.empty()) {
-        ui::draw_text_in_rect(dialog_state.status_message.c_str(), 16, message_rect,
-                              dialog_state.status_message_is_error ? theme.error : theme.success,
-                              ui::text_align::left);
-    }
 
     const char* primary_label = signup ? "SIGN UP" : "LOGIN";
     if ((draw_dialog_button(primary_rect, primary_label, 16, layer, !request_active).clicked || submitted) &&

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -10,19 +10,19 @@
 namespace {
 
 constexpr float kDialogWidth = 540.0f;
-constexpr float kLoginDialogHeight = 462.0f;
-constexpr float kSignupDialogHeight = 594.0f;
-constexpr float kVerifyDialogHeight = 462.0f;
-constexpr float kAccountDialogHeight = 387.0f;
+constexpr float kLoginDialogHeight = 360.0f;
+constexpr float kSignupDialogHeight = 510.0f;
+constexpr float kVerifyDialogHeight = 396.0f;
+constexpr float kAccountDialogHeight = 360.0f;
 constexpr float kDialogOffsetY = 27.0f;
 constexpr float kDialogPaddingX = 27.0f;
 constexpr float kTitleHeight = 39.0f;
 constexpr float kSubtitleHeight = 27.0f;
-constexpr float kHeaderTop = 27.0f;
-constexpr float kHeaderGap = 9.0f;
-constexpr float kTabTop = 105.0f;
+constexpr float kHeaderTop = 24.0f;
+constexpr float kHeaderGap = 6.0f;
+constexpr float kTabTop = 96.0f;
 constexpr float kTabHeight = 42.0f;
-constexpr float kBodyTop = 168.0f;
+constexpr float kBodyTop = 150.0f;
 constexpr float kRowHeight = 54.0f;
 constexpr float kRowGap = 12.0f;
 constexpr float kButtonHeight = 54.0f;

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -12,6 +12,7 @@ namespace {
 constexpr float kDialogWidth = 540.0f;
 constexpr float kLoginDialogHeight = 462.0f;
 constexpr float kSignupDialogHeight = 594.0f;
+constexpr float kVerifyDialogHeight = 462.0f;
 constexpr float kAccountDialogHeight = 387.0f;
 constexpr float kDialogOffsetY = 27.0f;
 constexpr float kDialogPaddingX = 27.0f;
@@ -44,11 +45,13 @@ constexpr float kTextInputLabelWidth = 135.0f;
 constexpr float kFormMessageGap = 18.0f;
 constexpr float kMessageHeight = 27.0f;
 constexpr float kLoginButtonOffsetY = 42.0f;
+constexpr float kVerifyButtonWidth = 168.0f;
 
 Rectangle dialog_rect_for(const song_select::state& state) {
     const float dialog_height = state.auth.logged_in ? kAccountDialogHeight
         : (state.login_dialog.mode == song_select::login_dialog_mode::signup ? kSignupDialogHeight
-                                                                             : kLoginDialogHeight);
+           : (state.login_dialog.mode == song_select::login_dialog_mode::verify ? kVerifyDialogHeight
+                                                                                : kLoginDialogHeight));
     Rectangle rect = {
         song_select::layout::kLoginButtonRect.x + song_select::layout::kLoginButtonRect.width - kDialogWidth,
         song_select::layout::kLoginButtonRect.y + song_select::layout::kLoginButtonRect.height + kDialogOffsetY,
@@ -70,7 +73,8 @@ Rectangle dialog_rect_for(const song_select::auth_state& auth_state,
                           Rectangle screen_rect) {
     const float dialog_height = auth_state.logged_in ? kAccountDialogHeight
         : (dialog_state.mode == song_select::login_dialog_mode::signup ? kSignupDialogHeight
-                                                                       : kLoginDialogHeight);
+           : (dialog_state.mode == song_select::login_dialog_mode::verify ? kVerifyDialogHeight
+                                                                          : kLoginDialogHeight));
     Rectangle rect = {
         anchor_rect.x + anchor_rect.width - kDialogWidth,
         anchor_rect.y + anchor_rect.height + kDialogOffsetY,
@@ -116,6 +120,7 @@ void deactivate_form_inputs(song_select::login_dialog_state& dialog_state) {
     deactivate_input(dialog_state.email_input);
     deactivate_input(dialog_state.password_input);
     deactivate_input(dialog_state.password_confirmation_input);
+    deactivate_input(dialog_state.verification_code_input);
 }
 
 void focus_input(song_select::login_dialog_state& dialog_state, ui::text_input_state& input) {
@@ -143,6 +148,12 @@ void focus_relative_input(song_select::login_dialog_state& dialog_state, bool si
         ? 0
         : (active_index + direction + count) % count;
     focus_input(dialog_state, *inputs[static_cast<size_t>(next_index)]);
+}
+
+const char* verification_title(auth::verification_purpose purpose) {
+    return purpose == auth::verification_purpose::login_verification
+        ? "Confirm login"
+        : "Verify email";
 }
 
 ui::button_state draw_tab(Rectangle rect, const char* label, bool selected, ui::draw_layer layer) {
@@ -185,6 +196,7 @@ void open_login_dialog(login_dialog_state& dialog_state, const auth::session_sum
     dialog_state.display_name_input.value.clear();
     dialog_state.password_input.value.clear();
     dialog_state.password_confirmation_input.value.clear();
+    dialog_state.verification_code_input.value.clear();
     deactivate_form_inputs(dialog_state);
 }
 
@@ -266,6 +278,51 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         }
         if (draw_dialog_button(logout_rect, "LOGOUT", 14, layer, !request_active).clicked) {
             return login_dialog_command::request_logout;
+        }
+        return login_dialog_command::none;
+    }
+
+    if (dialog_state.mode == login_dialog_mode::verify) {
+        const Rectangle title_rect = {form_x, dialog_rect.y + kBodyTop, form_width, 30.0f};
+        const Rectangle email_rect = {form_x, title_rect.y + 34.0f, form_width, 24.0f};
+        const Rectangle code_rect = {form_x, email_rect.y + 42.0f, form_width, kRowHeight};
+        const Rectangle message_rect = {form_x, code_rect.y + code_rect.height + kFormMessageGap,
+                                        form_width, kMessageHeight};
+        const Rectangle button_row = {form_x, message_rect.y + kLoginButtonOffsetY, form_width, kButtonHeight};
+        const Rectangle verify_rect = {
+            button_row.x + button_row.width - kVerifyButtonWidth,
+            button_row.y,
+            kVerifyButtonWidth,
+            kButtonHeight
+        };
+        const Rectangle resend_rect = {
+            verify_rect.x - kVerifyButtonWidth - kButtonGap,
+            button_row.y,
+            kVerifyButtonWidth,
+            kButtonHeight
+        };
+
+        ui::draw_text_in_rect(verification_title(dialog_state.verification), 20,
+                              title_rect, theme.text, ui::text_align::left);
+        ui::draw_text_in_rect(dialog_state.verification_email.c_str(), 14,
+                              email_rect, theme.text_muted, ui::text_align::left);
+        const ui::text_input_result code_result = ui::draw_text_input(
+            code_rect, dialog_state.verification_code_input, "Code", "6 digit code",
+            nullptr, layer, 15, 12, printable_filter, kTextInputLabelWidth);
+
+        if (!dialog_state.status_message.empty()) {
+            ui::draw_text_in_rect(dialog_state.status_message.c_str(), 16, message_rect,
+                                  dialog_state.status_message_is_error ? theme.error : theme.success,
+                                  ui::text_align::left);
+        }
+
+        if (draw_dialog_button(resend_rect, "RESEND", 15, layer, !request_active).clicked) {
+            return login_dialog_command::request_resend_code;
+        }
+        if ((draw_dialog_button(verify_rect, "VERIFY", 15, layer, !request_active).clicked ||
+             code_result.submitted) &&
+            !request_active) {
+            return login_dialog_command::request_verify;
         }
         return login_dialog_command::none;
     }

--- a/src/scenes/song_select/song_select_login_dialog.h
+++ b/src/scenes/song_select/song_select_login_dialog.h
@@ -11,6 +11,8 @@ enum class login_dialog_command {
     request_restore,
     request_login,
     request_register,
+    request_verify,
+    request_resend_code,
     request_logout,
 };
 

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -113,8 +113,6 @@ struct login_dialog_state {
     bool open = false;
     login_dialog_mode mode = login_dialog_mode::login;
     float open_anim = 0.0f;
-    std::string status_message;
-    bool status_message_is_error = false;
     auth::verification_purpose verification = auth::verification_purpose::none;
     std::string verification_email;
     ui::text_input_state display_name_input;

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include "data_models.h"
+#include "network/auth_client.h"
 #include "ranking_service.h"
 #include "raylib.h"
 #include "shared/scene_fade.h"
@@ -105,6 +106,7 @@ struct auth_state {
 enum class login_dialog_mode {
     login,
     signup,
+    verify,
 };
 
 struct login_dialog_state {
@@ -113,10 +115,13 @@ struct login_dialog_state {
     float open_anim = 0.0f;
     std::string status_message;
     bool status_message_is_error = false;
+    auth::verification_purpose verification = auth::verification_purpose::none;
+    std::string verification_email;
     ui::text_input_state display_name_input;
     ui::text_input_state email_input;
     ui::text_input_state password_input;
     ui::text_input_state password_confirmation_input;
+    ui::text_input_state verification_code_input;
 };
 
 struct state {

--- a/src/scenes/song_select_scene.cpp
+++ b/src/scenes/song_select_scene.cpp
@@ -423,10 +423,7 @@ void song_select_scene::update(float dt) {
     song_select::tick_animations(state_, dt);
     poll_song_library_reload();
     poll_selected_chart_ranking();
-    if (const auto restore_result = auth_overlay::poll_restore(auth_controller_, state_.auth, state_.login_dialog);
-        restore_result.should_show_notice) {
-        song_select::queue_status_message(state_, restore_result.notice_message, restore_result.notice_is_error);
-    }
+    auth_overlay::poll_restore(auth_controller_, state_.auth, state_.login_dialog);
     auth_overlay::poll_request(auth_controller_, state_.auth, state_.login_dialog);
     if (const auto prepared = transfer_controller_.poll_song_import_prepare(); prepared.has_value()) {
         if (prepared->requests.empty()) {


### PR DESCRIPTION
## 概要
- ACCOUNT ダイアログに `VERIFY` 状態を追加し、メールコード入力 / VERIFY / RESEND を扱えるようにしました
- `/auth/register` / `/auth/login` の `verificationRequired` レスポンスを解釈し、コード入力画面へ遷移します
- `/auth/verify-email` / `/auth/verify-login` / `/auth/resend-code` の client API を追加しました
- verify 成功時に session を保存し、server が返す `trustedDeviceToken` を `auth_device.json` に保存します
- 次回 login 時に保存済み trusted device token を送信します

## 検証
- `cmake --build cmake-build-codex --target raythm`
- `cmake --build cmake-build-codex --target song_select_state_smoke`
- `cmake-build-codex\song_select_state_smoke.exe`

Depends on raythm-Server#35
Closes #278