### PR TITLE
ACCOUNTからアカウント削除できるようにする

### DIFF
--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -517,6 +517,11 @@ void clear_saved_session() {
     fs::remove(app_paths::auth_session_path(), ec);
 }
 
+void clear_trusted_device_file() {
+    std::error_code ec;
+    fs::remove(app_paths::auth_device_path(), ec);
+}
+
 operation_result register_user(const std::string& server_url,
                                const std::string& email,
                                const std::string& display_name,
@@ -839,6 +844,79 @@ operation_result logout_saved_session() {
     return {
         .success = true,
         .message = "Logged out successfully.",
+        .session_data = std::nullopt,
+    };
+}
+
+operation_result delete_saved_account(const std::string& password) {
+    if (json::trim(password).empty()) {
+        return {
+            .success = false,
+            .message = "Password is required to delete the account.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        clear_saved_session();
+        clear_trusted_device_file();
+        return {
+            .success = true,
+            .message = "Account session was already cleared.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    const std::string body =
+        "{"
+        "\"password\":\"" + json::escape_string(password) + "\""
+        "}";
+
+    auto send_delete = [&](const session& session_data) {
+        return send_request(
+            "DELETE",
+            build_auth_url(session_data.server_url, "/me"),
+            body,
+            {
+                {"Accept", "application/json"},
+                {"Authorization", "Bearer " + session_data.access_token},
+                {"Content-Type", "application/json"},
+                {"User-Agent", "raythm/0.1"},
+            });
+    };
+
+    http_response response = send_delete(*stored);
+    if (response.error_message.empty() && response.status_code == 401) {
+        const operation_result restored = restore_saved_session();
+        if (restored.success && restored.session_data.has_value()) {
+            stored = restored.session_data;
+            response = send_delete(*stored);
+        }
+    }
+
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+
+    if (response.status_code != 204 &&
+        (response.status_code < 200 || response.status_code >= 300)) {
+        return {
+            .success = false,
+            .message = parse_error_message(response.body, "Failed to delete account."),
+            .session_data = std::nullopt,
+        };
+    }
+
+    clear_saved_session();
+    clear_trusted_device_file();
+    return {
+        .success = true,
+        .message = "Account deleted.",
         .session_data = std::nullopt,
     };
 }

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -69,5 +69,6 @@ operation_result resend_verification_code(const std::string& server_url,
                                           verification_purpose purpose);
 operation_result restore_saved_session();
 operation_result logout_saved_session();
+operation_result delete_saved_account(const std::string& password);
 
 }  // namespace auth

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -133,6 +133,17 @@ void start_request(controller& controller_state,
             return auth::logout_saved_session();
         });
         break;
+    case song_select::login_dialog_command::request_delete_account:
+        if (password.empty()) {
+            controller_state.request_active = false;
+            notify_auth("Password is required to delete the account.", ui::notice_tone::error);
+            break;
+        }
+        notify_auth("Deleting account...", ui::notice_tone::info);
+        controller_state.request_future = start_auth_task([password]() {
+            return auth::delete_saved_account(password);
+        });
+        break;
     case song_select::login_dialog_command::none:
     case song_select::login_dialog_command::close:
         controller_state.request_active = false;

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -13,7 +13,7 @@ constexpr float kDialogWidth = 540.0f;
 constexpr float kLoginDialogHeight = 360.0f;
 constexpr float kSignupDialogHeight = 510.0f;
 constexpr float kVerifyDialogHeight = 396.0f;
-constexpr float kAccountDialogHeight = 360.0f;
+constexpr float kAccountDialogHeight = 468.0f;
 constexpr float kDialogOffsetY = 27.0f;
 constexpr float kDialogPaddingX = 27.0f;
 constexpr float kTitleHeight = 39.0f;
@@ -37,6 +37,9 @@ constexpr float kEmailOffsetY = 78.0f;
 constexpr float kEmailLineHeight = 24.0f;
 constexpr float kVerifyOffsetY = 111.0f;
 constexpr float kVerifyLineHeight = 24.0f;
+constexpr float kDeleteHintOffsetY = 147.0f;
+constexpr float kDeleteHintHeight = 24.0f;
+constexpr float kDeletePasswordOffsetY = 183.0f;
 constexpr float kAccountButtonWidth = 138.0f;
 constexpr float kTextInputLabelWidth = 135.0f;
 constexpr float kVerifyButtonWidth = 168.0f;
@@ -234,8 +237,14 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         const Rectangle verify_rect = {
             form_x, dialog_rect.y + kBodyTop + kVerifyOffsetY, form_width, kVerifyLineHeight
         };
+        const Rectangle delete_hint_rect = {
+            form_x, dialog_rect.y + kBodyTop + kDeleteHintOffsetY, form_width, kDeleteHintHeight
+        };
+        const Rectangle delete_password_rect = {
+            form_x, dialog_rect.y + kBodyTop + kDeletePasswordOffsetY, form_width, kRowHeight
+        };
         const Rectangle button_row = {
-            form_x, centered_footer_button_y(dialog_rect, verify_rect.y + verify_rect.height),
+            form_x, centered_footer_button_y(dialog_rect, delete_password_rect.y + delete_password_rect.height),
             form_width, kButtonHeight
         };
         const Rectangle logout_rect = {
@@ -243,6 +252,9 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         };
         const Rectangle refresh_rect = {
             logout_rect.x - kAccountButtonWidth - kButtonGap, button_row.y, kAccountButtonWidth, kButtonHeight
+        };
+        const Rectangle delete_rect = {
+            refresh_rect.x - kAccountButtonWidth - kButtonGap, button_row.y, kAccountButtonWidth, kButtonHeight
         };
 
         ui::draw_text_in_rect("Signed in", 20, signed_in_rect, theme.success, ui::text_align::left);
@@ -263,7 +275,17 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                               verify_rect,
                               auth_state.email_verified ? theme.success : theme.error,
                               ui::text_align::left);
+        ui::draw_text_in_rect("Enter password to delete this account.", 13,
+                              delete_hint_rect, theme.text_muted, ui::text_align::left);
+        const ui::text_input_result delete_password_result = ui::draw_text_input(
+            delete_password_rect, dialog_state.password_input, "Pass", "Password",
+            nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth, true);
 
+        if ((draw_dialog_button(delete_rect, "DELETE", 14, layer, !request_active).clicked ||
+             delete_password_result.submitted) &&
+            !request_active) {
+            return login_dialog_command::request_delete_account;
+        }
         if (draw_dialog_button(refresh_rect, "REFRESH", 14, layer, !request_active).clicked) {
             return login_dialog_command::request_restore;
         }

--- a/src/scenes/song_select/song_select_login_dialog.h
+++ b/src/scenes/song_select/song_select_login_dialog.h
@@ -14,6 +14,7 @@ enum class login_dialog_command {
     request_verify,
     request_resend_code,
     request_logout,
+    request_delete_account,
 };
 
 void open_login_dialog(login_dialog_state& dialog_state, const auth::session_summary& summary);


### PR DESCRIPTION
## 概要

Issue #282 のプロフィール/アカウント管理UIのうち、サーバー側に実装済みの退会フローをクライアントから呼べるようにしました。

- ACCOUNTダイアログに削除用のパスワード入力を追加
- `DELETE /me` を呼ぶ `auth::delete_saved_account` を追加
- access tokenが期限切れの場合はsession restore後に削除を再試行
- 成功時はローカルsessionとtrusted deviceを削除
- 結果は既存のNoticeで表示

## 確認

- `cmake --build cmake-build-codex --target raythm`
- `cmake --build cmake-build-codex --target song_select_state_smoke`
- `cmake-build-codex\song_select_state_smoke.exe`

Refs #282