### PR TITLE
[codex] プロフィール画面に投稿管理タブを追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/title/title_layout.h
         src/scenes/title/play_session_controller.cpp
         src/scenes/title/play_session_controller.h
+        src/scenes/title/profile_view.cpp
+        src/scenes/title/profile_view.h
         src/scenes/title/title_header_view.cpp
         src/scenes/title/title_header_view.h
         src/scenes/title/create_upload_client.cpp

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -136,6 +136,95 @@ std::optional<auth::public_user> parse_me_response(const std::string& body) {
     return parse_user_object(*user_object);
 }
 
+std::optional<auth::community_song_upload> parse_community_song_upload(const std::string& object,
+                                                                        const std::string& user_id) {
+    const std::optional<std::string> uploader_object = json::extract_object(object, "uploader");
+    if (!uploader_object.has_value() || json::extract_string(*uploader_object, "id").value_or("") != user_id) {
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> id = json::extract_string(object, "id");
+    const std::optional<std::string> title = json::extract_string(object, "title");
+    if (!id.has_value() || !title.has_value()) {
+        return std::nullopt;
+    }
+
+    return auth::community_song_upload{
+        .id = *id,
+        .title = *title,
+        .artist = json::extract_string(object, "artist").value_or(""),
+        .visibility = json::extract_string(object, "visibility").value_or("public"),
+    };
+}
+
+std::optional<auth::community_chart_upload> parse_community_chart_upload(const std::string& object,
+                                                                          const std::string& user_id) {
+    const std::optional<std::string> uploader_object = json::extract_object(object, "uploader");
+    if (!uploader_object.has_value() || json::extract_string(*uploader_object, "id").value_or("") != user_id) {
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> id = json::extract_string(object, "id");
+    if (!id.has_value()) {
+        return std::nullopt;
+    }
+
+    const std::optional<std::string> song_object = json::extract_object(object, "song");
+    return auth::community_chart_upload{
+        .id = *id,
+        .song_id = json::extract_string(object, "songId").value_or(""),
+        .song_title = song_object.has_value() ? json::extract_string(*song_object, "title").value_or("") : "",
+        .difficulty_name = json::extract_string(object, "difficultyName").value_or(""),
+        .chart_author = json::extract_string(object, "chartAuthor").value_or(""),
+        .visibility = json::extract_string(object, "visibility").value_or("public"),
+    };
+}
+
+std::optional<auth::profile_ranking_record> parse_profile_ranking_record(const std::string& object) {
+    const std::optional<std::string> chart_id = json::extract_string(object, "chart_id");
+    const std::optional<std::string> song_id = json::extract_string(object, "song_id");
+    const std::optional<std::string> song_title = json::extract_string(object, "song_title");
+    const std::optional<std::string> difficulty_name = json::extract_string(object, "difficulty_name");
+    const std::optional<int> score = json::extract_int(object, "score");
+    const std::optional<int> placement = json::extract_int(object, "placement");
+    if (!chart_id.has_value() || !song_id.has_value() || !song_title.has_value() ||
+        !difficulty_name.has_value() || !score.has_value() || !placement.has_value()) {
+        return std::nullopt;
+    }
+
+    return auth::profile_ranking_record{
+        .chart_id = *chart_id,
+        .song_id = *song_id,
+        .song_title = *song_title,
+        .artist = json::extract_string(object, "artist").value_or(""),
+        .difficulty_name = *difficulty_name,
+        .chart_author = json::extract_string(object, "chart_author").value_or(""),
+        .clear_rank = json::extract_string(object, "clear_rank").value_or(""),
+        .recorded_at = json::extract_string(object, "recorded_at").value_or(""),
+        .submitted_at = json::extract_string(object, "submitted_at").value_or(""),
+        .score = *score,
+        .placement = *placement,
+        .max_combo = json::extract_int(object, "max_combo").value_or(0),
+        .accuracy = json::extract_float(object, "accuracy").value_or(0.0f),
+        .is_full_combo = json::extract_bool(object, "is_full_combo").value_or(false),
+    };
+}
+
+void parse_profile_ranking_array(const std::string& body,
+                                 const char* key,
+                                 std::vector<auth::profile_ranking_record>& output) {
+    const std::optional<std::string> array = json::extract_array(body, key);
+    if (!array.has_value()) {
+        return;
+    }
+
+    for (const std::string& object : json::extract_objects_from_array(*array)) {
+        if (const auto record = parse_profile_ranking_record(object); record.has_value()) {
+            output.push_back(*record);
+        }
+    }
+}
+
 std::string parse_error_message(const std::string& body, std::string fallback) {
     const std::optional<std::string> message = json::extract_string(body, "message");
     return message.value_or(std::move(fallback));
@@ -389,6 +478,22 @@ std::string build_auth_url(const std::string& server_url, std::string_view path)
 auth::operation_result finish_with_session(auth::operation_result result, const auth::session& session_data) {
     result.session_data = session_data;
     return result;
+}
+
+http_response send_authenticated_request(const auth::session& session_data,
+                                         const std::string& method,
+                                         std::string_view path,
+                                         const std::string& body = {}) {
+    std::vector<std::pair<std::string, std::string>> headers = {
+        {"Accept", "application/json"},
+        {"Authorization", "Bearer " + session_data.access_token},
+        {"User-Agent", "raythm/0.1"},
+    };
+    if (!body.empty()) {
+        headers.emplace_back("Content-Type", "application/json");
+    }
+
+    return send_request(method, build_auth_url(session_data.server_url, path), body, headers);
 }
 
 auth::operation_result parse_auth_response(const http_response& response,
@@ -917,6 +1022,223 @@ operation_result delete_saved_account(const std::string& password) {
     return {
         .success = true,
         .message = "Account deleted.",
+        .session_data = std::nullopt,
+    };
+}
+
+my_uploads_result fetch_my_community_uploads() {
+    my_uploads_result result;
+    std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        result.message = "Login required.";
+        return result;
+    }
+
+    auto fetch_page = [&](const session& session_data, std::string_view path) {
+        return send_authenticated_request(session_data, "GET", path);
+    };
+
+    auto refresh_session = [&]() -> bool {
+        const operation_result restored = restore_saved_session();
+        if (!restored.success || !restored.session_data.has_value()) {
+            result.message = restored.message.empty() ? "Saved session expired." : restored.message;
+            return false;
+        }
+        stored = restored.session_data;
+        return true;
+    };
+
+    constexpr int kPageSize = 50;
+    for (int page = 1; page <= 20; ++page) {
+        const std::string path =
+            "/songs?includeMine=true&contentSource=community&page=" + std::to_string(page) +
+            "&pageSize=" + std::to_string(kPageSize);
+        http_response response = fetch_page(*stored, path);
+        if (response.error_message.empty() && response.status_code == 401 && refresh_session()) {
+            response = fetch_page(*stored, path);
+        }
+        if (!response.error_message.empty()) {
+            result.message = response.error_message;
+            return result;
+        }
+        if (response.status_code < 200 || response.status_code >= 300) {
+            result.message = parse_error_message(response.body, "Failed to load uploaded songs.");
+            return result;
+        }
+
+        const std::optional<std::string> items = json::extract_array(response.body, "items");
+        if (!items.has_value()) {
+            result.message = "Server returned an unexpected songs response.";
+            return result;
+        }
+        const std::vector<std::string> objects = json::extract_objects_from_array(*items);
+        for (const std::string& object : objects) {
+            if (const auto song = parse_community_song_upload(object, stored->user.id); song.has_value()) {
+                result.songs.push_back(*song);
+            }
+        }
+        if (static_cast<int>(objects.size()) < kPageSize) {
+            break;
+        }
+    }
+
+    for (int page = 1; page <= 20; ++page) {
+        const std::string path =
+            "/charts?includeMine=true&contentSource=community&page=" + std::to_string(page) +
+            "&pageSize=" + std::to_string(kPageSize);
+        http_response response = fetch_page(*stored, path);
+        if (response.error_message.empty() && response.status_code == 401 && refresh_session()) {
+            response = fetch_page(*stored, path);
+        }
+        if (!response.error_message.empty()) {
+            result.message = response.error_message;
+            return result;
+        }
+        if (response.status_code < 200 || response.status_code >= 300) {
+            result.message = parse_error_message(response.body, "Failed to load uploaded charts.");
+            return result;
+        }
+
+        const std::optional<std::string> items = json::extract_array(response.body, "items");
+        if (!items.has_value()) {
+            result.message = "Server returned an unexpected charts response.";
+            return result;
+        }
+        const std::vector<std::string> objects = json::extract_objects_from_array(*items);
+        for (const std::string& object : objects) {
+            if (const auto chart = parse_community_chart_upload(object, stored->user.id); chart.has_value()) {
+                result.charts.push_back(*chart);
+            }
+        }
+        if (static_cast<int>(objects.size()) < kPageSize) {
+            break;
+        }
+    }
+
+    result.success = true;
+    result.message = "Uploaded content loaded.";
+    return result;
+}
+
+profile_rankings_result fetch_my_profile_rankings() {
+    profile_rankings_result result;
+    std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        result.message = "Login required.";
+        return result;
+    }
+
+    auto send_profile_request = [&](const session& session_data) {
+        return send_authenticated_request(session_data, "GET", "/me/profile/rankings?limit=20");
+    };
+
+    http_response response = send_profile_request(*stored);
+    if (response.error_message.empty() && response.status_code == 401) {
+        const operation_result restored = restore_saved_session();
+        if (restored.success && restored.session_data.has_value()) {
+            stored = restored.session_data;
+            response = send_profile_request(*stored);
+        }
+    }
+
+    if (!response.error_message.empty()) {
+        result.message = response.error_message;
+        return result;
+    }
+    if (response.status_code < 200 || response.status_code >= 300) {
+        result.message = parse_error_message(response.body, "Failed to load profile rankings.");
+        return result;
+    }
+
+    parse_profile_ranking_array(response.body, "recent_records", result.recent_records);
+    parse_profile_ranking_array(response.body, "first_place_records", result.first_place_records);
+    result.success = true;
+    result.message = "Profile rankings loaded.";
+    return result;
+}
+
+operation_result delete_community_song_upload(const std::string& song_id) {
+    std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        return {
+            .success = false,
+            .message = "Login required.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    auto send_delete = [&](const session& session_data) {
+        return send_authenticated_request(session_data, "DELETE", "/songs/" + song_id);
+    };
+
+    http_response response = send_delete(*stored);
+    if (response.error_message.empty() && response.status_code == 401) {
+        const operation_result restored = restore_saved_session();
+        if (restored.success && restored.session_data.has_value()) {
+            stored = restored.session_data;
+            response = send_delete(*stored);
+        }
+    }
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+    if (response.status_code != 204 && (response.status_code < 200 || response.status_code >= 300)) {
+        return {
+            .success = false,
+            .message = parse_error_message(response.body, "Failed to delete uploaded song."),
+            .session_data = std::nullopt,
+        };
+    }
+    return {
+        .success = true,
+        .message = "Uploaded song deleted.",
+        .session_data = std::nullopt,
+    };
+}
+
+operation_result delete_community_chart_upload(const std::string& chart_id) {
+    std::optional<session> stored = load_saved_session();
+    if (!stored.has_value()) {
+        return {
+            .success = false,
+            .message = "Login required.",
+            .session_data = std::nullopt,
+        };
+    }
+
+    auto send_delete = [&](const session& session_data) {
+        return send_authenticated_request(session_data, "DELETE", "/charts/" + chart_id);
+    };
+
+    http_response response = send_delete(*stored);
+    if (response.error_message.empty() && response.status_code == 401) {
+        const operation_result restored = restore_saved_session();
+        if (restored.success && restored.session_data.has_value()) {
+            stored = restored.session_data;
+            response = send_delete(*stored);
+        }
+    }
+    if (!response.error_message.empty()) {
+        return {
+            .success = false,
+            .message = response.error_message,
+            .session_data = std::nullopt,
+        };
+    }
+    if (response.status_code != 204 && (response.status_code < 200 || response.status_code >= 300)) {
+        return {
+            .success = false,
+            .message = parse_error_message(response.body, "Failed to delete uploaded chart."),
+            .session_data = std::nullopt,
+        };
+    }
+    return {
+        .success = true,
+        .message = "Uploaded chart deleted.",
         .session_data = std::nullopt,
     };
 }

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -2,6 +2,7 @@
 
 #include <optional>
 #include <string>
+#include <vector>
 
 namespace auth {
 
@@ -44,6 +45,53 @@ struct operation_result {
     std::string verification_email;
 };
 
+struct community_song_upload {
+    std::string id;
+    std::string title;
+    std::string artist;
+    std::string visibility;
+};
+
+struct community_chart_upload {
+    std::string id;
+    std::string song_id;
+    std::string song_title;
+    std::string difficulty_name;
+    std::string chart_author;
+    std::string visibility;
+};
+
+struct my_uploads_result {
+    bool success = false;
+    std::string message;
+    std::vector<community_song_upload> songs;
+    std::vector<community_chart_upload> charts;
+};
+
+struct profile_ranking_record {
+    std::string chart_id;
+    std::string song_id;
+    std::string song_title;
+    std::string artist;
+    std::string difficulty_name;
+    std::string chart_author;
+    std::string clear_rank;
+    std::string recorded_at;
+    std::string submitted_at;
+    int score = 0;
+    int placement = 0;
+    int max_combo = 0;
+    float accuracy = 0.0f;
+    bool is_full_combo = false;
+};
+
+struct profile_rankings_result {
+    bool success = false;
+    std::string message;
+    std::vector<profile_ranking_record> recent_records;
+    std::vector<profile_ranking_record> first_place_records;
+};
+
 std::string normalize_server_url(const std::string& server_url);
 
 std::optional<session> load_saved_session();
@@ -70,5 +118,9 @@ operation_result resend_verification_code(const std::string& server_url,
 operation_result restore_saved_session();
 operation_result logout_saved_session();
 operation_result delete_saved_account(const std::string& password);
+my_uploads_result fetch_my_community_uploads();
+profile_rankings_result fetch_my_profile_rankings();
+operation_result delete_community_song_upload(const std::string& song_id);
+operation_result delete_community_chart_upload(const std::string& chart_id);
 
 }  // namespace auth

--- a/src/scenes/song_select/song_select_login_dialog.cpp
+++ b/src/scenes/song_select/song_select_login_dialog.cpp
@@ -13,7 +13,7 @@ constexpr float kDialogWidth = 540.0f;
 constexpr float kLoginDialogHeight = 360.0f;
 constexpr float kSignupDialogHeight = 510.0f;
 constexpr float kVerifyDialogHeight = 396.0f;
-constexpr float kAccountDialogHeight = 468.0f;
+constexpr float kAccountDialogHeight = 432.0f;
 constexpr float kDialogOffsetY = 27.0f;
 constexpr float kDialogPaddingX = 27.0f;
 constexpr float kTitleHeight = 39.0f;
@@ -37,9 +37,7 @@ constexpr float kEmailOffsetY = 78.0f;
 constexpr float kEmailLineHeight = 24.0f;
 constexpr float kVerifyOffsetY = 111.0f;
 constexpr float kVerifyLineHeight = 24.0f;
-constexpr float kDeleteHintOffsetY = 147.0f;
-constexpr float kDeleteHintHeight = 24.0f;
-constexpr float kDeletePasswordOffsetY = 183.0f;
+constexpr float kProfileButtonOffsetY = 147.0f;
 constexpr float kAccountButtonWidth = 138.0f;
 constexpr float kTextInputLabelWidth = 135.0f;
 constexpr float kVerifyButtonWidth = 168.0f;
@@ -237,14 +235,11 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         const Rectangle verify_rect = {
             form_x, dialog_rect.y + kBodyTop + kVerifyOffsetY, form_width, kVerifyLineHeight
         };
-        const Rectangle delete_hint_rect = {
-            form_x, dialog_rect.y + kBodyTop + kDeleteHintOffsetY, form_width, kDeleteHintHeight
-        };
-        const Rectangle delete_password_rect = {
-            form_x, dialog_rect.y + kBodyTop + kDeletePasswordOffsetY, form_width, kRowHeight
+        const Rectangle profile_rect = {
+            form_x, dialog_rect.y + kBodyTop + kProfileButtonOffsetY, form_width, kButtonHeight
         };
         const Rectangle button_row = {
-            form_x, centered_footer_button_y(dialog_rect, delete_password_rect.y + delete_password_rect.height),
+            form_x, centered_footer_button_y(dialog_rect, profile_rect.y + profile_rect.height),
             form_width, kButtonHeight
         };
         const Rectangle logout_rect = {
@@ -252,9 +247,6 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
         };
         const Rectangle refresh_rect = {
             logout_rect.x - kAccountButtonWidth - kButtonGap, button_row.y, kAccountButtonWidth, kButtonHeight
-        };
-        const Rectangle delete_rect = {
-            refresh_rect.x - kAccountButtonWidth - kButtonGap, button_row.y, kAccountButtonWidth, kButtonHeight
         };
 
         ui::draw_text_in_rect("Signed in", 20, signed_in_rect, theme.success, ui::text_align::left);
@@ -275,16 +267,8 @@ login_dialog_command draw_login_dialog(const auth_state& auth_state, login_dialo
                               verify_rect,
                               auth_state.email_verified ? theme.success : theme.error,
                               ui::text_align::left);
-        ui::draw_text_in_rect("Enter password to delete this account.", 13,
-                              delete_hint_rect, theme.text_muted, ui::text_align::left);
-        const ui::text_input_result delete_password_result = ui::draw_text_input(
-            delete_password_rect, dialog_state.password_input, "Pass", "Password",
-            nullptr, layer, 15, 64, printable_filter, kTextInputLabelWidth, true);
-
-        if ((draw_dialog_button(delete_rect, "DELETE", 14, layer, !request_active).clicked ||
-             delete_password_result.submitted) &&
-            !request_active) {
-            return login_dialog_command::request_delete_account;
+        if (draw_dialog_button(profile_rect, "PROFILE", 16, layer, !request_active).clicked && !request_active) {
+            return login_dialog_command::request_profile;
         }
         if (draw_dialog_button(refresh_rect, "REFRESH", 14, layer, !request_active).clicked) {
             return login_dialog_command::request_restore;

--- a/src/scenes/song_select/song_select_login_dialog.h
+++ b/src/scenes/song_select/song_select_login_dialog.h
@@ -13,6 +13,7 @@ enum class login_dialog_command {
     request_register,
     request_verify,
     request_resend_code,
+    request_profile,
     request_logout,
     request_delete_account,
 };

--- a/src/scenes/title/profile_view.cpp
+++ b/src/scenes/title/profile_view.cpp
@@ -1,0 +1,679 @@
+#include "title/profile_view.h"
+
+#include <algorithm>
+#include <cctype>
+#include <string>
+
+#include "scene_common.h"
+#include "theme.h"
+#include "tween.h"
+#include "ui_clip.h"
+#include "ui_draw.h"
+#include "virtual_screen.h"
+
+#include "rlgl.h"
+
+namespace title_profile_view {
+namespace {
+
+constexpr Rectangle kDialogRect = {210.0f, 96.0f, 1500.0f, 888.0f};
+constexpr float kHeaderHeight = 190.0f;
+constexpr float kTabHeight = 46.0f;
+constexpr float kContentTopGap = 30.0f;
+constexpr float kContentOuterPadding = 42.0f;
+constexpr float kOpenAnimOffsetY = 30.0f;
+constexpr float kOpenAnimScaleInset = 0.035f;
+constexpr int kTabCount = 5;
+constexpr float kRowHeight = 70.0f;
+constexpr float kRowGap = 10.0f;
+constexpr float kWheelStep = 78.0f;
+
+Rectangle content_rect() {
+    return {
+        kDialogRect.x + kContentOuterPadding,
+        kDialogRect.y + kHeaderHeight + kTabHeight + kContentTopGap,
+        kDialogRect.width - kContentOuterPadding * 2.0f,
+        kDialogRect.height - kHeaderHeight - kTabHeight - kContentTopGap - kContentOuterPadding,
+    };
+}
+
+Rectangle close_rect() {
+    return {kDialogRect.x + kDialogRect.width - 132.0f, kDialogRect.y + 24.0f, 92.0f, 42.0f};
+}
+
+Rectangle confirm_rect() {
+    return {kDialogRect.x + kDialogRect.width - 334.0f,
+            kDialogRect.y + kDialogRect.height - 66.0f,
+            138.0f,
+            42.0f};
+}
+
+Rectangle cancel_rect() {
+    return {kDialogRect.x + kDialogRect.width - 184.0f,
+            kDialogRect.y + kDialogRect.height - 66.0f,
+            132.0f,
+            42.0f};
+}
+
+Rectangle tab_rect(int index) {
+    constexpr float width = 178.0f;
+    constexpr float gap = 8.0f;
+    return {
+        kDialogRect.x + 42.0f + static_cast<float>(index) * (width + gap),
+        kDialogRect.y + kHeaderHeight,
+        width,
+        kTabHeight,
+    };
+}
+
+float max_scroll(Rectangle list_rect, int item_count) {
+    const float content_height = static_cast<float>(item_count) * (kRowHeight + kRowGap) - kRowGap;
+    return std::max(0.0f, content_height - list_rect.height);
+}
+
+Rectangle row_rect(Rectangle list_rect, int visible_index, float scroll_y) {
+    const float y = list_rect.y + static_cast<float>(visible_index) * (kRowHeight + kRowGap) - scroll_y;
+    return {list_rect.x, y, list_rect.width, kRowHeight};
+}
+
+Rectangle row_action_rect(Rectangle row) {
+    return {row.x + row.width - 112.0f, row.y + 14.0f, 92.0f, 42.0f};
+}
+
+Rectangle overview_card_rect(Rectangle content, int index) {
+    constexpr float gap = 12.0f;
+    const float width = (content.width - gap * 3.0f) / 4.0f;
+    return {
+        content.x + static_cast<float>(index) * (width + gap),
+        content.y,
+        width,
+        92.0f,
+    };
+}
+
+Rectangle settings_delete_account_rect(Rectangle content) {
+    return {content.x + 18.0f, content.y + 116.0f, 238.0f, 42.0f};
+}
+
+Rectangle account_delete_panel_rect() {
+    return {
+        kDialogRect.x + (kDialogRect.width - 560.0f) * 0.5f,
+        kDialogRect.y + (kDialogRect.height - 232.0f) * 0.5f,
+        560.0f,
+        232.0f,
+    };
+}
+
+Rectangle account_delete_password_rect() {
+    const Rectangle panel = account_delete_panel_rect();
+    return {panel.x + 32.0f, panel.y + 94.0f, panel.width - 64.0f, 42.0f};
+}
+
+Rectangle account_delete_confirm_rect() {
+    const Rectangle panel = account_delete_panel_rect();
+    return {panel.x + panel.width - 308.0f, panel.y + panel.height - 62.0f, 132.0f, 42.0f};
+}
+
+Rectangle account_delete_cancel_rect() {
+    const Rectangle panel = account_delete_panel_rect();
+    return {panel.x + panel.width - 164.0f, panel.y + panel.height - 62.0f, 132.0f, 42.0f};
+}
+
+std::string song_label(const auth::community_song_upload& song) {
+    return song.title.empty() ? song.id : song.title;
+}
+
+std::string chart_label(const auth::community_chart_upload& chart) {
+    if (!chart.song_title.empty() && !chart.difficulty_name.empty()) {
+        return chart.song_title + " / " + chart.difficulty_name;
+    }
+    if (!chart.difficulty_name.empty()) {
+        return chart.difficulty_name;
+    }
+    return chart.id;
+}
+
+std::string make_avatar_label(const song_select::auth_state& auth_state) {
+    const std::string source = auth_state.display_name.empty() ? auth_state.email : auth_state.display_name;
+    if (source.empty()) {
+        return "A";
+    }
+
+    std::string result;
+    result.reserve(2);
+    for (char ch : source) {
+        if (std::isalnum(static_cast<unsigned char>(ch))) {
+            result.push_back(static_cast<char>(std::toupper(static_cast<unsigned char>(ch))));
+            if (result.size() == 2) {
+                break;
+            }
+        }
+    }
+    return result.empty() ? "A" : result;
+}
+
+void draw_profile_button(Rectangle rect, const char* label, bool enabled, Color tone) {
+    const auto& t = *g_theme;
+    const bool hovered = enabled && CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), rect);
+    const Color bg = hovered ? t.row_hover : t.row;
+    ui::draw_rect_f(rect, with_alpha(lerp_color(bg, tone, hovered ? 0.16f : 0.08f), enabled ? 220 : 95));
+    ui::draw_rect_lines(rect, 1.5f, with_alpha(lerp_color(t.border, tone, 0.35f), enabled ? 220 : 115));
+    ui::draw_text_in_rect(label, 13, rect, enabled ? t.text : t.text_muted);
+}
+
+void draw_empty(Rectangle content, const char* message) {
+    ui::draw_section(content);
+    ui::draw_text_in_rect(message, 15, content, g_theme->text_muted);
+}
+
+void draw_metric_card(Rectangle rect, const char* label, const std::string& value, Color tone) {
+    const auto& t = *g_theme;
+    ui::draw_rect_f(rect, with_alpha(t.row, 205));
+    ui::draw_rect_lines(rect, 1.2f, with_alpha(lerp_color(t.border, tone, 0.35f), 210));
+    ui::draw_text_in_rect(label, 12,
+                          {rect.x + 18.0f, rect.y + 14.0f, rect.width - 36.0f, 22.0f},
+                          t.text_muted, ui::text_align::left);
+    ui::draw_text_in_rect(value.c_str(), 23,
+                          {rect.x + 18.0f, rect.y + 42.0f, rect.width - 36.0f, 34.0f},
+                          tone, ui::text_align::left);
+}
+
+void draw_row_shell(Rectangle row) {
+    const auto& t = *g_theme;
+    const bool hovered = CheckCollisionPointRec(virtual_screen::get_virtual_mouse(), row);
+    ui::draw_rect_f(row, with_alpha(hovered ? t.row_hover : t.row, hovered ? 225 : 195));
+    ui::draw_rect_lines(row, 1.2f, with_alpha(t.border, 205));
+}
+
+tab tab_for_index(int index) {
+    switch (index) {
+    case 0:
+        return tab::overview;
+    case 1:
+        return tab::activity;
+    case 2:
+        return tab::songs;
+    case 3:
+        return tab::charts;
+    default:
+        return tab::settings;
+    }
+}
+
+bool is_upload_tab(tab selected_tab) {
+    return selected_tab == tab::songs || selected_tab == tab::charts;
+}
+
+}  // namespace
+
+Rectangle bounds() {
+    return kDialogRect;
+}
+
+void open(state& profile) {
+    if (!profile.open) {
+        profile.open_anim = 0.0f;
+    }
+    profile.open = true;
+    profile.closing = false;
+    profile.pending_delete = delete_target::none;
+    profile.pending_id.clear();
+    profile.pending_label.clear();
+    profile.delete_password_input.active = false;
+    profile.delete_password_input.has_selection = false;
+    profile.delete_password_input.mouse_selecting = false;
+}
+
+void close(state& profile) {
+    if (profile.open) {
+        profile.closing = true;
+    } else {
+        profile.open_anim = 0.0f;
+    }
+    profile.pending_delete = delete_target::none;
+    profile.pending_id.clear();
+    profile.pending_label.clear();
+    profile.delete_password_input.active = false;
+    profile.delete_password_input.has_selection = false;
+    profile.delete_password_input.mouse_selecting = false;
+}
+
+void clamp_scroll(state& profile) {
+    const Rectangle content = content_rect();
+    profile.activity_scroll =
+        std::clamp(profile.activity_scroll, 0.0f, max_scroll(content, static_cast<int>(profile.activity.size())));
+    profile.song_scroll =
+        std::clamp(profile.song_scroll, 0.0f, max_scroll(content, static_cast<int>(profile.uploads.songs.size())));
+    profile.chart_scroll =
+        std::clamp(profile.chart_scroll, 0.0f, max_scroll(content, static_cast<int>(profile.uploads.charts.size())));
+}
+
+command update(state& profile, bool request_active) {
+    if (!profile.open) {
+        return {};
+    }
+    if (profile.closing) {
+        return {};
+    }
+
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+    const bool left_pressed = IsMouseButtonPressed(MOUSE_BUTTON_LEFT);
+    const float wheel = GetMouseWheelMove();
+    const bool busy = profile.loading || profile.deleting || request_active;
+    const Rectangle content = content_rect();
+
+    if (!busy && profile.pending_delete != delete_target::none &&
+        (IsKeyPressed(KEY_ESCAPE) || IsMouseButtonPressed(MOUSE_BUTTON_RIGHT))) {
+        profile.pending_delete = delete_target::none;
+        profile.pending_id.clear();
+        profile.pending_label.clear();
+        profile.delete_password_input.active = false;
+        profile.delete_password_input.has_selection = false;
+        profile.delete_password_input.mouse_selecting = false;
+        return {};
+    }
+
+    if (!busy && (IsKeyPressed(KEY_ESCAPE) || IsMouseButtonPressed(MOUSE_BUTTON_RIGHT))) {
+        close(profile);
+        return {.type = command_type::close};
+    }
+
+    if (!busy && wheel != 0.0f && CheckCollisionPointRec(mouse, content)) {
+        if (profile.selected_tab == tab::activity) {
+            profile.activity_scroll = std::clamp(
+                profile.activity_scroll - wheel * kWheelStep, 0.0f,
+                max_scroll(content, static_cast<int>(profile.activity.size())));
+        } else if (profile.selected_tab == tab::songs) {
+            profile.song_scroll = std::clamp(
+                profile.song_scroll - wheel * kWheelStep, 0.0f,
+                max_scroll(content, static_cast<int>(profile.uploads.songs.size())));
+        } else if (profile.selected_tab == tab::charts) {
+            profile.chart_scroll = std::clamp(
+                profile.chart_scroll - wheel * kWheelStep, 0.0f,
+                max_scroll(content, static_cast<int>(profile.uploads.charts.size())));
+        }
+    }
+
+    if (!left_pressed) {
+        return {};
+    }
+
+    if (profile.pending_delete != delete_target::none) {
+        if (profile.pending_delete == delete_target::account) {
+            if (!busy && CheckCollisionPointRec(mouse, account_delete_confirm_rect())) {
+                return {.type = command_type::delete_account, .password = profile.delete_password_input.value};
+            }
+            if (!busy && CheckCollisionPointRec(mouse, account_delete_cancel_rect())) {
+                profile.pending_delete = delete_target::none;
+                profile.delete_password_input.active = false;
+                profile.delete_password_input.has_selection = false;
+                profile.delete_password_input.mouse_selecting = false;
+            }
+            return {};
+        }
+        if (!busy && CheckCollisionPointRec(mouse, confirm_rect())) {
+            const command_type type =
+                profile.pending_delete == delete_target::song ? command_type::delete_song : command_type::delete_chart;
+            return {.type = type, .id = profile.pending_id};
+        }
+        if (!busy && CheckCollisionPointRec(mouse, cancel_rect())) {
+            profile.pending_delete = delete_target::none;
+            profile.pending_id.clear();
+            profile.pending_label.clear();
+        }
+        return {};
+    }
+
+    if (!busy && CheckCollisionPointRec(mouse, close_rect())) {
+        close(profile);
+        return {.type = command_type::close};
+    }
+
+    for (int i = 0; i < kTabCount; ++i) {
+        if (CheckCollisionPointRec(mouse, tab_rect(i))) {
+            profile.selected_tab = tab_for_index(i);
+            return {};
+        }
+    }
+
+    if (!busy && profile.uploads.success && profile.selected_tab == tab::songs) {
+        for (int i = 0; i < static_cast<int>(profile.uploads.songs.size()); ++i) {
+            const Rectangle row = row_rect(content, i, profile.song_scroll);
+            if (row.y + row.height < content.y || row.y > content.y + content.height) {
+                continue;
+            }
+            if (CheckCollisionPointRec(mouse, row_action_rect(row))) {
+                profile.pending_delete = delete_target::song;
+                profile.pending_id = profile.uploads.songs[static_cast<size_t>(i)].id;
+                profile.pending_label = song_label(profile.uploads.songs[static_cast<size_t>(i)]);
+                return {};
+            }
+        }
+    }
+
+    if (!busy && profile.uploads.success && profile.selected_tab == tab::charts) {
+        for (int i = 0; i < static_cast<int>(profile.uploads.charts.size()); ++i) {
+            const Rectangle row = row_rect(content, i, profile.chart_scroll);
+            if (row.y + row.height < content.y || row.y > content.y + content.height) {
+                continue;
+            }
+            if (CheckCollisionPointRec(mouse, row_action_rect(row))) {
+                profile.pending_delete = delete_target::chart;
+                profile.pending_id = profile.uploads.charts[static_cast<size_t>(i)].id;
+                profile.pending_label = chart_label(profile.uploads.charts[static_cast<size_t>(i)]);
+                return {};
+            }
+        }
+    }
+
+    if (!busy && profile.selected_tab == tab::settings &&
+        CheckCollisionPointRec(mouse, settings_delete_account_rect(content))) {
+        profile.pending_delete = delete_target::account;
+        profile.delete_password_input.value.clear();
+        profile.delete_password_input.cursor = 0;
+        profile.delete_password_input.has_selection = false;
+        profile.delete_password_input.selection_anchor = 0;
+        profile.delete_password_input.mouse_selecting = false;
+        profile.delete_password_input.scroll_x = 0.0f;
+        profile.delete_password_input.active = true;
+        return {};
+    }
+
+    return {};
+}
+
+void draw(state& profile, const song_select::auth_state& auth_state, bool request_active, ui::draw_layer layer) {
+    if (!profile.open) {
+        return;
+    }
+
+    ui::enqueue_draw_command(layer, [&profile, auth_state, request_active, layer]() {
+        const auto& t = *g_theme;
+        const Vector2 mouse = virtual_screen::get_virtual_mouse();
+        const bool busy = profile.loading || profile.deleting || request_active || profile.closing;
+        const float anim_t = tween::ease_out_cubic(std::clamp(profile.open_anim, 0.0f, 1.0f));
+        const float scale = 1.0f - (1.0f - anim_t) * kOpenAnimScaleInset;
+        const float offset_y = (1.0f - anim_t) * kOpenAnimOffsetY;
+        const Vector2 center = {
+            kDialogRect.x + kDialogRect.width * 0.5f,
+            kDialogRect.y + kDialogRect.height * 0.5f,
+        };
+
+        DrawRectangle(0, 0, kScreenWidth, kScreenHeight,
+                      with_alpha(BLACK, static_cast<unsigned char>(160.0f * anim_t)));
+        rlPushMatrix();
+        rlTranslatef(center.x, center.y + offset_y, 0.0f);
+        rlScalef(scale, scale, 1.0f);
+        rlTranslatef(-center.x, -center.y, 0.0f);
+        ui::draw_panel(kDialogRect);
+
+        const Rectangle avatar = {kDialogRect.x + 44.0f, kDialogRect.y + 42.0f, 96.0f, 96.0f};
+        ui::draw_rect_f(avatar, with_alpha(t.accent, 210));
+        ui::draw_rect_lines(avatar, 2.0f, with_alpha(t.border_active, 230));
+        ui::draw_text_in_rect(make_avatar_label(auth_state).c_str(), 28, avatar, t.bg);
+
+        const std::string display_name =
+            auth_state.display_name.empty() ? auth_state.email : auth_state.display_name;
+        ui::draw_text_in_rect(display_name.c_str(), 27,
+                              {avatar.x + avatar.width + 24.0f, avatar.y + 4.0f, 620.0f, 38.0f},
+                              t.text, ui::text_align::left);
+        ui::draw_text_in_rect(auth_state.email.c_str(), 14,
+                              {avatar.x + avatar.width + 25.0f, avatar.y + 47.0f, 620.0f, 24.0f},
+                              t.text_muted, ui::text_align::left);
+        ui::draw_text_in_rect(auth_state.email_verified ? "Verified profile" : "Email verification pending",
+                              13,
+                              {avatar.x + avatar.width + 25.0f, avatar.y + 76.0f, 260.0f, 24.0f},
+                              auth_state.email_verified ? t.success : t.error, ui::text_align::left);
+
+        const std::string songs_count = std::to_string(profile.uploads.songs.size()) + " songs";
+        const std::string charts_count = std::to_string(profile.uploads.charts.size()) + " charts";
+        ui::draw_text_in_rect(songs_count.c_str(), 15,
+                              {kDialogRect.x + 900.0f, avatar.y + 22.0f, 180.0f, 28.0f},
+                              t.text, ui::text_align::left);
+        ui::draw_text_in_rect(charts_count.c_str(), 15,
+                              {kDialogRect.x + 900.0f, avatar.y + 58.0f, 180.0f, 28.0f},
+                              t.text, ui::text_align::left);
+
+        draw_profile_button(close_rect(), "CLOSE", !busy, t.text_muted);
+
+        const Rectangle tab_bar = {
+            kDialogRect.x + 42.0f,
+            kDialogRect.y + kHeaderHeight,
+            kDialogRect.width - 84.0f,
+            kTabHeight,
+        };
+        ui::draw_rect_f(tab_bar, with_alpha(t.bg, 70));
+        ui::draw_rect_lines({tab_bar.x, tab_bar.y + tab_bar.height - 1.0f, tab_bar.width, 1.0f},
+                            1.0f, with_alpha(t.border, 180));
+
+        const char* tab_labels[] = {"OVERVIEW", "ACTIVITY", "SONGS", "CHARTS", "SETTINGS"};
+        for (int i = 0; i < kTabCount; ++i) {
+            const tab current_tab = tab_for_index(i);
+            const bool selected = current_tab == profile.selected_tab;
+            const Rectangle rect = tab_rect(i);
+            const bool hovered = CheckCollisionPointRec(mouse, rect);
+            if (hovered || selected) {
+                ui::draw_rect_f(rect, with_alpha(selected ? t.row_selected : t.row_hover, selected ? 135 : 90));
+            }
+            ui::draw_text_in_rect(tab_labels[i], 14, rect, selected ? t.text : t.text_secondary);
+            if (selected) {
+                ui::draw_rect_f({rect.x + 18.0f, rect.y + rect.height - 4.0f, rect.width - 36.0f, 3.0f},
+                                with_alpha(t.accent, 235));
+            }
+        }
+
+        const Rectangle content = content_rect();
+        if (profile.loading && !profile.loaded_once) {
+            draw_empty(content, "Loading profile...");
+        } else if (profile.selected_tab == tab::overview) {
+            ui::draw_section(content);
+            draw_metric_card(overview_card_rect(content, 0), "Uploaded Songs",
+                             std::to_string(profile.uploads.songs.size()), t.accent);
+            draw_metric_card(overview_card_rect(content, 1), "Uploaded Charts",
+                             std::to_string(profile.uploads.charts.size()), t.success);
+            draw_metric_card(overview_card_rect(content, 2), "Recent Plays",
+                             std::to_string(profile.activity.size()), t.text);
+            draw_metric_card(overview_card_rect(content, 3), "#1 Records",
+                             std::to_string(profile.first_place_records.size()), t.rank_ss);
+
+            const Rectangle recent = {
+                content.x,
+                content.y + 118.0f,
+                content.width,
+                112.0f,
+            };
+            ui::draw_rect_f(recent, with_alpha(t.row, 185));
+            ui::draw_rect_lines(recent, 1.2f, with_alpha(t.border, 205));
+            ui::draw_text_in_rect("Recent Activity", 16,
+                                  {recent.x + 18.0f, recent.y + 16.0f, recent.width - 36.0f, 26.0f},
+                                  t.text, ui::text_align::left);
+            if (profile.activity.empty()) {
+                ui::draw_text_in_rect("No recent play activity yet.", 13,
+                                      {recent.x + 18.0f, recent.y + 54.0f, recent.width - 36.0f, 22.0f},
+                                      t.text_muted, ui::text_align::left);
+            } else {
+                const auto& item = profile.activity.front();
+                ui::draw_text_in_rect(item.song_title.c_str(), 15,
+                                      {recent.x + 18.0f, recent.y + 48.0f, 540.0f, 24.0f},
+                                      t.text, ui::text_align::left);
+                ui::draw_text_in_rect((item.artist + " / " + item.difficulty_name).c_str(), 11,
+                                      {recent.x + 18.0f, recent.y + 76.0f, 540.0f, 18.0f},
+                                      t.text_muted, ui::text_align::left);
+                ui::draw_text_in_rect(item.local_summary.c_str(), 13,
+                                      {recent.x + 650.0f, recent.y + 50.0f, 310.0f, 22.0f},
+                                      t.text_secondary, ui::text_align::left);
+                ui::draw_text_in_rect(item.online_summary.c_str(), 13,
+                                      {recent.x + 650.0f, recent.y + 76.0f, 360.0f, 22.0f},
+                                      t.accent, ui::text_align::left);
+            }
+
+            const Rectangle first_place = {
+                content.x,
+                recent.y + recent.height + 12.0f,
+                content.width,
+                112.0f,
+            };
+            ui::draw_rect_f(first_place, with_alpha(t.row, 185));
+            ui::draw_rect_lines(first_place, 1.2f, with_alpha(t.border, 205));
+            ui::draw_text_in_rect("#1 Records", 16,
+                                  {first_place.x + 18.0f, first_place.y + 16.0f,
+                                   first_place.width - 36.0f, 26.0f},
+                                  t.text, ui::text_align::left);
+            if (profile.first_place_records.empty()) {
+                ui::draw_text_in_rect("No #1 online records yet.", 13,
+                                      {first_place.x + 18.0f, first_place.y + 54.0f,
+                                       first_place.width - 36.0f, 22.0f},
+                                      t.text_muted, ui::text_align::left);
+            } else {
+                const auto& item = profile.first_place_records.front();
+                ui::draw_text_in_rect(item.song_title.c_str(), 15,
+                                      {first_place.x + 18.0f, first_place.y + 48.0f, 540.0f, 24.0f},
+                                      t.text, ui::text_align::left);
+                ui::draw_text_in_rect((item.artist + " / " + item.difficulty_name).c_str(), 11,
+                                      {first_place.x + 18.0f, first_place.y + 76.0f, 540.0f, 18.0f},
+                                      t.text_muted, ui::text_align::left);
+                ui::draw_text_in_rect(item.online_summary.c_str(), 13,
+                                      {first_place.x + 650.0f, first_place.y + 62.0f, 360.0f, 22.0f},
+                                      t.rank_ss, ui::text_align::left);
+            }
+        } else if (profile.selected_tab == tab::activity) {
+            if (profile.activity.empty()) {
+                draw_empty(content, "No recent play activity yet.");
+            } else {
+                ui::scoped_clip_rect clip(content);
+                for (int i = 0; i < static_cast<int>(profile.activity.size()); ++i) {
+                    const Rectangle row = row_rect(content, i, profile.activity_scroll);
+                    if (row.y + row.height < content.y || row.y > content.y + content.height) {
+                        continue;
+                    }
+                    const auto& item = profile.activity[static_cast<size_t>(i)];
+                    draw_row_shell(row);
+                    ui::draw_text_in_rect(item.song_title.c_str(), 15,
+                                          {row.x + 18.0f, row.y + 9.0f, 520.0f, 24.0f},
+                                          t.text, ui::text_align::left);
+                    ui::draw_text_in_rect((item.artist + " / " + item.difficulty_name).c_str(), 11,
+                                          {row.x + 18.0f, row.y + 38.0f, 520.0f, 18.0f},
+                                          t.text_muted, ui::text_align::left);
+                    ui::draw_text_in_rect(item.local_summary.c_str(), 13,
+                                          {row.x + 650.0f, row.y + 10.0f, 310.0f, 22.0f},
+                                          t.text_secondary, ui::text_align::left);
+                    ui::draw_text_in_rect(item.online_summary.c_str(), 13,
+                                          {row.x + 650.0f, row.y + 38.0f, 360.0f, 22.0f},
+                                          t.accent, ui::text_align::left);
+                }
+            }
+        } else if (is_upload_tab(profile.selected_tab) && !profile.uploads.success) {
+            draw_empty(content, profile.uploads.message.empty()
+                                    ? "Uploaded content could not be loaded."
+                                    : profile.uploads.message.c_str());
+        } else if (profile.selected_tab == tab::songs) {
+            if (profile.uploads.songs.empty()) {
+                draw_empty(content, "No uploaded songs.");
+            } else {
+                ui::scoped_clip_rect clip(content);
+                for (int i = 0; i < static_cast<int>(profile.uploads.songs.size()); ++i) {
+                    const Rectangle row = row_rect(content, i, profile.song_scroll);
+                    if (row.y + row.height < content.y || row.y > content.y + content.height) {
+                        continue;
+                    }
+                    const auto& song = profile.uploads.songs[static_cast<size_t>(i)];
+                    draw_row_shell(row);
+                    ui::draw_text_in_rect(song_label(song).c_str(), 15,
+                                          {row.x + 18.0f, row.y + 9.0f, row.width - 160.0f, 24.0f},
+                                          t.text, ui::text_align::left);
+                    ui::draw_text_in_rect(song.artist.c_str(), 11,
+                                          {row.x + 18.0f, row.y + 38.0f, row.width - 160.0f, 18.0f},
+                                          t.text_muted, ui::text_align::left);
+                    draw_profile_button(row_action_rect(row), "DELETE", !busy, t.error);
+                }
+            }
+        } else if (profile.selected_tab == tab::charts) {
+            if (profile.uploads.charts.empty()) {
+                draw_empty(content, "No uploaded charts.");
+            } else {
+                ui::scoped_clip_rect clip(content);
+                for (int i = 0; i < static_cast<int>(profile.uploads.charts.size()); ++i) {
+                    const Rectangle row = row_rect(content, i, profile.chart_scroll);
+                    if (row.y + row.height < content.y || row.y > content.y + content.height) {
+                        continue;
+                    }
+                    const auto& chart = profile.uploads.charts[static_cast<size_t>(i)];
+                    draw_row_shell(row);
+                    ui::draw_text_in_rect(chart_label(chart).c_str(), 15,
+                                          {row.x + 18.0f, row.y + 9.0f, row.width - 160.0f, 24.0f},
+                                          t.text, ui::text_align::left);
+                    ui::draw_text_in_rect(chart.chart_author.c_str(), 11,
+                                          {row.x + 18.0f, row.y + 38.0f, row.width - 160.0f, 18.0f},
+                                          t.text_muted, ui::text_align::left);
+                    draw_profile_button(row_action_rect(row), "DELETE", !busy, t.error);
+                }
+            }
+        } else {
+            ui::draw_section(content);
+            ui::draw_text_in_rect("Settings", 18,
+                                  {content.x + 18.0f, content.y + 18.0f, content.width - 36.0f, 30.0f},
+                                  t.text, ui::text_align::left);
+            ui::draw_text_in_rect("Delete this account from raythm-Server.",
+                                  13,
+                                  {content.x + 18.0f, content.y + 56.0f, 560.0f, 22.0f},
+                                  t.text_secondary, ui::text_align::left);
+            ui::draw_text_in_rect("This does not delete local songs or charts.",
+                                  12,
+                                  {content.x + 18.0f, content.y + 78.0f, 560.0f, 20.0f},
+                                  t.text_muted, ui::text_align::left);
+            draw_profile_button(settings_delete_account_rect(content), "DELETE ACCOUNT", !busy, t.error);
+        }
+
+        if (profile.loading && profile.loaded_once) {
+            ui::draw_text_in_rect("Refreshing...", 13,
+                                  {kDialogRect.x + 42.0f, kDialogRect.y + kDialogRect.height - 104.0f,
+                                   260.0f, 24.0f},
+                                  t.text_muted, ui::text_align::left);
+        }
+        if (profile.deleting) {
+            ui::draw_text_in_rect("Deleting...", 13,
+                                  {kDialogRect.x + 42.0f, kDialogRect.y + kDialogRect.height - 104.0f,
+                                   260.0f, 24.0f},
+                                  t.text_muted, ui::text_align::left);
+        }
+
+        if (profile.pending_delete == delete_target::account) {
+            const Rectangle confirm_panel = account_delete_panel_rect();
+            ui::draw_rect_f(confirm_panel, with_alpha(t.panel, 248));
+            ui::draw_rect_lines(confirm_panel, 2.0f, with_alpha(t.error, 220));
+            ui::draw_text_in_rect("Delete Account", 20,
+                                  {confirm_panel.x + 32.0f, confirm_panel.y + 24.0f,
+                                   confirm_panel.width - 64.0f, 30.0f},
+                                  t.text, ui::text_align::left);
+            ui::draw_text_in_rect("Enter your password to permanently delete this server account.",
+                                  12,
+                                  {confirm_panel.x + 32.0f, confirm_panel.y + 58.0f,
+                                   confirm_panel.width - 64.0f, 22.0f},
+                                  t.text_secondary, ui::text_align::left);
+            ui::draw_text_input(account_delete_password_rect(), profile.delete_password_input,
+                                "Pass", "Delete account password", nullptr,
+                                layer, 13, 64, ui::default_text_input_filter, 92.0f, true);
+            draw_profile_button(account_delete_confirm_rect(), "DELETE", !busy, t.error);
+            draw_profile_button(account_delete_cancel_rect(), "CANCEL", !busy, t.text_muted);
+        } else if (profile.pending_delete != delete_target::none) {
+            const Rectangle confirm_panel = {
+                kDialogRect.x + 540.0f,
+                kDialogRect.y + kDialogRect.height - 124.0f,
+                600.0f,
+                74.0f,
+            };
+            ui::draw_rect_f(confirm_panel, with_alpha(t.panel, 245));
+            ui::draw_rect_lines(confirm_panel, 2.0f, with_alpha(t.error, 210));
+            const std::string message = "Delete " + profile.pending_label + "? Hidden from Community listings.";
+            ui::draw_text_in_rect(message.c_str(), 12,
+                                  {confirm_panel.x + 18.0f, confirm_panel.y + 14.0f,
+                                   confirm_panel.width - 36.0f, 22.0f},
+                                  t.text, ui::text_align::left);
+            draw_profile_button(confirm_rect(), "DELETE", !busy, t.error);
+            draw_profile_button(cancel_rect(), "CANCEL", !busy, t.text_muted);
+        }
+        rlPopMatrix();
+    });
+}
+
+}  // namespace title_profile_view

--- a/src/scenes/title/profile_view.h
+++ b/src/scenes/title/profile_view.h
@@ -1,0 +1,89 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "network/auth_client.h"
+#include "raylib.h"
+#include "song_select/song_select_state.h"
+#include "ui_draw.h"
+#include "ui_text_input.h"
+
+namespace title_profile_view {
+
+enum class tab {
+    overview,
+    activity,
+    songs,
+    charts,
+    settings,
+};
+
+enum class delete_target {
+    none,
+    account,
+    song,
+    chart,
+};
+
+enum class command_type {
+    none,
+    close,
+    delete_account,
+    delete_song,
+    delete_chart,
+};
+
+struct command {
+    command_type type = command_type::none;
+    std::string id;
+    std::string password;
+};
+
+struct activity_item {
+    std::string song_title;
+    std::string artist;
+    std::string difficulty_name;
+    std::string local_summary;
+    std::string online_summary;
+};
+
+struct load_result {
+    auth::my_uploads_result uploads;
+    auth::profile_rankings_result rankings;
+    std::vector<activity_item> activity;
+    std::vector<activity_item> first_place_records;
+};
+
+struct state {
+    bool open = false;
+    bool closing = false;
+    bool loading = false;
+    bool deleting = false;
+    bool loaded_once = false;
+    float open_anim = 0.0f;
+    tab selected_tab = tab::overview;
+    float activity_scroll = 0.0f;
+    float song_scroll = 0.0f;
+    float chart_scroll = 0.0f;
+    auth::my_uploads_result uploads;
+    auth::profile_rankings_result rankings;
+    std::vector<activity_item> activity;
+    std::vector<activity_item> first_place_records;
+    delete_target pending_delete = delete_target::none;
+    std::string pending_id;
+    std::string pending_label;
+    ui::text_input_state delete_password_input;
+};
+
+Rectangle bounds();
+void open(state& profile);
+void close(state& profile);
+void clamp_scroll(state& profile);
+command update(state& profile, bool request_active);
+void draw(state& profile,
+          const song_select::auth_state& auth_state,
+          bool request_active,
+          ui::draw_layer layer = ui::draw_layer::modal);
+
+}  // namespace title_profile_view

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -1,5 +1,6 @@
 #include "title_scene.h"
 
+#include <algorithm>
 #include <array>
 #include <cctype>
 #include <chrono>
@@ -19,6 +20,7 @@
 #include "scene_manager.h"
 #include "song_select/song_catalog_service.h"
 #include "song_select/song_import_export_service.h"
+#include "song_select/song_select_last_played.h"
 #include "song_select/song_select_command_controller.h"
 #include "song_select/song_select_confirmation_dialog.h"
 #include "song_select/song_select_detail_view.h"
@@ -432,6 +434,176 @@ void title_scene::poll_create_upload() {
     }
 }
 
+void title_scene::open_profile() {
+    title_profile_view::open(profile_state_);
+    request_profile_reload();
+}
+
+void title_scene::request_profile_reload() {
+    if (profile_state_.loading) {
+        return;
+    }
+
+    profile_state_.loading = true;
+    std::promise<title_profile_view::load_result> promise;
+    profile_load_future_ = promise.get_future();
+    std::thread([promise = std::move(promise)]() mutable {
+        try {
+            title_profile_view::load_result loaded;
+            loaded.uploads = auth::fetch_my_community_uploads();
+            loaded.rankings = auth::fetch_my_profile_rankings();
+
+            auto to_activity_item = [](const auth::profile_ranking_record& record) {
+                title_profile_view::activity_item item;
+                item.song_title = record.song_title;
+                item.artist = record.artist;
+                item.difficulty_name = record.difficulty_name;
+                item.local_summary = "Score " + std::to_string(record.score);
+                item.online_summary = "Online #" + std::to_string(record.placement) +
+                                      " / " + std::to_string(record.score);
+                return item;
+            };
+
+            if (loaded.rankings.success) {
+                for (const auth::profile_ranking_record& record : loaded.rankings.recent_records) {
+                    loaded.activity.push_back(to_activity_item(record));
+                }
+                for (const auth::profile_ranking_record& record : loaded.rankings.first_place_records) {
+                    loaded.first_place_records.push_back(to_activity_item(record));
+                }
+            }
+
+            promise.set_value(std::move(loaded));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+void title_scene::poll_profile() {
+    if (profile_state_.loading &&
+        profile_load_future_.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready) {
+        title_profile_view::load_result loaded;
+        try {
+            loaded = profile_load_future_.get();
+        } catch (const std::exception& ex) {
+            loaded.uploads = {
+                .success = false,
+                .message = ex.what(),
+            };
+        } catch (...) {
+            loaded.uploads = {
+                .success = false,
+                .message = "Failed to load profile.",
+            };
+        }
+        profile_state_.uploads = std::move(loaded.uploads);
+        profile_state_.rankings = std::move(loaded.rankings);
+        profile_state_.activity = std::move(loaded.activity);
+        profile_state_.first_place_records = std::move(loaded.first_place_records);
+        profile_state_.loading = false;
+        profile_state_.loaded_once = true;
+        title_profile_view::clamp_scroll(profile_state_);
+        if (!profile_state_.uploads.success) {
+            ui::notify(profile_state_.uploads.message, ui::notice_tone::error, 3.0f);
+        } else if (!profile_state_.rankings.success) {
+            ui::notify(profile_state_.rankings.message, ui::notice_tone::error, 3.0f);
+        }
+    }
+
+    if (!profile_state_.deleting ||
+        profile_delete_future_.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready) {
+        return;
+    }
+
+    auth::operation_result result;
+    try {
+        result = profile_delete_future_.get();
+    } catch (const std::exception& ex) {
+        result.success = false;
+        result.message = ex.what();
+    } catch (...) {
+        result.success = false;
+        result.message = "Delete failed.";
+    }
+    profile_state_.deleting = false;
+    profile_state_.pending_delete = title_profile_view::delete_target::none;
+    profile_state_.pending_id.clear();
+    profile_state_.pending_label.clear();
+    ui::notify(result.message, result.success ? ui::notice_tone::success : ui::notice_tone::error, 3.0f);
+    if (result.success) {
+        title_online_view::reload_catalog(online_state_);
+        request_play_catalog_reload("", "", mode_ == hub_mode::play || mode_ == hub_mode::create);
+        request_profile_reload();
+    }
+}
+
+void title_scene::start_profile_delete_song(std::string song_id) {
+    if (profile_state_.deleting) {
+        return;
+    }
+
+    profile_state_.deleting = true;
+    std::promise<auth::operation_result> promise;
+    profile_delete_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), song_id = std::move(song_id)]() mutable {
+        try {
+            promise.set_value(auth::delete_community_song_upload(song_id));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+void title_scene::start_profile_delete_chart(std::string chart_id) {
+    if (profile_state_.deleting) {
+        return;
+    }
+
+    profile_state_.deleting = true;
+    std::promise<auth::operation_result> promise;
+    profile_delete_future_ = promise.get_future();
+    std::thread([promise = std::move(promise), chart_id = std::move(chart_id)]() mutable {
+        try {
+            promise.set_value(auth::delete_community_chart_upload(chart_id));
+        } catch (...) {
+            promise.set_exception(std::current_exception());
+        }
+    }).detach();
+}
+
+bool title_scene::handle_profile_input() {
+    const title_profile_view::command command =
+        title_profile_view::update(profile_state_, auth_controller_.request_active);
+    switch (command.type) {
+    case title_profile_view::command_type::delete_account:
+        if (command.password.empty()) {
+            ui::notify("Password is required to delete the account.", ui::notice_tone::error, 2.8f);
+        } else {
+            play_state_.login_dialog.password_input.value = command.password;
+            auth_overlay::start_request(auth_controller_, play_state_.login_dialog,
+                                        song_select::login_dialog_command::request_delete_account);
+            title_profile_view::close(profile_state_);
+        }
+        return true;
+    case title_profile_view::command_type::delete_song:
+        start_profile_delete_song(command.id);
+        return true;
+    case title_profile_view::command_type::delete_chart:
+        start_profile_delete_chart(command.id);
+        return true;
+    case title_profile_view::command_type::close:
+        return true;
+    case title_profile_view::command_type::none:
+        return profile_state_.open;
+    }
+    return profile_state_.open;
+}
+
+void title_scene::draw_profile_modal() {
+    title_profile_view::draw(profile_state_, play_state_.auth, auth_controller_.request_active, kTitleModalLayer);
+}
+
 void title_scene::apply_play_delete_result(const song_select::delete_result& result) {
     play_state_.confirmation_dialog = {};
     if (!result.success) {
@@ -736,9 +908,13 @@ void title_scene::update_common_animation(float dt) {
     poll_play_ranking_reload();
     poll_scoring_ruleset_warm();
     poll_create_upload();
+    poll_profile();
     title_online_view::poll_song_page(online_state_);
     title_online_view::poll_chart_page(online_state_);
     title_online_view::poll_owned(online_state_);
+    if (profile_state_.open && !play_state_.auth.logged_in) {
+        title_profile_view::close(profile_state_);
+    }
     if (title_online_view::poll_download(online_state_)) {
         preferred_song_id_ = title_online_view::selected_song_id(online_state_);
         preferred_chart_id_.clear();
@@ -759,6 +935,18 @@ void title_scene::update_common_animation(float dt) {
         play_state_.login_dialog.open_anim = tween::advance(play_state_.login_dialog.open_anim, dt, 8.0f);
     } else {
         play_state_.login_dialog.open_anim = 0.0f;
+    }
+
+    if (profile_state_.open && profile_state_.closing) {
+        profile_state_.open_anim = tween::retreat(profile_state_.open_anim, dt, 8.0f);
+        if (profile_state_.open_anim <= 0.0f) {
+            profile_state_.open = false;
+            profile_state_.closing = false;
+        }
+    } else if (profile_state_.open) {
+        profile_state_.open_anim = tween::advance(profile_state_.open_anim, dt, 8.0f);
+    } else {
+        profile_state_.open_anim = 0.0f;
     }
 
     const float target_anim = mode_ == hub_mode::title ? 0.0f : 1.0f;
@@ -949,6 +1137,7 @@ void title_scene::on_enter() {
     play_state_.ranking_panel.selected_source = ranking_service::source::local;
     auth_overlay::refresh_auth_state(play_state_.auth);
     scoring_ruleset_loading_ = false;
+    profile_state_ = {};
     request_scoring_ruleset_warm(true);
     play_state_.recent_result_offset = recent_result_offset_;
     if (play_intro_fade_) {
@@ -981,6 +1170,7 @@ void title_scene::on_enter() {
 
 void title_scene::on_exit() {
     play_state_.login_dialog.open = false;
+    title_profile_view::close(profile_state_);
     transfer_controller_.on_exit();
     title_online_view::on_exit(online_state_);
     audio_controller_.on_exit();
@@ -994,6 +1184,9 @@ void title_scene::update(float dt) {
     }
     if (play_state_.confirmation_dialog.open) {
         ui::register_hit_region(song_select::layout::kConfirmDialogRect, song_select::layout::kModalLayer);
+    }
+    if (profile_state_.open) {
+        ui::register_hit_region(title_profile_view::bounds(), kTitleModalLayer);
     }
     update_common_animation(dt);
 
@@ -1031,6 +1224,10 @@ void title_scene::update(float dt) {
     }
 
     if (transfer_controller_.busy()) {
+        return;
+    }
+
+    if (handle_profile_input()) {
         return;
     }
 
@@ -1132,12 +1329,16 @@ void title_scene::draw() {
                 [this](const song_select::transfer_result& result) { apply_play_transfer_result(result); });
         }
     }
+    draw_profile_modal();
     const song_select::login_dialog_command login_command =
         song_select::draw_login_dialog(play_state_.auth, play_state_.login_dialog,
                                        account_dialog_anchor, screen_rect,
                                        auth_controller_.request_active, kTitleModalLayer);
     if (login_command == song_select::login_dialog_command::close) {
         play_state_.login_dialog.open = false;
+    } else if (login_command == song_select::login_dialog_command::request_profile) {
+        play_state_.login_dialog.open = false;
+        open_profile();
     } else if (login_command != song_select::login_dialog_command::none) {
         auth_overlay::start_request(auth_controller_, play_state_.login_dialog, login_command);
     }

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "scene.h"
+#include "network/auth_client.h"
 #include "ranking_service.h"
 #include "shared/auth_overlay_controller.h"
 #include "song_select/song_catalog_service.h"
@@ -9,6 +10,7 @@
 #include "song_select/song_transfer_controller.h"
 #include "title/create_upload_client.h"
 #include "title/online_download_view.h"
+#include "title/profile_view.h"
 #include "title/title_audio_controller.h"
 #include <future>
 #include <optional>
@@ -81,6 +83,13 @@ private:
     void start_chart_upload(const song_select::song_entry& song,
                             const song_select::chart_option& chart);
     void poll_create_upload();
+    void open_profile();
+    void request_profile_reload();
+    void poll_profile();
+    bool handle_profile_input();
+    void draw_profile_modal();
+    void start_profile_delete_song(std::string song_id);
+    void start_profile_delete_chart(std::string chart_id);
     void update_home_pointer_suppression();
     bool handle_title_input(bool left_click_for_home, bool right_click_for_home);
     bool handle_home_input();
@@ -122,6 +131,9 @@ private:
     int play_ranking_pending_generation_ = 0;
     std::future<bool> scoring_ruleset_future_;
     bool scoring_ruleset_loading_ = false;
+    title_profile_view::state profile_state_;
+    std::future<title_profile_view::load_result> profile_load_future_;
+    std::future<auth::operation_result> profile_delete_future_;
     bool play_catalog_reload_pending_ = false;
     bool play_catalog_sync_media_on_apply_ = false;
     bool queued_play_catalog_sync_media_on_apply_ = false;


### PR DESCRIPTION
## 概要
- 既存のアカウントメニューに `PROFILE` ボタンを追加し、そこからプロフィール画面へ遷移するようにしました。
- プロフィール画面は `OVERVIEW` / `ACTIVITY` / `SONGS` / `CHARTS` / `SETTINGS` タブ構成にしました。
- タブ表示を枠付きボタン風から、プロフィール内ナビゲーションらしい下線インジケータ式のタブバーへ変更しました。
- プロフィール内コンテンツ矩形の下余白を左右余白と揃えました。
- プロフィール画面の表示時と閉じる時に、軽いスライド/スケールのアニメーションを追加しました。
- `MY UPLOADS` の独立ボタンを Create Tools から削除し、プロフィール内の `SONGS` / `CHARTS` タブへ統合しました。
- アカウント削除はプロフィールの `SETTINGS` タブへ移し、`DELETE ACCOUNT` を押した後にパスワード入力付き確認ポップアップを出すようにしました。
- `DELETE ACCOUNT` ボタンの文字が収まるようにボタン幅を調整しました。
- アカウントメニュー側の削除導線は外しました。
- プロフィール読み込みでサーバーの `/me/profile/rankings` を参照し、最近のオンラインプレイ履歴と現在1位の記録を表示できるようにしました。
- プロフィール UI を `src/scenes/title/profile_view.*` に分離し、今後タブを増やしやすい構成にしました。

## 補足
- サーバー側には `play_history` テーブルと `/me/profile/rankings` の追加が必要です。`raythm-Server` 側では `95ecbad Add profile ranking history endpoint` としてローカルコミット済みです。
- Ubuntu側の `/home/raythm/raythm-server` には反映済みで、migration `20260426060000_add_play_history` も適用済みです。

## 確認
- `cmake --build cmake-build-codex --target raythm`
- `cmake --build cmake-build-codex --target song_select_state_smoke`
- `./cmake-build-codex/song_select_state_smoke.exe`