### PR TITLE
[codex] Local以外の投稿を禁止する

### DIFF
--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -1038,6 +1038,11 @@ upload_request_result send_chart_upload_request(const auth::session& session,
 upload_result upload_song(const song_select::song_entry& song) {
     upload_result result;
 
+    if (song.status != content_status::local) {
+        result.message = "Only Local songs can be uploaded.";
+        return result;
+    }
+
     std::string error_message;
     const std::optional<auth::session> session_opt = require_saved_session(error_message);
     if (!session_opt.has_value()) {
@@ -1098,6 +1103,11 @@ upload_result upload_song(const song_select::song_entry& song) {
 upload_result upload_chart(const song_select::song_entry& song,
                            const song_select::chart_option& chart) {
     upload_result result;
+
+    if (song.status != content_status::local || chart.status != content_status::local) {
+        result.message = "Only Local charts from Local songs can be uploaded.";
+        return result;
+    }
 
     std::string error_message;
     const std::optional<auth::session> session_opt = require_saved_session(error_message);

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -93,6 +93,10 @@ const char* account_status_for(const song_select::auth_state& auth_state) {
     return auth_state.email_verified ? "Verified profile" : "Manage account";
 }
 
+bool can_upload_content(content_status status) {
+    return status == content_status::local;
+}
+
 const song_select::song_entry* selected_audio_song(title_scene::hub_mode mode,
                                                    const song_select::state& play_state,
                                                    const title_online_view::state& online_state) {
@@ -634,6 +638,8 @@ void title_scene::update_create_mode(float dt) {
     if (result.upload_song_requested) {
         if (song == nullptr) {
             song_select::queue_status_message(play_state_, "Select a song to upload.", true);
+        } else if (!can_upload_content(song->status)) {
+            ui::notify("Only Local songs can be uploaded.", ui::notice_tone::error, 2.8f);
         } else {
             start_song_upload(*song);
         }
@@ -666,6 +672,8 @@ void title_scene::update_create_mode(float dt) {
     if (result.upload_chart_requested) {
         if (song == nullptr || chart == nullptr) {
             song_select::queue_status_message(play_state_, "Select a chart to upload.", true);
+        } else if (!can_upload_content(song->status) || !can_upload_content(chart->status)) {
+            ui::notify("Only Local charts from Local songs can be uploaded.", ui::notice_tone::error, 2.8f);
         } else {
             start_chart_upload(*song, *chart);
         }


### PR DESCRIPTION
## 概要
- CREATE画面の `UPLOAD SONG` / `UPLOAD CHART` を Local コンテンツ以外では実行しないようにしました
- 投稿処理本体にも同じガードを追加し、別経路から呼ばれても Official / Community / Modified / Update / Checking を投稿しないようにしました
- `UPLOAD CHART` は song と chart の両方が Local の場合だけ許可します

## 検証
- `cmake --build cmake-build-codex --target raythm`
- `cmake --build cmake-build-codex --target song_select_state_smoke`
- `cmake-build-codex\song_select_state_smoke.exe`