### PR TITLE
コンテンツIDを外部化してダウンロード/アップロード判定を安定化

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,10 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/chart_parser.h
         src/gameplay/chart_difficulty.cpp
         src/gameplay/chart_difficulty.h
+        src/gameplay/chart_identity_store.cpp
+        src/gameplay/chart_identity_store.h
+        src/gameplay/chart_fingerprint.cpp
+        src/gameplay/chart_fingerprint.h
         src/gameplay/chart_level_cache.cpp
         src/gameplay/chart_level_cache.h
         src/gameplay/chart_serializer.cpp
@@ -140,6 +144,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/gameplay/score_system.h
         src/gameplay/song_loader.cpp
         src/gameplay/song_loader.h
+        src/gameplay/song_fingerprint.cpp
+        src/gameplay/song_fingerprint.h
         src/gameplay/song_writer.cpp
         src/gameplay/song_writer.h
         src/gameplay/timing_engine.cpp
@@ -190,6 +196,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/title/title_header_view.h
         src/scenes/title/create_upload_client.cpp
         src/scenes/title/create_upload_client.h
+        src/scenes/title/upload_mapping_store.cpp
+        src/scenes/title/upload_mapping_store.h
         src/scenes/title/online_download_internal.h
         src/scenes/title/online_download_catalog.cpp
         src/scenes/title/online_download_remote_client.cpp
@@ -397,8 +405,12 @@ add_executable(chart_parser_smoke
 add_executable(chart_serializer_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
+        src/gameplay/chart_fingerprint.cpp
+        src/gameplay/chart_fingerprint.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
+        src/updater/update_verify.cpp
+        src/updater/update_verify.h
         src/tests/chart_serializer_smoke.cpp
         src/models/data_models.h)
 
@@ -431,8 +443,19 @@ add_executable(song_loader_smoke
         src/gameplay/chart_parser.cpp
         src/gameplay/chart_parser.h
         src/models/data_models.h
+        src/core/app_paths.cpp
+        src/core/app_paths.h
+        src/core/path_utils.h
+        src/gameplay/chart_identity_store.cpp
+        src/gameplay/chart_identity_store.h
+        src/gameplay/song_fingerprint.cpp
+        src/gameplay/song_fingerprint.h
         src/gameplay/song_loader.cpp
         src/gameplay/song_loader.h
+        src/gameplay/song_writer.cpp
+        src/gameplay/song_writer.h
+        src/updater/update_verify.cpp
+        src/updater/update_verify.h
         src/tests/song_loader_smoke.cpp)
 
 add_executable(song_select_state_smoke
@@ -450,6 +473,13 @@ add_executable(settings_io_smoke
         src/gameplay/settings_io.cpp
         src/gameplay/settings_io.h
         src/tests/settings_io_smoke.cpp)
+
+add_executable(upload_mapping_store_smoke
+        src/core/app_paths.cpp
+        src/core/app_paths.h
+        src/scenes/title/upload_mapping_store.cpp
+        src/scenes/title/upload_mapping_store.h
+        src/tests/upload_mapping_store_smoke.cpp)
 
 add_executable(mv_storage_smoke
         src/core/app_paths.cpp
@@ -496,10 +526,16 @@ add_executable(ranking_service_smoke
         src/core/app_paths.cpp
         src/core/app_paths.h
         src/models/data_models.h
+        src/gameplay/chart_fingerprint.cpp
+        src/gameplay/chart_fingerprint.h
         src/gameplay/ranking_service.cpp
         src/gameplay/ranking_service.h
         src/gameplay/scoring_ruleset_runtime.cpp
         src/gameplay/scoring_ruleset_runtime.h
+        src/gameplay/song_fingerprint.cpp
+        src/gameplay/song_fingerprint.h
+        src/scenes/title/upload_mapping_store.cpp
+        src/scenes/title/upload_mapping_store.h
         src/network/auth_client.cpp
         src/network/auth_client.h
         src/network/json_helpers.cpp
@@ -575,6 +611,8 @@ add_executable(editor_flow_controller_smoke
         src/scenes/editor/editor_timing_panel.h
         src/gameplay/chart_serializer.cpp
         src/gameplay/chart_serializer.h
+        src/gameplay/chart_identity_store.cpp
+        src/gameplay/chart_identity_store.h
         src/gameplay/timing_engine.cpp
         src/gameplay/timing_engine.h
         src/models/data_models.h
@@ -736,6 +774,7 @@ target_include_directories(editor_meter_map_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS}
 target_include_directories(song_loader_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(song_select_state_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(settings_io_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(upload_mapping_store_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(input_handler_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(timing_engine_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(judge_system_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
@@ -758,12 +797,14 @@ target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32 c
 target_link_libraries(raythm_launcher PRIVATE winhttp)
 target_link_libraries(raythm_updater PRIVATE winhttp)
 target_link_libraries(update_version_smoke PRIVATE winhttp)
+target_link_libraries(upload_mapping_store_smoke PRIVATE crypt32)
 target_link_libraries(song_select_state_smoke PRIVATE raylib)
 target_link_libraries(settings_io_smoke PRIVATE raylib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
 target_link_libraries(judge_system_smoke PRIVATE raylib)
 target_link_libraries(ranking_service_smoke PRIVATE crypt32 winhttp)
 target_link_libraries(play_flow_controller_smoke PRIVATE raylib)
+target_link_libraries(editor_flow_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_timeline_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_panel_controller_smoke PRIVATE raylib)
 target_link_libraries(audio_manager_smoke PRIVATE ${RAYTHM_BASS_IMPORT_LIB})

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -114,6 +114,10 @@ std::filesystem::path source_verification_cache_path() {
     return app_data_root() / "source_verification_cache.txt";
 }
 
+std::filesystem::path chart_identity_index_path() {
+    return app_data_root() / "chart_identity_index.txt";
+}
+
 std::filesystem::path mvs_root() {
     return app_data_root() / "mvs";
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -56,6 +56,9 @@ std::filesystem::path scoring_ruleset_cache_path();
 // AppData/Local/raythm/source_verification_cache.txt
 std::filesystem::path source_verification_cache_path();
 
+// AppData/Local/raythm/chart_identity_index.txt
+std::filesystem::path chart_identity_index_path();
+
 // AppData/Local/raythm/mvs/
 std::filesystem::path mvs_root();
 

--- a/src/gameplay/chart_fingerprint.cpp
+++ b/src/gameplay/chart_fingerprint.cpp
@@ -1,0 +1,130 @@
+#include "chart_fingerprint.h"
+
+#include <cctype>
+#include <fstream>
+#include <iterator>
+#include <string>
+#include <vector>
+
+#include "updater/update_verify.h"
+
+namespace {
+
+std::string normalize_newlines(std::string_view content) {
+    std::string normalized;
+    normalized.reserve(content.size());
+
+    for (size_t index = 0; index < content.size(); ++index) {
+        const char ch = content[index];
+        if (ch == '\r' && index + 1 < content.size() && content[index + 1] == '\n') {
+            normalized.push_back('\n');
+            ++index;
+            continue;
+        }
+        normalized.push_back(ch);
+    }
+
+    return normalized;
+}
+
+std::vector<std::string> split_preserve_trailing_empty(std::string_view content) {
+    std::vector<std::string> lines;
+    size_t start = 0;
+    while (start <= content.size()) {
+        const size_t end = content.find('\n', start);
+        if (end == std::string_view::npos) {
+            lines.emplace_back(content.substr(start));
+            break;
+        }
+        lines.emplace_back(content.substr(start, end - start));
+        start = end + 1;
+    }
+    return lines;
+}
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+
+    return std::string(value.substr(start, end - start));
+}
+
+std::string trim_end(std::string value) {
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back()))) {
+        value.pop_back();
+    }
+    return value;
+}
+
+std::string read_text_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        return {};
+    }
+    return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+namespace chart_fingerprint {
+
+std::string build(std::string_view content) {
+    const std::string normalized = normalize_newlines(content);
+    const std::vector<std::string> lines = split_preserve_trailing_empty(normalized);
+    std::vector<std::string> kept_lines;
+    kept_lines.reserve(lines.size());
+
+    bool in_metadata = false;
+    for (const std::string& line : lines) {
+        const std::string trimmed = trim(line);
+
+        if (trimmed == "[Metadata]") {
+            in_metadata = true;
+            kept_lines.push_back(trim_end(line));
+            continue;
+        }
+
+        if (in_metadata && trimmed.size() >= 2 && trimmed.front() == '[' && trimmed.back() == ']') {
+            in_metadata = false;
+        }
+
+        if (in_metadata) {
+            const size_t separator_index = line.find('=');
+            if (separator_index != std::string::npos) {
+                const std::string key = trim(std::string_view(line).substr(0, separator_index));
+                if (key == "chartId" || key == "songId") {
+                    continue;
+                }
+            }
+        }
+
+        kept_lines.push_back(trim_end(line));
+    }
+
+    std::string result;
+    for (size_t index = 0; index < kept_lines.size(); ++index) {
+        if (index > 0) {
+            result.push_back('\n');
+        }
+        result += kept_lines[index];
+    }
+    return result;
+}
+
+std::optional<std::string> compute_sha256_hex(const std::filesystem::path& chart_path) {
+    const std::string content = read_text_file(chart_path);
+    if (content.empty()) {
+        return std::nullopt;
+    }
+    const std::string fingerprint = build(content);
+    return updater::compute_sha256_hex(std::string_view(fingerprint));
+}
+
+}  // namespace chart_fingerprint

--- a/src/gameplay/chart_fingerprint.h
+++ b/src/gameplay/chart_fingerprint.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace chart_fingerprint {
+
+std::string build(std::string_view content);
+std::optional<std::string> compute_sha256_hex(const std::filesystem::path& chart_path);
+
+}  // namespace chart_fingerprint

--- a/src/gameplay/chart_identity_store.cpp
+++ b/src/gameplay/chart_identity_store.cpp
@@ -1,0 +1,137 @@
+#include "chart_identity_store.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "app_paths.h"
+
+namespace chart_identity {
+namespace {
+
+constexpr char kHeader[] = "# raythm chart identity index v1";
+
+struct entry {
+    std::string chart_id;
+    std::string song_id;
+};
+
+std::vector<std::string> split_tab_fields(const std::string& line) {
+    std::vector<std::string> fields;
+    size_t start = 0;
+    while (start <= line.size()) {
+        const size_t end = line.find('\t', start);
+        if (end == std::string::npos) {
+            fields.push_back(line.substr(start));
+            break;
+        }
+        fields.push_back(line.substr(start, end - start));
+        start = end + 1;
+    }
+    return fields;
+}
+
+std::vector<entry> load_entries() {
+    std::ifstream input(app_paths::chart_identity_index_path(), std::ios::binary);
+    if (!input.is_open()) {
+        return {};
+    }
+
+    std::vector<entry> entries;
+    std::string line;
+    while (std::getline(input, line)) {
+        while (!line.empty() && (line.back() == '\r' || line.back() == '\n')) {
+            line.pop_back();
+        }
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+
+        const std::vector<std::string> fields = split_tab_fields(line);
+        if (fields.size() >= 2 && !fields[0].empty() && !fields[1].empty()) {
+            entries.push_back({
+                .chart_id = fields[0],
+                .song_id = fields[1],
+            });
+        }
+    }
+    return entries;
+}
+
+void save_entries(const std::vector<entry>& entries) {
+    app_paths::ensure_directories();
+    std::ofstream output(app_paths::chart_identity_index_path(), std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return;
+    }
+
+    output << kHeader << '\n';
+    for (const entry& item : entries) {
+        output << item.chart_id << '\t' << item.song_id << '\n';
+    }
+}
+
+}  // namespace
+
+std::optional<std::string> find_song_id(const std::string& chart_id) {
+    if (chart_id.empty()) {
+        return std::nullopt;
+    }
+
+    for (const entry& item : load_entries()) {
+        if (item.chart_id == chart_id) {
+            return item.song_id;
+        }
+    }
+    return std::nullopt;
+}
+
+void put(const std::string& chart_id, const std::string& song_id) {
+    if (chart_id.empty() || song_id.empty()) {
+        return;
+    }
+
+    std::vector<entry> entries = load_entries();
+    for (entry& item : entries) {
+        if (item.chart_id == chart_id) {
+            item.song_id = song_id;
+            save_entries(entries);
+            return;
+        }
+    }
+
+    entries.push_back({
+        .chart_id = chart_id,
+        .song_id = song_id,
+    });
+    save_entries(entries);
+}
+
+void remove(const std::string& chart_id) {
+    if (chart_id.empty()) {
+        return;
+    }
+
+    std::vector<entry> entries = load_entries();
+    std::erase_if(entries, [&](const entry& item) {
+        return item.chart_id == chart_id;
+    });
+    save_entries(entries);
+}
+
+void remove_for_song(const std::string& song_id) {
+    if (song_id.empty()) {
+        return;
+    }
+
+    std::vector<entry> entries = load_entries();
+    std::erase_if(entries, [&](const entry& item) {
+        return item.song_id == song_id;
+    });
+    save_entries(entries);
+}
+
+}  // namespace chart_identity

--- a/src/gameplay/chart_identity_store.h
+++ b/src/gameplay/chart_identity_store.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace chart_identity {
+
+std::optional<std::string> find_song_id(const std::string& chart_id);
+void put(const std::string& chart_id, const std::string& song_id);
+void remove(const std::string& chart_id);
+void remove_for_song(const std::string& song_id);
+
+}  // namespace chart_identity

--- a/src/gameplay/chart_parser.cpp
+++ b/src/gameplay/chart_parser.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <array>
 #include <cctype>
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <optional>
@@ -167,6 +168,9 @@ chart_parse_result chart_parser::parse(const std::string& file_path) {
 
     chart_data data;
     data.meta = parse_metadata(sections["Metadata"], errors);
+    if (data.meta.chart_id.empty()) {
+        data.meta.chart_id = path_utils::to_utf8(path_utils::from_utf8(file_path).stem());
+    }
     data.timing_events = parse_timing(sections["Timing"], errors);
     data.notes = parse_notes(sections["Notes"], errors);
 
@@ -250,8 +254,7 @@ chart_meta chart_parser::parse_metadata(const std::vector<numbered_line>& lines,
         }
     }
 
-    const std::array<std::string, 6> required_fields = {
-        "chartId",
+    const std::array<std::string, 5> required_fields = {
         "keyCount",
         "difficulty",
         "chartAuthor",

--- a/src/gameplay/chart_serializer.cpp
+++ b/src/gameplay/chart_serializer.cpp
@@ -47,16 +47,12 @@ bool chart_serializer::serialize(const chart_data& data, const std::string& file
     }
 
     output << "[Metadata]\n";
-    output << "chartId=" << data.meta.chart_id << '\n';
     output << "keyCount=" << data.meta.key_count << '\n';
     output << "difficulty=" << data.meta.difficulty << '\n';
     output << "chartAuthor=" << data.meta.chart_author << '\n';
     output << "formatVersion=" << data.meta.format_version << '\n';
     output << "resolution=" << data.meta.resolution << '\n';
     output << "offset=" << data.meta.offset << '\n';
-    if (!data.meta.song_id.empty()) {
-        output << "songId=" << data.meta.song_id << '\n';
-    }
     output << '\n';
 
     std::vector<timing_event> sorted_timing = data.timing_events;

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -591,6 +591,13 @@ std::string expected_remote_song_id(const std::string& server_url,
         .value_or(local_song_id);
 }
 
+std::string expected_remote_chart_id(const std::string& server_url,
+                                     const std::string& local_chart_id) {
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    return title_upload_mapping::find_remote_chart_id(mappings, server_url, local_chart_id)
+        .value_or(local_chart_id);
+}
+
 struct local_official_hashes {
     std::string song_json_sha256;
     std::string song_json_fingerprint;
@@ -688,8 +695,10 @@ verification_result verify_official_manifest(const song_data& song,
                                              const std::string& chart_path,
                                              const chart_meta& chart,
                                              const std::string& server_url) {
+    const std::string remote_song_id = expected_remote_song_id(server_url, song.meta.song_id);
+    const std::string remote_chart_id = expected_remote_chart_id(server_url, chart.chart_id);
     const ranking_client::manifest_operation_result manifest_result =
-        ranking_client::fetch_official_chart_manifest(server_url, chart.chart_id);
+        ranking_client::fetch_official_chart_manifest(server_url, remote_chart_id);
     if (!manifest_result.success || !manifest_result.manifest.has_value()) {
         return {
             .success = false,
@@ -709,8 +718,8 @@ verification_result verify_official_manifest(const song_data& song,
         };
     }
 
-    if (manifest.chart_id != chart.chart_id ||
-        manifest.song_id != expected_remote_song_id(server_url, song.meta.song_id)) {
+    if (manifest.chart_id != remote_chart_id ||
+        manifest.song_id != remote_song_id) {
         return {
             .success = false,
             .message = "Official chart verification failed because the manifest IDs do not match local content.",
@@ -1106,7 +1115,7 @@ online_submit_result submit_online_result(const song_data& song,
         ranking_client::submit_chart_ranking(
             stored->server_url,
             stored->access_token,
-            chart.chart_id,
+            expected_remote_chart_id(stored->server_url, chart.chart_id),
             result,
             recorded_at,
             submission_ruleset_version);
@@ -1124,7 +1133,7 @@ online_submit_result submit_online_result(const song_data& song,
         request = ranking_client::submit_chart_ranking(
             restored.session_data->server_url,
             restored.session_data->access_token,
-            chart.chart_id,
+            expected_remote_chart_id(restored.session_data->server_url, chart.chart_id),
             result,
             recorded_at,
             submission_ruleset_version);

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -15,10 +15,13 @@
 #include <vector>
 
 #include "app_paths.h"
+#include "chart_fingerprint.h"
 #include "network/auth_client.h"
 #include "network/ranking_client.h"
 #include "path_utils.h"
 #include "scoring_ruleset_runtime.h"
+#include "song_fingerprint.h"
+#include "title/upload_mapping_store.h"
 #include "updater/update_verify.h"
 
 #ifdef _WIN32
@@ -581,11 +584,20 @@ std::string lowercase(std::string value) {
     return value;
 }
 
+std::string expected_remote_song_id(const std::string& server_url,
+                                    const std::string& local_song_id) {
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    return title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id)
+        .value_or(local_song_id);
+}
+
 struct local_official_hashes {
     std::string song_json_sha256;
+    std::string song_json_fingerprint;
     std::string audio_sha256;
     std::string jacket_sha256;
     std::string chart_sha256;
+    std::string chart_fingerprint;
 };
 
 struct verification_result {
@@ -630,6 +642,12 @@ std::optional<local_official_hashes> compute_local_official_hashes(const song_da
         error_message = "Failed to hash local song.json for Official verification.";
         return std::nullopt;
     }
+    const std::optional<std::string> song_json_fingerprint_sha256 =
+        song_fingerprint::compute_sha256_hex(song_json_path);
+    if (!song_json_fingerprint_sha256.has_value()) {
+        error_message = "Failed to fingerprint local song.json for Official verification.";
+        return std::nullopt;
+    }
 
     const std::optional<std::string> audio_sha256 = updater::compute_sha256_hex(audio_path);
     if (!audio_sha256.has_value()) {
@@ -649,11 +667,20 @@ std::optional<local_official_hashes> compute_local_official_hashes(const song_da
         return std::nullopt;
     }
 
+    const std::optional<std::string> chart_fingerprint_sha256 =
+        chart_fingerprint::compute_sha256_hex(local_chart_path);
+    if (!chart_fingerprint_sha256.has_value()) {
+        error_message = "Failed to fingerprint local chart for Official verification.";
+        return std::nullopt;
+    }
+
     return local_official_hashes{
         .song_json_sha256 = *song_json_sha256,
+        .song_json_fingerprint = *song_json_fingerprint_sha256,
         .audio_sha256 = *audio_sha256,
         .jacket_sha256 = *jacket_sha256,
         .chart_sha256 = *chart_sha256,
+        .chart_fingerprint = *chart_fingerprint_sha256,
     };
 }
 
@@ -682,7 +709,8 @@ verification_result verify_official_manifest(const song_data& song,
         };
     }
 
-    if (manifest.chart_id != chart.chart_id || manifest.song_id != song.meta.song_id) {
+    if (manifest.chart_id != chart.chart_id ||
+        manifest.song_id != expected_remote_song_id(server_url, song.meta.song_id)) {
         return {
             .success = false,
             .message = "Official chart verification failed because the manifest IDs do not match local content.",
@@ -700,10 +728,22 @@ verification_result verify_official_manifest(const song_data& song,
     }
 
     for (const verification_result& result : {
-             compare_hash("song.json", local_hashes->song_json_sha256, manifest.song_json_sha256),
+             compare_hash("song.json",
+                          manifest.song_json_fingerprint.empty()
+                              ? local_hashes->song_json_sha256
+                              : local_hashes->song_json_fingerprint,
+                          manifest.song_json_fingerprint.empty()
+                              ? manifest.song_json_sha256
+                              : manifest.song_json_fingerprint),
              compare_hash("audio", local_hashes->audio_sha256, manifest.audio_sha256),
              compare_hash("jacket", local_hashes->jacket_sha256, manifest.jacket_sha256),
-             compare_hash("chart", local_hashes->chart_sha256, manifest.chart_sha256),
+             compare_hash("chart",
+                          manifest.chart_fingerprint.empty()
+                              ? local_hashes->chart_sha256
+                              : local_hashes->chart_fingerprint,
+                          manifest.chart_fingerprint.empty()
+                              ? manifest.chart_sha256
+                              : manifest.chart_fingerprint),
          }) {
         if (!result.success) {
             return result;

--- a/src/gameplay/song_fingerprint.cpp
+++ b/src/gameplay/song_fingerprint.cpp
@@ -1,0 +1,229 @@
+#include "song_fingerprint.h"
+
+#include <cctype>
+#include <fstream>
+#include <iomanip>
+#include <iterator>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#include "updater/update_verify.h"
+
+namespace {
+
+std::string trim(std::string_view value) {
+    size_t start = 0;
+    while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) {
+        ++start;
+    }
+    size_t end = value.size();
+    while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) {
+        --end;
+    }
+    return std::string(value.substr(start, end - start));
+}
+
+std::string unescape_json_string(std::string_view value) {
+    std::string result;
+    result.reserve(value.size());
+    for (size_t index = 0; index < value.size(); ++index) {
+        const char ch = value[index];
+        if (ch != '\\' || index + 1 >= value.size()) {
+            result.push_back(ch);
+            continue;
+        }
+
+        const char escaped = value[++index];
+        switch (escaped) {
+            case '"': result.push_back('"'); break;
+            case '\\': result.push_back('\\'); break;
+            case '/': result.push_back('/'); break;
+            case 'b': result.push_back('\b'); break;
+            case 'f': result.push_back('\f'); break;
+            case 'n': result.push_back('\n'); break;
+            case 'r': result.push_back('\r'); break;
+            case 't': result.push_back('\t'); break;
+            default:
+                result.push_back('\\');
+                result.push_back(escaped);
+                break;
+        }
+    }
+    return result;
+}
+
+std::optional<std::string> extract_json_string(std::string_view content, std::string_view key) {
+    const std::string token = "\"" + std::string(key) + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    size_t value_start = colon_pos + 1;
+    while (value_start < content.size() && std::isspace(static_cast<unsigned char>(content[value_start])) != 0) {
+        ++value_start;
+    }
+
+    if (value_start >= content.size() || content[value_start] != '"') {
+        return std::nullopt;
+    }
+
+    ++value_start;
+    size_t value_end = value_start;
+    while (value_end < content.size()) {
+        if (content[value_end] == '"' && content[value_end - 1] != '\\') {
+            return unescape_json_string(content.substr(value_start, value_end - value_start));
+        }
+        ++value_end;
+    }
+
+    return std::nullopt;
+}
+
+std::optional<std::string> extract_json_number_token(std::string_view content, std::string_view key) {
+    const std::string token = "\"" + std::string(key) + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string_view::npos) {
+        return std::nullopt;
+    }
+
+    size_t value_start = colon_pos + 1;
+    while (value_start < content.size() && std::isspace(static_cast<unsigned char>(content[value_start])) != 0) {
+        ++value_start;
+    }
+
+    size_t value_end = value_start;
+    while (value_end < content.size() && content[value_end] != ',' && content[value_end] != '}' &&
+           content[value_end] != '\n' && content[value_end] != '\r') {
+        ++value_end;
+    }
+
+    const std::string token_value = trim(content.substr(value_start, value_end - value_start));
+    if (token_value.empty()) {
+        return std::nullopt;
+    }
+    return token_value;
+}
+
+std::optional<double> parse_number(const std::string& value) {
+    try {
+        size_t parsed = 0;
+        const double result = std::stod(value, &parsed);
+        if (parsed != value.size()) {
+            return std::nullopt;
+        }
+        return result;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::optional<int> parse_int(const std::string& value) {
+    try {
+        size_t parsed = 0;
+        const int result = std::stoi(value, &parsed);
+        if (parsed != value.size()) {
+            return std::nullopt;
+        }
+        return result;
+    } catch (...) {
+        return std::nullopt;
+    }
+}
+
+std::string format_number(double value) {
+    std::ostringstream out;
+    out << std::setprecision(15) << value;
+    return out.str();
+}
+
+std::string canonical_string(std::string_view content) {
+    const std::optional<std::string> base_bpm = extract_json_number_token(content, "baseBpm");
+    const std::optional<std::string> preview_start_ms = extract_json_number_token(content, "previewStartMs");
+    const std::optional<std::string> chorus_start_seconds = extract_json_number_token(content, "chorusStartSeconds");
+    const std::optional<std::string> preview_start_seconds = extract_json_number_token(content, "previewStartSeconds");
+    const std::optional<std::string> song_version = extract_json_number_token(content, "songVersion");
+
+    std::string preview_ms = "0";
+    if (preview_start_ms.has_value()) {
+        if (const std::optional<int> parsed = parse_int(*preview_start_ms)) {
+            preview_ms = std::to_string(*parsed);
+        } else {
+            preview_ms = *preview_start_ms;
+        }
+    } else {
+        const std::optional<std::string> seconds =
+            chorus_start_seconds.has_value() ? chorus_start_seconds : preview_start_seconds;
+        if (seconds.has_value()) {
+            if (const std::optional<double> parsed = parse_number(*seconds)) {
+                preview_ms = std::to_string(static_cast<int>(*parsed * 1000.0));
+            } else {
+                preview_ms = *seconds;
+            }
+        }
+    }
+
+    std::string canonical_bpm;
+    if (base_bpm.has_value()) {
+        if (const std::optional<double> parsed = parse_number(*base_bpm)) {
+            canonical_bpm = format_number(*parsed);
+        } else {
+            canonical_bpm = *base_bpm;
+        }
+    }
+
+    std::string canonical_version = "1";
+    if (song_version.has_value()) {
+        if (const std::optional<int> parsed = parse_int(*song_version)) {
+            canonical_version = std::to_string(*parsed);
+        } else {
+            canonical_version = *song_version;
+        }
+    }
+
+    std::ostringstream out;
+    out << "title=" << extract_json_string(content, "title").value_or("") << '\n'
+        << "artist=" << extract_json_string(content, "artist").value_or("") << '\n'
+        << "baseBpm=" << canonical_bpm << '\n'
+        << "previewStartMs=" << preview_ms << '\n'
+        << "songVersion=" << canonical_version;
+    return out.str();
+}
+
+std::string read_text_file(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        return {};
+    }
+    return std::string(std::istreambuf_iterator<char>(input), std::istreambuf_iterator<char>());
+}
+
+}  // namespace
+
+namespace song_fingerprint {
+
+std::string build(std::string_view content) {
+    return canonical_string(content);
+}
+
+std::optional<std::string> compute_sha256_hex(const std::filesystem::path& song_json_path) {
+    const std::string content = read_text_file(song_json_path);
+    if (content.empty()) {
+        return std::nullopt;
+    }
+    const std::string fingerprint = build(content);
+    return updater::compute_sha256_hex(std::string_view(fingerprint));
+}
+
+}  // namespace song_fingerprint

--- a/src/gameplay/song_fingerprint.h
+++ b/src/gameplay/song_fingerprint.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <filesystem>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace song_fingerprint {
+
+std::string build(std::string_view content);
+std::optional<std::string> compute_sha256_hex(const std::filesystem::path& song_json_path);
+
+}  // namespace song_fingerprint

--- a/src/gameplay/song_loader.cpp
+++ b/src/gameplay/song_loader.cpp
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <string_view>
 
+#include "chart_identity_store.h"
 #include "path_utils.h"
 
 namespace {
@@ -169,7 +170,9 @@ std::optional<float> parse_float(const std::string& value) {
     }
 }
 
-std::optional<song_meta> parse_song_meta(const fs::path& song_json_path, std::vector<std::string>& errors) {
+std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
+                                         const std::string& fallback_song_id,
+                                         std::vector<std::string>& errors) {
     const std::string content = read_file(song_json_path);
     if (content.empty()) {
         errors.push_back("Failed to read song metadata file: " + path_utils::to_utf8(song_json_path));
@@ -190,7 +193,7 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path, std::ve
     const std::optional<std::string> song_version = extract_json_number_token(content, "songVersion");
 
     if (!song_id.has_value()) {
-        errors.push_back("Missing required field songId in " + path_utils::to_utf8(song_json_path));
+        meta.song_id = fallback_song_id;
     } else {
         meta.song_id = *song_id;
     }
@@ -307,7 +310,8 @@ song_load_result song_loader::load_all(const std::string& songs_dir) {
         }
 
         std::vector<std::string> song_errors;
-        const std::optional<song_meta> meta = parse_song_meta(song_json_path, song_errors);
+        const std::optional<song_meta> meta =
+            parse_song_meta(song_json_path, path_utils::to_utf8(song_dir.filename()), song_errors);
         if (!meta.has_value()) {
             result.errors.insert(result.errors.end(), song_errors.begin(), song_errors.end());
             continue;
@@ -350,7 +354,8 @@ song_load_result song_loader::load_directory(const std::string& song_dir_utf8) {
     }
 
     std::vector<std::string> song_errors;
-    const std::optional<song_meta> meta = parse_song_meta(song_json_path, song_errors);
+    const std::optional<song_meta> meta =
+        parse_song_meta(song_json_path, path_utils::to_utf8(song_dir.filename()), song_errors);
     if (!meta.has_value()) {
         result.errors = std::move(song_errors);
         return result;
@@ -389,7 +394,10 @@ void song_loader::attach_external_charts(const std::string& charts_dir, std::vec
             continue;
         }
 
-        const std::string& song_id = parse_result.data->meta.song_id;
+        std::string song_id = parse_result.data->meta.song_id;
+        if (song_id.empty()) {
+            song_id = chart_identity::find_song_id(parse_result.data->meta.chart_id).value_or("");
+        }
         if (song_id.empty()) {
             continue;
         }

--- a/src/gameplay/song_writer.cpp
+++ b/src/gameplay/song_writer.cpp
@@ -44,7 +44,6 @@ bool song_writer::write_song_json(const song_meta& meta, const std::string& dire
     }
 
     out << "{\n";
-    out << "  \"songId\": \"" << escape_json_string(meta.song_id) << "\",\n";
     out << "  \"title\": \"" << escape_json_string(meta.title) << "\",\n";
     out << "  \"artist\": \"" << escape_json_string(meta.artist) << "\",\n";
     out << "  \"baseBpm\": " << format_float(meta.base_bpm) << ",\n";

--- a/src/network/ranking_client.cpp
+++ b/src/network/ranking_client.cpp
@@ -376,9 +376,13 @@ std::optional<ranking_client::official_manifest> parse_official_manifest_respons
         .chart_id = *chart_id,
         .song_id = *song_id,
         .song_json_sha256 = json::extract_string(body, "song_json_sha256").value_or(""),
+        .song_json_fingerprint = json::extract_string(body, "song_json_fingerprint").value_or(
+            json::extract_string(body, "songJsonFingerprint").value_or("")),
         .audio_sha256 = json::extract_string(body, "audio_sha256").value_or(""),
         .jacket_sha256 = json::extract_string(body, "jacket_sha256").value_or(""),
         .chart_sha256 = json::extract_string(body, "chart_sha256").value_or(""),
+        .chart_fingerprint = json::extract_string(body, "chart_fingerprint").value_or(
+            json::extract_string(body, "chartFingerprint").value_or("")),
     };
 }
 
@@ -396,6 +400,8 @@ std::optional<ranking_client::song_manifest> parse_song_manifest_response(const 
             json::extract_string(body, "contentSource").value_or("")),
         .song_id = *song_id,
         .song_json_sha256 = json::extract_string(body, "song_json_sha256").value_or(""),
+        .song_json_fingerprint = json::extract_string(body, "song_json_fingerprint").value_or(
+            json::extract_string(body, "songJsonFingerprint").value_or("")),
         .audio_sha256 = json::extract_string(body, "audio_sha256").value_or(""),
         .jacket_sha256 = json::extract_string(body, "jacket_sha256").value_or(""),
     };

--- a/src/network/ranking_client.h
+++ b/src/network/ranking_client.h
@@ -51,9 +51,11 @@ struct official_manifest {
     std::string chart_id;
     std::string song_id;
     std::string song_json_sha256;
+    std::string song_json_fingerprint;
     std::string audio_sha256;
     std::string jacket_sha256;
     std::string chart_sha256;
+    std::string chart_fingerprint;
 };
 
 struct song_manifest {
@@ -62,6 +64,7 @@ struct song_manifest {
     std::string content_source;
     std::string song_id;
     std::string song_json_sha256;
+    std::string song_json_fingerprint;
     std::string audio_sha256;
     std::string jacket_sha256;
 };

--- a/src/scenes/editor/editor_flow_controller.cpp
+++ b/src/scenes/editor/editor_flow_controller.cpp
@@ -5,6 +5,7 @@
 #include <filesystem>
 
 #include "app_paths.h"
+#include "chart_identity_store.h"
 #include "chart_serializer.h"
 #include "path_utils.h"
 
@@ -104,6 +105,7 @@ bool save_to_path(const editor_flow_context& context, const std::string& file_pa
     }
 
     const std::string saved_path = path_utils::to_utf8(path);
+    chart_identity::put(context.chart_for_save->meta.chart_id, context.chart_for_save->meta.song_id);
     context.state->mark_saved(saved_path);
     context.save_dialog->error.clear();
     result.saved_chart_path = saved_path;

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -128,6 +128,13 @@ std::string expected_remote_song_id(const std::string& server_url,
         .value_or(local_song_id);
 }
 
+std::string expected_remote_chart_id(const std::string& server_url,
+                                     const std::string& local_chart_id) {
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    return title_upload_mapping::find_remote_chart_id(mappings, server_url, local_chart_id)
+        .value_or(local_chart_id);
+}
+
 std::string file_signature(const std::filesystem::path& path) {
     std::error_code ec;
     if (!std::filesystem::exists(path, ec) || !std::filesystem::is_regular_file(path, ec)) {
@@ -421,8 +428,9 @@ content_status verify_song_content_source(const song_data& song,
         return cached_status_for(cached, signature);
     }
 
+    const std::string remote_song_id = expected_remote_song_id(server_url, song.meta.song_id);
     const ranking_client::song_manifest_operation_result request =
-        ranking_client::fetch_song_manifest(server_url, song.meta.song_id);
+        ranking_client::fetch_song_manifest(server_url, remote_song_id);
     if (!request.success) {
         server_reachable = false;
         return cached_status_for(cached, signature);
@@ -432,7 +440,7 @@ content_status verify_song_content_source(const song_data& song,
     }
 
     const ranking_client::song_manifest& manifest = *request.manifest;
-    if (manifest.song_id != expected_remote_song_id(server_url, song.meta.song_id)) {
+    if (manifest.song_id != remote_song_id) {
         return content_status::local;
     }
 
@@ -504,8 +512,10 @@ content_status verify_chart_content_source(const song_data& song,
         return cached_status_for(cached, signature);
     }
 
+    const std::string remote_song_id = expected_remote_song_id(server_url, song.meta.song_id);
+    const std::string remote_chart_id = expected_remote_chart_id(server_url, chart.meta.chart_id);
     const ranking_client::manifest_operation_result request =
-        ranking_client::fetch_official_chart_manifest(server_url, chart.meta.chart_id);
+        ranking_client::fetch_official_chart_manifest(server_url, remote_chart_id);
     if (!request.success) {
         server_reachable = false;
         return cached_status_for(cached, signature);
@@ -515,8 +525,8 @@ content_status verify_chart_content_source(const song_data& song,
     }
 
     const ranking_client::official_manifest& manifest = *request.manifest;
-    if (manifest.chart_id != chart.meta.chart_id ||
-        manifest.song_id != expected_remote_song_id(server_url, song.meta.song_id)) {
+    if (manifest.chart_id != remote_chart_id ||
+        manifest.song_id != remote_song_id) {
         return content_status::local;
     }
 

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -10,6 +10,8 @@
 #include <unordered_map>
 
 #include "app_paths.h"
+#include "chart_fingerprint.h"
+#include "chart_identity_store.h"
 #include "chart_level_cache.h"
 #include "mv/mv_storage.h"
 #include "network/auth_client.h"
@@ -18,6 +20,8 @@
 #include "player_note_offsets.h"
 #include "ranking_service.h"
 #include "song_loader.h"
+#include "song_fingerprint.h"
+#include "title/upload_mapping_store.h"
 #include "updater/update_verify.h"
 
 namespace {
@@ -117,6 +121,13 @@ std::string current_manifest_server_url() {
     return auth::normalize_server_url(auth::kDefaultServerUrl);
 }
 
+std::string expected_remote_song_id(const std::string& server_url,
+                                    const std::string& local_song_id) {
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    return title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id)
+        .value_or(local_song_id);
+}
+
 std::string file_signature(const std::filesystem::path& path) {
     std::error_code ec;
     if (!std::filesystem::exists(path, ec) || !std::filesystem::is_regular_file(path, ec)) {
@@ -142,43 +153,67 @@ struct local_content_files {
 
 struct content_hashes {
     std::string song_json_sha256;
+    std::string song_json_fingerprint;
     std::string audio_sha256;
     std::string jacket_sha256;
     std::string chart_sha256;
+    std::string chart_fingerprint;
 };
 
 content_hashes manifest_hashes(const ranking_client::official_manifest& manifest) {
     return {
         manifest.song_json_sha256,
+        manifest.song_json_fingerprint,
         manifest.audio_sha256,
         manifest.jacket_sha256,
         manifest.chart_sha256,
+        manifest.chart_fingerprint,
     };
 }
 
 content_hashes manifest_song_hashes(const ranking_client::song_manifest& manifest) {
     return {
         manifest.song_json_sha256,
+        manifest.song_json_fingerprint,
         manifest.audio_sha256,
         manifest.jacket_sha256,
+        {},
         {},
     };
 }
 
 bool hashes_present(const content_hashes& hashes) {
-    return !hashes.song_json_sha256.empty() && !hashes.audio_sha256.empty() &&
-           !hashes.jacket_sha256.empty() && !hashes.chart_sha256.empty();
+    return (!hashes.song_json_fingerprint.empty() || !hashes.song_json_sha256.empty()) &&
+           !hashes.audio_sha256.empty() &&
+           !hashes.jacket_sha256.empty() &&
+           (!hashes.chart_fingerprint.empty() || !hashes.chart_sha256.empty());
 }
 
 bool song_hashes_present(const content_hashes& hashes) {
-    return !hashes.song_json_sha256.empty() && !hashes.audio_sha256.empty() &&
+    return (!hashes.song_json_fingerprint.empty() || !hashes.song_json_sha256.empty()) &&
+           !hashes.audio_sha256.empty() &&
            !hashes.jacket_sha256.empty();
 }
 
+bool song_json_hash_equal(const content_hashes& left, const content_hashes& right) {
+    if (!left.song_json_fingerprint.empty() && !right.song_json_fingerprint.empty()) {
+        return left.song_json_fingerprint == right.song_json_fingerprint;
+    }
+    return !left.song_json_sha256.empty() && !right.song_json_sha256.empty() &&
+           left.song_json_sha256 == right.song_json_sha256;
+}
+
 bool hashes_equal(const content_hashes& left, const content_hashes& right) {
-    return left.song_json_sha256 == right.song_json_sha256 &&
-           left.audio_sha256 == right.audio_sha256 &&
-           left.jacket_sha256 == right.jacket_sha256 &&
+    if (!song_json_hash_equal(left, right) ||
+        left.audio_sha256 != right.audio_sha256 ||
+        left.jacket_sha256 != right.jacket_sha256) {
+        return false;
+    }
+
+    if (!left.chart_fingerprint.empty() && !right.chart_fingerprint.empty()) {
+        return left.chart_fingerprint == right.chart_fingerprint;
+    }
+    return !left.chart_sha256.empty() && !right.chart_sha256.empty() &&
            left.chart_sha256 == right.chart_sha256;
 }
 
@@ -211,26 +246,35 @@ std::string song_content_signature(const song_data& song) {
 
 std::optional<content_hashes> compute_hashes(const local_content_files& files) {
     const std::optional<std::string> song_json = updater::compute_sha256_hex(files.song_json_path);
+    const std::optional<std::string> song_json_fingerprint =
+        song_fingerprint::compute_sha256_hex(files.song_json_path);
     const std::optional<std::string> audio = updater::compute_sha256_hex(files.audio_path);
     const std::optional<std::string> jacket = updater::compute_sha256_hex(files.jacket_path);
     const std::optional<std::string> chart = updater::compute_sha256_hex(files.chart_path);
-    if (!song_json.has_value() || !audio.has_value() || !jacket.has_value() || !chart.has_value()) {
+    const std::optional<std::string> fingerprint = chart_fingerprint::compute_sha256_hex(files.chart_path);
+    if (!song_json.has_value() || !song_json_fingerprint.has_value() ||
+        !audio.has_value() || !jacket.has_value() ||
+        !chart.has_value() || !fingerprint.has_value()) {
         return std::nullopt;
     }
-    return content_hashes{*song_json, *audio, *jacket, *chart};
+    return content_hashes{*song_json, *song_json_fingerprint, *audio, *jacket, *chart, *fingerprint};
 }
 
 std::optional<content_hashes> compute_song_hashes(const song_data& song) {
+    const std::filesystem::path song_json_path = path_utils::from_utf8(song.directory) / "song.json";
     const std::optional<std::string> song_json =
-        updater::compute_sha256_hex(path_utils::from_utf8(song.directory) / "song.json");
+        updater::compute_sha256_hex(song_json_path);
+    const std::optional<std::string> song_json_fingerprint =
+        song_fingerprint::compute_sha256_hex(song_json_path);
     const std::optional<std::string> audio =
         updater::compute_sha256_hex(path_utils::from_utf8(song.directory) / path_utils::from_utf8(song.meta.audio_file));
     const std::optional<std::string> jacket =
         updater::compute_sha256_hex(path_utils::from_utf8(song.directory) / path_utils::from_utf8(song.meta.jacket_file));
-    if (!song_json.has_value() || !audio.has_value() || !jacket.has_value()) {
+    if (!song_json.has_value() || !song_json_fingerprint.has_value() ||
+        !audio.has_value() || !jacket.has_value()) {
         return std::nullopt;
     }
-    return content_hashes{*song_json, *audio, *jacket, {}};
+    return content_hashes{*song_json, *song_json_fingerprint, *audio, *jacket, {}, {}};
 }
 
 struct verification_cache_record {
@@ -283,9 +327,13 @@ verification_cache load_verification_cache() {
             !std::getline(row, record.server_hashes.song_json_sha256, '\t') ||
             !std::getline(row, record.server_hashes.audio_sha256, '\t') ||
             !std::getline(row, record.server_hashes.jacket_sha256, '\t') ||
-            !std::getline(row, record.server_hashes.chart_sha256)) {
+            !std::getline(row, record.server_hashes.chart_sha256, '\t')) {
             continue;
         }
+        std::getline(row, record.local_hashes.chart_fingerprint, '\t');
+        std::getline(row, record.server_hashes.chart_fingerprint, '\t');
+        std::getline(row, record.local_hashes.song_json_fingerprint, '\t');
+        std::getline(row, record.server_hashes.song_json_fingerprint);
         record.status = parse_status(status_token);
         if (!record.server_url.empty() && !record.chart_id.empty()) {
             cache[cache_key(record.server_url, record.chart_id)] = std::move(record);
@@ -316,7 +364,11 @@ void save_verification_cache(const verification_cache& cache) {
                << record.server_hashes.song_json_sha256 << '\t'
                << record.server_hashes.audio_sha256 << '\t'
                << record.server_hashes.jacket_sha256 << '\t'
-               << record.server_hashes.chart_sha256 << '\n';
+               << record.server_hashes.chart_sha256 << '\t'
+               << record.local_hashes.chart_fingerprint << '\t'
+               << record.server_hashes.chart_fingerprint << '\t'
+               << record.local_hashes.song_json_fingerprint << '\t'
+               << record.server_hashes.song_json_fingerprint << '\n';
     }
 }
 
@@ -380,7 +432,7 @@ content_status verify_song_content_source(const song_data& song,
     }
 
     const ranking_client::song_manifest& manifest = *request.manifest;
-    if (manifest.song_id != song.meta.song_id) {
+    if (manifest.song_id != expected_remote_song_id(server_url, song.meta.song_id)) {
         return content_status::local;
     }
 
@@ -401,13 +453,13 @@ content_status verify_song_content_source(const song_data& song,
 
     const content_status source_status = status_for_content_source(manifest.content_source);
     const bool matched = song_hashes_present(*local_hashes) &&
-                         local_hashes->song_json_sha256 == server_hashes.song_json_sha256 &&
+                         song_json_hash_equal(*local_hashes, server_hashes) &&
                          local_hashes->audio_sha256 == server_hashes.audio_sha256 &&
                          local_hashes->jacket_sha256 == server_hashes.jacket_sha256;
     const bool local_unchanged =
         cached != nullptr &&
         cached->file_signature == signature &&
-        local_hashes->song_json_sha256 == cached->local_hashes.song_json_sha256 &&
+        song_json_hash_equal(*local_hashes, cached->local_hashes) &&
         local_hashes->audio_sha256 == cached->local_hashes.audio_sha256 &&
         local_hashes->jacket_sha256 == cached->local_hashes.jacket_sha256;
     const content_status status = matched ? source_status : mismatched_verified_status(cached, local_unchanged);
@@ -415,7 +467,7 @@ content_status verify_song_content_source(const song_data& song,
     cache[key] = verification_cache_record{
         .server_url = server_url,
         .chart_id = song_cache_id,
-        .song_id = song.meta.song_id,
+        .song_id = manifest.song_id,
         .status = status,
         .content_source = manifest.content_source,
         .file_signature = signature,
@@ -463,7 +515,8 @@ content_status verify_chart_content_source(const song_data& song,
     }
 
     const ranking_client::official_manifest& manifest = *request.manifest;
-    if (manifest.chart_id != chart.meta.chart_id || manifest.song_id != song.meta.song_id) {
+    if (manifest.chart_id != chart.meta.chart_id ||
+        manifest.song_id != expected_remote_song_id(server_url, song.meta.song_id)) {
         return content_status::local;
     }
 
@@ -493,7 +546,7 @@ content_status verify_chart_content_source(const song_data& song,
     cache[key] = verification_cache_record{
         .server_url = server_url,
         .chart_id = chart.meta.chart_id,
-        .song_id = song.meta.song_id,
+        .song_id = manifest.song_id,
         .status = status,
         .content_source = manifest.content_source,
         .file_signature = signature,
@@ -608,6 +661,9 @@ catalog_data load_catalog(bool calculate_missing_levels) {
             }
 
             chart_meta meta = parse_result.data->meta;
+            if (meta.song_id.empty()) {
+                meta.song_id = song.meta.song_id;
+            }
             if (calculate_missing_levels) {
                 meta.level = chart_level_cache::get_or_calculate(chart_path, *parse_result.data);
             } else if (const std::optional<float> cached_level = chart_level_cache::find_level(chart_path);
@@ -665,7 +721,11 @@ delete_result delete_song(const state& state, int song_index) {
         return result;
     }
 
-    std::vector<std::filesystem::path> chart_paths_to_delete;
+    struct chart_delete_target {
+        std::filesystem::path path;
+        std::string chart_id;
+    };
+    std::vector<chart_delete_target> chart_paths_to_delete;
     const std::filesystem::path charts_root = app_paths::charts_root();
     if (std::filesystem::exists(charts_root) && std::filesystem::is_directory(charts_root)) {
         for (const auto& chart_entry : std::filesystem::directory_iterator(charts_root)) {
@@ -678,19 +738,28 @@ delete_result delete_song(const state& state, int song_index) {
                 continue;
             }
 
-            if (parse_result.data->meta.song_id == entry.song.meta.song_id) {
-                chart_paths_to_delete.push_back(chart_entry.path());
+            std::string linked_song_id = parse_result.data->meta.song_id;
+            if (linked_song_id.empty()) {
+                linked_song_id = chart_identity::find_song_id(parse_result.data->meta.chart_id).value_or("");
+            }
+
+            if (linked_song_id == entry.song.meta.song_id) {
+                chart_paths_to_delete.push_back({
+                    .path = chart_entry.path(),
+                    .chart_id = parse_result.data->meta.chart_id,
+                });
             }
         }
     }
 
     std::error_code ec;
-    for (const auto& chart_path : chart_paths_to_delete) {
-        std::filesystem::remove(chart_path, ec);
+    for (const auto& chart_target : chart_paths_to_delete) {
+        std::filesystem::remove(chart_target.path, ec);
         if (ec) {
             result.message = "Failed to delete a linked chart file.";
             return result;
         }
+        chart_identity::remove(chart_target.chart_id);
     }
 
     for (const auto& package : mv::load_all_packages()) {
@@ -710,6 +779,7 @@ delete_result delete_song(const state& state, int song_index) {
         result.message = "Failed to delete the song directory.";
         return result;
     }
+    chart_identity::remove_for_song(entry.song.meta.song_id);
 
     result.success = true;
     result.message = "Song deleted.";
@@ -742,6 +812,7 @@ delete_result delete_chart(const state& state, int song_index, int chart_index) 
         result.message = "Failed to delete the chart file.";
         return result;
     }
+    chart_identity::remove(charts[static_cast<size_t>(chart_index)].meta.chart_id);
 
     result.success = true;
     result.message = "Chart deleted.";

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -11,11 +11,11 @@
 #include <utility>
 #include <vector>
 
-#include "app_paths.h"
 #include "network/auth_client.h"
 #include "network/json_helpers.h"
 #include "path_utils.h"
 #include "title/online_download_remote_client.h"
+#include "title/upload_mapping_store.h"
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -43,25 +43,6 @@ struct http_response {
     int status_code = 0;
     std::string body;
     std::string error_message;
-};
-
-struct song_mapping_entry {
-    std::string server_url;
-    std::string local_song_id;
-    std::string remote_song_id;
-};
-
-struct chart_mapping_entry {
-    std::string server_url;
-    std::string local_chart_id;
-    std::string local_song_id;
-    std::string remote_chart_id;
-    std::string remote_song_id;
-};
-
-struct upload_mapping_store {
-    std::vector<song_mapping_entry> songs;
-    std::vector<chart_mapping_entry> charts;
 };
 
 struct multipart_field {
@@ -114,28 +95,6 @@ std::string trim_ascii(std::string_view value) {
     return std::string(value.substr(start, end - start));
 }
 
-std::string strip_trailing_cr(std::string value) {
-    while (!value.empty() && (value.back() == '\r' || value.back() == '\n')) {
-        value.pop_back();
-    }
-    return value;
-}
-
-std::vector<std::string> split_tab_fields(const std::string& line) {
-    std::vector<std::string> fields;
-    size_t start = 0;
-    while (start <= line.size()) {
-        const size_t end = line.find('\t', start);
-        if (end == std::string::npos) {
-            fields.push_back(line.substr(start));
-            break;
-        }
-        fields.push_back(line.substr(start, end - start));
-        start = end + 1;
-    }
-    return fields;
-}
-
 std::string escape_multipart_header_value(const std::string& value) {
     std::string result;
     result.reserve(value.size());
@@ -159,185 +118,6 @@ std::string parse_error_message(const http_response& response, std::string fallb
     return fallback;
 }
 
-upload_mapping_store load_upload_mappings() {
-    upload_mapping_store store;
-
-    std::ifstream input(app_paths::upload_mapping_path(), std::ios::binary);
-    if (!input.is_open()) {
-        return store;
-    }
-
-    enum class section {
-        none,
-        songs,
-        charts,
-    };
-
-    section current_section = section::none;
-    std::string line;
-    while (std::getline(input, line)) {
-        line = strip_trailing_cr(line);
-        if (line.empty() || line[0] == '#') {
-            continue;
-        }
-        if (line == "[songs]") {
-            current_section = section::songs;
-            continue;
-        }
-        if (line == "[charts]") {
-            current_section = section::charts;
-            continue;
-        }
-
-        const std::vector<std::string> fields = split_tab_fields(line);
-        if (current_section == section::songs && fields.size() >= 3) {
-            store.songs.push_back(song_mapping_entry{
-                .server_url = fields[0],
-                .local_song_id = fields[1],
-                .remote_song_id = fields[2],
-            });
-        } else if (current_section == section::charts && fields.size() >= 5) {
-            store.charts.push_back(chart_mapping_entry{
-                .server_url = fields[0],
-                .local_chart_id = fields[1],
-                .local_song_id = fields[2],
-                .remote_chart_id = fields[3],
-                .remote_song_id = fields[4],
-            });
-        }
-    }
-
-    return store;
-}
-
-bool save_upload_mappings(const upload_mapping_store& store) {
-    app_paths::ensure_directories();
-
-    std::ofstream output(app_paths::upload_mapping_path(), std::ios::binary | std::ios::trunc);
-    if (!output.is_open()) {
-        return false;
-    }
-
-    output << "# raythm upload mappings v1\n";
-    output << "[songs]\n";
-    for (const song_mapping_entry& entry : store.songs) {
-        output << entry.server_url << '\t'
-               << entry.local_song_id << '\t'
-               << entry.remote_song_id << '\n';
-    }
-    output << "[charts]\n";
-    for (const chart_mapping_entry& entry : store.charts) {
-        output << entry.server_url << '\t'
-               << entry.local_chart_id << '\t'
-               << entry.local_song_id << '\t'
-               << entry.remote_chart_id << '\t'
-               << entry.remote_song_id << '\n';
-    }
-
-    return output.good();
-}
-
-std::optional<std::string> find_song_mapping(const upload_mapping_store& store,
-                                             const std::string& server_url,
-                                             const std::string& local_song_id) {
-    for (const song_mapping_entry& entry : store.songs) {
-        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
-            return entry.remote_song_id;
-        }
-    }
-    return std::nullopt;
-}
-
-std::optional<std::string> find_chart_mapping(const upload_mapping_store& store,
-                                              const std::string& server_url,
-                                              const std::string& local_chart_id) {
-    for (const chart_mapping_entry& entry : store.charts) {
-        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
-            return entry.remote_chart_id;
-        }
-    }
-    return std::nullopt;
-}
-
-void remove_chart_mapping(upload_mapping_store& store,
-                          const std::string& server_url,
-                          const std::string& local_chart_id) {
-    std::erase_if(store.charts, [&](const chart_mapping_entry& entry) {
-        return entry.server_url == server_url && entry.local_chart_id == local_chart_id;
-    });
-}
-
-void remove_song_mapping(upload_mapping_store& store,
-                         const std::string& server_url,
-                         const std::string& local_song_id) {
-    std::erase_if(store.songs, [&](const song_mapping_entry& entry) {
-        return entry.server_url == server_url && entry.local_song_id == local_song_id;
-    });
-    std::erase_if(store.charts, [&](const chart_mapping_entry& entry) {
-        return entry.server_url == server_url && entry.local_song_id == local_song_id;
-    });
-}
-
-void store_song_mapping(upload_mapping_store& store,
-                        const std::string& server_url,
-                        const std::string& local_song_id,
-                        const std::string& remote_song_id) {
-    if (local_song_id.empty() || remote_song_id.empty()) {
-        return;
-    }
-
-    bool found = false;
-    for (song_mapping_entry& entry : store.songs) {
-        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
-            found = true;
-            if (entry.remote_song_id != remote_song_id) {
-                entry.remote_song_id = remote_song_id;
-                std::erase_if(store.charts, [&](const chart_mapping_entry& chart_entry) {
-                    return chart_entry.server_url == server_url &&
-                           chart_entry.local_song_id == local_song_id;
-                });
-            }
-            break;
-        }
-    }
-
-    if (!found) {
-        store.songs.push_back(song_mapping_entry{
-            .server_url = server_url,
-            .local_song_id = local_song_id,
-            .remote_song_id = remote_song_id,
-        });
-    }
-}
-
-void store_chart_mapping(upload_mapping_store& store,
-                         const std::string& server_url,
-                         const std::string& local_chart_id,
-                         const std::string& local_song_id,
-                         const std::string& remote_chart_id,
-                         const std::string& remote_song_id) {
-    if (local_chart_id.empty() || remote_chart_id.empty()) {
-        return;
-    }
-
-    for (chart_mapping_entry& entry : store.charts) {
-        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
-            entry.local_song_id = local_song_id;
-            entry.remote_chart_id = remote_chart_id;
-            entry.remote_song_id = remote_song_id;
-            return;
-        }
-    }
-
-    store.charts.push_back(chart_mapping_entry{
-        .server_url = server_url,
-        .local_chart_id = local_chart_id,
-        .local_song_id = local_song_id,
-        .remote_chart_id = remote_chart_id,
-        .remote_song_id = remote_song_id,
-    });
-}
-
 bool read_binary_file(const fs::path& path,
                       std::vector<unsigned char>& bytes,
                       std::string& error_message) {
@@ -353,26 +133,6 @@ bool read_binary_file(const fs::path& path,
         return false;
     }
 
-    return true;
-}
-
-bool read_text_file(const fs::path& path,
-                    std::string& content,
-                    std::string& error_message) {
-    std::ifstream input(path, std::ios::binary);
-    if (!input.is_open()) {
-        error_message = "Failed to open a local chart file for upload.";
-        return false;
-    }
-
-    std::ostringstream buffer;
-    buffer << input.rdbuf();
-    if (!input.good() && !input.eof()) {
-        error_message = "Failed to read a local chart file for upload.";
-        return false;
-    }
-
-    content = buffer.str();
     return true;
 }
 
@@ -683,6 +443,10 @@ upload_request_result parse_song_upload_response(const http_response& response,
         result.message = parse_error_message(response, "Log in before uploading community content.");
         return result;
     }
+    if (response.status_code == 409) {
+        result.message = parse_error_message(response, "Song ID already exists on the server.");
+        return result;
+    }
     if (response.status_code < 200 || response.status_code >= 300) {
         result.message = parse_error_message(response, "Song upload failed.");
         return result;
@@ -724,6 +488,10 @@ upload_request_result parse_chart_upload_response(const http_response& response,
     if (response.status_code == 401) {
         result.unauthorized = true;
         result.message = parse_error_message(response, "Log in before uploading community content.");
+        return result;
+    }
+    if (response.status_code == 409) {
+        result.message = parse_error_message(response, "Chart ID already exists on the server.");
         return result;
     }
     if (response.status_code < 200 || response.status_code >= 300) {
@@ -816,6 +584,7 @@ upload_request_result send_song_upload_request(const auth::session& session,
     }
 
     std::vector<multipart_field> fields;
+    fields.push_back({"songId", meta.song_id});
     fields.push_back({"title", meta.title});
     fields.push_back({"artist", meta.artist});
     {
@@ -861,10 +630,10 @@ upload_request_result send_song_upload_request(const auth::session& session,
     return parse_song_upload_response(response, remote_song_id.has_value());
 }
 
-std::optional<std::string> find_remote_song_id(const auth::session& session,
-                                               upload_mapping_store& store,
-                                               const song_select::song_entry& song) {
-    if (const std::optional<std::string> mapped = find_song_mapping(
+std::optional<std::string> resolve_remote_song_id_for_chart_upload(const auth::session& session,
+                                                                   title_upload_mapping::store& store,
+                                                                   const song_select::song_entry& song) {
+    if (const std::optional<std::string> mapped = title_upload_mapping::find_remote_song_id(
             store, session.server_url, song.song.meta.song_id);
         mapped.has_value()) {
         return mapped;
@@ -880,108 +649,53 @@ std::optional<std::string> find_remote_song_id(const auth::session& session,
         return std::nullopt;
     }
 
-    store_song_mapping(store, session.server_url, song.song.meta.song_id, lookup.song.id);
+    title_upload_mapping::put_song(store, session.server_url, song.song.meta.song_id, lookup.song.id,
+                                   title_upload_mapping::mapping_origin::linked);
     return lookup.song.id;
 }
 
-std::optional<std::string> rewrite_chart_song_id(const std::string& content,
-                                                 const std::string& remote_song_id,
-                                                 std::string& error_message) {
-    if (remote_song_id.empty()) {
-        error_message = "Chart upload is missing a remote song ID.";
+std::optional<bool> remote_song_exists_for_local_id(const auth::session& session,
+                                                    const song_select::song_entry& song) {
+    if (song.song.meta.song_id.empty()) {
+        return false;
+    }
+
+    const title_online_view::remote_song_lookup_result lookup =
+        title_online_view::fetch_remote_song_by_id(song.song.meta.song_id, session.server_url);
+    if (!lookup.success && !lookup.not_found) {
         return std::nullopt;
     }
+    return lookup.success && !lookup.not_found && !lookup.song.id.empty();
+}
 
-    std::vector<std::string> lines;
-    {
-        std::string normalized = content;
-        size_t position = 0;
-        while ((position = normalized.find("\r\n", position)) != std::string::npos) {
-            normalized.replace(position, 2, "\n");
-        }
-
-        std::istringstream stream(normalized);
-        std::string line;
-        while (std::getline(stream, line)) {
-            lines.push_back(line);
-        }
+std::optional<bool> remote_chart_exists_for_local_id(const auth::session& session,
+                                                     const std::string& remote_song_id,
+                                                     const song_select::chart_option& chart) {
+    if (remote_song_id.empty() || chart.meta.chart_id.empty()) {
+        return false;
     }
 
-    int metadata_header_index = -1;
-    int metadata_end_index = static_cast<int>(lines.size());
-    for (int index = 0; index < static_cast<int>(lines.size()); ++index) {
-        const std::string trimmed = trim_ascii(lines[static_cast<size_t>(index)]);
-        if (metadata_header_index < 0) {
-            if (trimmed == "[Metadata]") {
-                metadata_header_index = index;
-            }
-            continue;
+    constexpr int kChartLookupPageSize = 50;
+    int page = 1;
+    while (true) {
+        const title_online_view::remote_chart_page_fetch_result page_result =
+            title_online_view::fetch_remote_chart_page(session.server_url, remote_song_id, page, kChartLookupPageSize);
+        if (!page_result.success) {
+            return std::nullopt;
         }
-        if (!trimmed.empty() && trimmed.front() == '[' && trimmed.back() == ']') {
-            metadata_end_index = index;
-            break;
+        const auto found = std::find_if(page_result.charts.begin(), page_result.charts.end(),
+                                        [&](const title_online_view::remote_chart_payload& remote_chart) {
+                                            return remote_chart.id == chart.meta.chart_id;
+                                        });
+        if (found != page_result.charts.end()) {
+            return true;
         }
-    }
-
-    if (metadata_header_index < 0) {
-        error_message = "Selected chart does not contain a [Metadata] section.";
-        return std::nullopt;
-    }
-
-    std::vector<std::string> ordered_keys;
-    std::vector<std::pair<std::string, std::string>> metadata_values;
-    auto find_metadata = [&](const std::string& key) {
-        return std::find_if(metadata_values.begin(), metadata_values.end(), [&](const auto& entry) {
-            return entry.first == key;
-        });
-    };
-
-    for (int index = metadata_header_index + 1; index < metadata_end_index; ++index) {
-        const std::string& line = lines[static_cast<size_t>(index)];
-        const size_t separator = line.find('=');
-        if (separator == std::string::npos) {
-            continue;
+        if (page_result.charts.empty() ||
+            page * kChartLookupPageSize >= page_result.total) {
+            return false;
         }
-
-        const std::string key = trim_ascii(line.substr(0, separator));
-        const std::string value = trim_ascii(line.substr(separator + 1));
-        if (key.empty()) {
-            continue;
-        }
-
-        if (find_metadata(key) == metadata_values.end()) {
-            ordered_keys.push_back(key);
-            metadata_values.emplace_back(key, value);
-        }
+        ++page;
     }
-
-    auto song_id_entry = find_metadata("songId");
-    if (song_id_entry == metadata_values.end()) {
-        ordered_keys.push_back("songId");
-        metadata_values.emplace_back("songId", remote_song_id);
-    } else {
-        song_id_entry->second = remote_song_id;
-    }
-
-    std::ostringstream rebuilt;
-    for (int index = 0; index <= metadata_header_index; ++index) {
-        rebuilt << lines[static_cast<size_t>(index)] << '\n';
-    }
-    for (const std::string& key : ordered_keys) {
-        const auto entry = find_metadata(key);
-        if (entry == metadata_values.end()) {
-            continue;
-        }
-        rebuilt << entry->first << '=' << entry->second << '\n';
-    }
-    for (int index = metadata_end_index; index < static_cast<int>(lines.size()); ++index) {
-        rebuilt << lines[static_cast<size_t>(index)];
-        if (index + 1 < static_cast<int>(lines.size())) {
-            rebuilt << '\n';
-        }
-    }
-
-    return rebuilt.str();
 }
 
 upload_request_result send_chart_upload_request(const auth::session& session,
@@ -997,20 +711,16 @@ upload_request_result send_chart_upload_request(const auth::session& session,
         return result;
     }
 
-    std::string chart_content;
-    if (!read_text_file(chart_path, chart_content, result.message)) {
-        return result;
-    }
-
-    std::optional<std::string> rewritten_chart = rewrite_chart_song_id(chart_content, remote_song_id, result.message);
-    if (!rewritten_chart.has_value()) {
+    std::vector<unsigned char> chart_bytes;
+    if (!read_binary_file(chart_path, chart_bytes, result.message)) {
         return result;
     }
 
     std::vector<multipart_field> fields;
+    fields.push_back({"chartId", chart.meta.chart_id});
+    fields.push_back({"songId", remote_song_id});
     fields.push_back({"visibility", "public"});
 
-    std::vector<unsigned char> chart_bytes(rewritten_chart->begin(), rewritten_chart->end());
     std::vector<multipart_file> files;
     files.push_back({
         .name = "chart",
@@ -1038,11 +748,6 @@ upload_request_result send_chart_upload_request(const auth::session& session,
 upload_result upload_song(const song_select::song_entry& song) {
     upload_result result;
 
-    if (song.status != content_status::local) {
-        result.message = "Only Local songs can be uploaded.";
-        return result;
-    }
-
     std::string error_message;
     const std::optional<auth::session> session_opt = require_saved_session(error_message);
     if (!session_opt.has_value()) {
@@ -1051,9 +756,28 @@ upload_result upload_song(const song_select::song_entry& song) {
     }
     auth::session session = *session_opt;
 
-    upload_mapping_store store = load_upload_mappings();
+    title_upload_mapping::store store = title_upload_mapping::load();
     const std::optional<std::string> existing_remote_song_id =
-        find_song_mapping(store, session.server_url, song.song.meta.song_id);
+        title_upload_mapping::find_remote_song_id(store, session.server_url, song.song.meta.song_id);
+    const std::optional<title_upload_mapping::mapping_origin> existing_song_origin =
+        title_upload_mapping::find_song_origin(store, session.server_url, song.song.meta.song_id);
+    if (existing_remote_song_id.has_value() &&
+        existing_song_origin.value_or(title_upload_mapping::mapping_origin::owned_upload) !=
+            title_upload_mapping::mapping_origin::owned_upload) {
+        result.message = "This song is linked to online content but was not uploaded from this client.";
+        return result;
+    }
+    if (!existing_remote_song_id.has_value()) {
+        const std::optional<bool> remote_exists = remote_song_exists_for_local_id(session, song);
+        if (!remote_exists.has_value()) {
+            result.message = "Could not verify whether this song already exists on the server.";
+            return result;
+        }
+        if (*remote_exists) {
+            result.message = "This song already exists on the server. Downloaded Community/Official songs cannot be uploaded again.";
+            return result;
+        }
+    }
 
     upload_request_result request_result =
         send_song_upload_request(session, song, existing_remote_song_id);
@@ -1068,8 +792,8 @@ upload_result upload_song(const song_select::song_entry& song) {
         request_result = send_song_upload_request(session, song, existing_remote_song_id);
     }
     if (request_result.not_found && existing_remote_song_id.has_value()) {
-        remove_song_mapping(store, session.server_url, song.song.meta.song_id);
-        save_upload_mappings(store);
+        title_upload_mapping::remove_song(store, session.server_url, song.song.meta.song_id);
+        title_upload_mapping::save(store);
         request_result = send_song_upload_request(session, song, std::nullopt);
         if (request_result.unauthorized) {
             std::string restore_error;
@@ -1090,8 +814,9 @@ upload_result upload_song(const song_select::song_entry& song) {
         return result;
     }
 
-    store_song_mapping(store, session.server_url, song.song.meta.song_id, request_result.remote_song_id);
-    if (!save_upload_mappings(store)) {
+    title_upload_mapping::put_song(store, session.server_url, song.song.meta.song_id, request_result.remote_song_id,
+                                   title_upload_mapping::mapping_origin::owned_upload);
+    if (!title_upload_mapping::save(store)) {
         result.message += " Local upload mapping was not saved.";
     } else if (!request_result.updated_existing) {
         result.message += " Charts for this song can now be uploaded.";
@@ -1104,11 +829,6 @@ upload_result upload_chart(const song_select::song_entry& song,
                            const song_select::chart_option& chart) {
     upload_result result;
 
-    if (song.status != content_status::local || chart.status != content_status::local) {
-        result.message = "Only Local charts from Local songs can be uploaded.";
-        return result;
-    }
-
     std::string error_message;
     const std::optional<auth::session> session_opt = require_saved_session(error_message);
     if (!session_opt.has_value()) {
@@ -1117,17 +837,41 @@ upload_result upload_chart(const song_select::song_entry& song,
     }
     auth::session session = *session_opt;
 
-    upload_mapping_store store = load_upload_mappings();
-    const std::optional<std::string> remote_song_id = find_remote_song_id(session, store, song);
+    title_upload_mapping::store store = title_upload_mapping::load();
+    const std::optional<std::string> remote_song_id = resolve_remote_song_id_for_chart_upload(session, store, song);
     if (!remote_song_id.has_value()) {
         result.message = "Upload the song first so the server can assign a song ID.";
         return result;
     }
 
     const std::optional<std::string> existing_remote_chart_id =
-        find_chart_mapping(store, session.server_url, chart.meta.chart_id);
+        title_upload_mapping::find_remote_chart_id(store, session.server_url, chart.meta.chart_id);
+    const std::optional<title_upload_mapping::mapping_origin> existing_chart_origin =
+        title_upload_mapping::find_chart_origin(store, session.server_url, chart.meta.chart_id);
+    const std::optional<std::string> updatable_remote_chart_id =
+        existing_chart_origin.value_or(title_upload_mapping::mapping_origin::owned_upload) ==
+            title_upload_mapping::mapping_origin::owned_upload
+        ? existing_remote_chart_id
+        : std::nullopt;
+    if (!existing_remote_chart_id.has_value()) {
+        const std::optional<bool> remote_chart_exists =
+            remote_chart_exists_for_local_id(session, *remote_song_id, chart);
+        if (!remote_chart_exists.has_value()) {
+            result.message = "Could not verify whether this chart already exists on the server.";
+            return result;
+        }
+        if (*remote_chart_exists) {
+            result.message = "This chart already exists on the server. Downloaded Community/Official charts cannot be uploaded again.";
+            return result;
+        }
+    }
+    if (existing_remote_chart_id.has_value() && !updatable_remote_chart_id.has_value()) {
+        result.message = "This chart is linked to online content but was not uploaded from this client.";
+        return result;
+    }
+
     upload_request_result request_result =
-        send_chart_upload_request(session, song, chart, *remote_song_id, existing_remote_chart_id);
+        send_chart_upload_request(session, song, chart, *remote_song_id, updatable_remote_chart_id);
     if (request_result.unauthorized) {
         std::string restore_error;
         const std::optional<auth::session> restored = restore_upload_session(restore_error);
@@ -1136,11 +880,11 @@ upload_result upload_chart(const song_select::song_entry& song,
             return result;
         }
         session = *restored;
-        request_result = send_chart_upload_request(session, song, chart, *remote_song_id, existing_remote_chart_id);
+        request_result = send_chart_upload_request(session, song, chart, *remote_song_id, updatable_remote_chart_id);
     }
     if (request_result.not_found && existing_remote_chart_id.has_value()) {
-        remove_chart_mapping(store, session.server_url, chart.meta.chart_id);
-        save_upload_mappings(store);
+        title_upload_mapping::remove_chart(store, session.server_url, chart.meta.chart_id);
+        title_upload_mapping::save(store);
         request_result =
             send_chart_upload_request(session, song, chart, *remote_song_id, std::nullopt);
         if (request_result.unauthorized) {
@@ -1163,10 +907,14 @@ upload_result upload_chart(const song_select::song_entry& song,
         return result;
     }
 
-    store_song_mapping(store, session.server_url, song.song.meta.song_id, *remote_song_id);
-    store_chart_mapping(store, session.server_url, chart.meta.chart_id, song.song.meta.song_id,
-                        request_result.remote_chart_id, *remote_song_id);
-    if (!save_upload_mappings(store)) {
+    if (!title_upload_mapping::find_song_origin(store, session.server_url, song.song.meta.song_id).has_value()) {
+        title_upload_mapping::put_song(store, session.server_url, song.song.meta.song_id, *remote_song_id,
+                                       title_upload_mapping::mapping_origin::linked);
+    }
+    title_upload_mapping::put_chart(store, session.server_url, chart.meta.chart_id, song.song.meta.song_id,
+                                    request_result.remote_chart_id, *remote_song_id,
+                                    title_upload_mapping::mapping_origin::owned_upload);
+    if (!title_upload_mapping::save(store)) {
         result.message += " Local upload mapping was not saved.";
     }
 

--- a/src/scenes/title/online_download_catalog.cpp
+++ b/src/scenes/title/online_download_catalog.cpp
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <optional>
 #include <thread>
 #include <unordered_map>
 #include <utility>
@@ -14,6 +15,7 @@
 #include "path_utils.h"
 #include "song_select/song_catalog_service.h"
 #include "title/online_download_remote_client.h"
+#include "title/upload_mapping_store.h"
 
 namespace title_online_view {
 namespace {
@@ -22,12 +24,32 @@ constexpr int kInitialSongPageSize = 12;
 constexpr int kSongPageSize = 12;
 constexpr int kChartPageSize = 8;
 
-using local_song_lookup = std::unordered_map<std::string, const song_select::song_entry*>;
+struct local_song_ref {
+    const song_select::song_entry* song = nullptr;
+    std::string local_song_id;
+};
 
-local_song_lookup build_local_lookup(const std::vector<song_select::song_entry>& local_songs) {
+using local_song_lookup = std::unordered_map<std::string, local_song_ref>;
+
+local_song_lookup build_local_lookup(const std::vector<song_select::song_entry>& local_songs,
+                                     const std::string& server_url) {
     local_song_lookup lookup;
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
     for (const song_select::song_entry& song : local_songs) {
-        lookup[song.song.meta.song_id] = &song;
+        const std::string& local_song_id = song.song.meta.song_id;
+        lookup[local_song_id] = local_song_ref{
+            .song = &song,
+            .local_song_id = local_song_id,
+        };
+
+        const std::optional<std::string> remote_song_id =
+            title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id);
+        if (remote_song_id.has_value() && !remote_song_id->empty()) {
+            lookup[*remote_song_id] = local_song_ref{
+                .song = &song,
+                .local_song_id = local_song_id,
+            };
+        }
     }
     return lookup;
 }
@@ -64,14 +86,15 @@ song_entry_state build_song_state(const remote_song_payload& remote_song,
     song_entry_state state_entry;
     state_entry.song = make_remote_song_entry(remote_song, server_url);
 
-    const song_select::song_entry* local_song = nullptr;
+    local_song_ref local_song;
     if (const auto it = local_lookup.find(remote_song.id); it != local_lookup.end()) {
         local_song = it->second;
     }
 
-    state_entry.installed = local_song != nullptr;
-    state_entry.update_available = local_song != nullptr &&
-                                   local_song->song.meta.song_version < state_entry.song.song.meta.song_version;
+    state_entry.installed = local_song.song != nullptr;
+    state_entry.installed_local_song_id = local_song.local_song_id;
+    state_entry.update_available = local_song.song != nullptr &&
+                                   local_song.song->song.meta.song_version < state_entry.song.song.meta.song_version;
     state_entry.charts_loaded = false;
     state_entry.charts_loading = false;
     state_entry.charts_has_more = false;
@@ -92,6 +115,7 @@ song_entry_state build_owned_song_state(const song_select::song_entry& local_son
         static_cast<float>(remote_song.preview_start_ms) / 1000.0f;
     state_entry.song.song.meta.duration_seconds = remote_song.duration_seconds;
     state_entry.installed = true;
+    state_entry.installed_local_song_id = local_song.song.meta.song_id;
     state_entry.update_available = local_song.song.meta.song_version < remote_song.song_version;
     state_entry.charts_loaded = true;
     state_entry.charts_loading = false;
@@ -102,6 +126,7 @@ song_entry_state build_owned_song_state(const song_select::song_entry& local_son
     for (const song_select::chart_option& chart : local_song.charts) {
         state_entry.charts.push_back({
             chart,
+            chart.meta.chart_id,
             true,
             false,
         });
@@ -123,8 +148,11 @@ void append_song_page(std::vector<song_entry_state>& target, std::vector<song_en
 void append_chart_page(song_entry_state& song_state,
                        const std::vector<song_select::song_entry>& local_songs,
                        const remote_chart_page_fetch_result& page_result) {
-    const song_select::song_entry* local_song =
-        find_local_song(local_songs, song_state.song.song.meta.song_id);
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const std::string local_song_id = !song_state.installed_local_song_id.empty()
+        ? song_state.installed_local_song_id
+        : song_state.song.song.meta.song_id;
+    const song_select::song_entry* local_song = find_local_song(local_songs, local_song_id);
     for (const remote_chart_payload& chart : page_result.charts) {
         const auto exists = std::find_if(song_state.charts.begin(), song_state.charts.end(),
                                          [&](const chart_entry_state& state_chart) {
@@ -134,10 +162,19 @@ void append_chart_page(song_entry_state& song_state,
             continue;
         }
 
+        const std::optional<std::string> mapped_local_chart_id =
+            title_upload_mapping::find_local_chart_id(mappings, page_result.server_url, chart.id);
+        std::string installed_local_chart_id;
         const bool local_chart_installed = local_song != nullptr &&
             std::any_of(local_song->charts.begin(), local_song->charts.end(),
                         [&](const song_select::chart_option& local_chart) {
-                            return local_chart.meta.chart_id == chart.id;
+                            const bool matches = local_chart.meta.chart_id == chart.id ||
+                                (mapped_local_chart_id.has_value() &&
+                                 local_chart.meta.chart_id == *mapped_local_chart_id);
+                            if (matches) {
+                                installed_local_chart_id = local_chart.meta.chart_id;
+                            }
+                            return matches;
                         });
 
         song_state.charts.push_back({
@@ -161,6 +198,7 @@ void append_chart_page(song_entry_state& song_state,
                 0.0f,
                 0.0f,
             },
+            installed_local_chart_id,
             local_chart_installed,
             false,
         });
@@ -293,10 +331,20 @@ std::vector<song_entry_state> load_owned_songs(const std::vector<song_select::so
         return owned;
     }
 
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
     owned.reserve(local_songs.size());
     for (const song_select::song_entry& local_song : local_songs) {
+        const std::optional<title_upload_mapping::mapping_origin> origin =
+            title_upload_mapping::find_song_origin(mappings, server_url, local_song.song.meta.song_id);
+        if (origin.value_or(title_upload_mapping::mapping_origin::downloaded) !=
+            title_upload_mapping::mapping_origin::owned_upload) {
+            continue;
+        }
+
+        const std::string remote_song_id = title_upload_mapping::find_remote_song_id(
+            mappings, server_url, local_song.song.meta.song_id).value_or(local_song.song.meta.song_id);
         const remote_song_lookup_result remote_song =
-            fetch_remote_song_by_id(local_song.song.meta.song_id, server_url);
+            fetch_remote_song_by_id(remote_song_id, server_url);
         if (!remote_song.success) {
             continue;
         }
@@ -311,7 +359,6 @@ std::vector<song_entry_state> load_owned_songs(const std::vector<song_select::so
 
 catalog_load_result load_catalog_result() {
     const song_select::catalog_data local_catalog = song_select::load_catalog();
-    const local_song_lookup local_lookup = build_local_lookup(local_catalog.songs);
 
     const remote_song_page_fetch_result official_page =
         fetch_remote_song_page(catalog_mode::official, 1, kInitialSongPageSize);
@@ -329,11 +376,13 @@ catalog_load_result load_catalog_result() {
     result.community_has_more = community_page.success &&
                                 static_cast<int>(community_page.songs.size()) < community_page.total;
 
+    const local_song_lookup official_lookup = build_local_lookup(local_catalog.songs, official_page.server_url);
+    const local_song_lookup community_lookup = build_local_lookup(local_catalog.songs, community_page.server_url);
     for (const remote_song_payload& song : official_page.songs) {
-        result.official_songs.push_back(build_song_state(song, official_page.server_url, local_lookup));
+        result.official_songs.push_back(build_song_state(song, official_page.server_url, official_lookup));
     }
     for (const remote_song_payload& song : community_page.songs) {
-        result.community_songs.push_back(build_song_state(song, community_page.server_url, local_lookup));
+        result.community_songs.push_back(build_song_state(song, community_page.server_url, community_lookup));
     }
 
     return result;
@@ -562,7 +611,7 @@ bool poll_song_page(state& state) {
         return true;
     }
 
-    const local_song_lookup local_lookup = build_local_lookup(state.local_songs);
+    const local_song_lookup local_lookup = build_local_lookup(state.local_songs, page_result.server_url);
     std::vector<song_entry_state> page_items;
     page_items.reserve(page_result.songs.size());
     for (const remote_song_payload& song : page_result.songs) {
@@ -585,7 +634,10 @@ void request_charts_for_selected_song(state& state) {
         return;
     }
 
-    song_entry_state* song = find_song_state(songs_for_mode(state, state.mode), selected_song_id(state));
+    const song_entry_state* selected = selected_song(state);
+    song_entry_state* song = selected == nullptr
+        ? nullptr
+        : find_song_state(songs_for_mode(state, state.mode), selected->song.song.meta.song_id);
     if (song == nullptr || song->charts_loading) {
         return;
     }

--- a/src/scenes/title/online_download_state.cpp
+++ b/src/scenes/title/online_download_state.cpp
@@ -385,7 +385,13 @@ bool can_open_local(const state& state) {
 
 std::string selected_song_id(const state& state) {
     const song_entry_state* song = selected_song(state);
-    return song != nullptr ? song->song.song.meta.song_id : "";
+    if (song == nullptr) {
+        return "";
+    }
+    if (song->installed && !song->installed_local_song_id.empty()) {
+        return song->installed_local_song_id;
+    }
+    return song->song.song.meta.song_id;
 }
 
 }  // namespace title_online_view

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -270,21 +270,25 @@ download_song_result download_chart_file(const song_entry_state song,
         progress->current_total_bytes.store(0);
     }
 
+    const std::string local_chart_id = chart.installed_local_chart_id.empty()
+        ? result.chart_id
+        : chart.installed_local_chart_id;
+
     std::string error_message;
     app_paths::ensure_directories();
-    if (!write_binary_file(app_paths::chart_path(result.chart_id), chart_fetch.bytes, error_message)) {
+    if (!write_binary_file(app_paths::chart_path(local_chart_id), chart_fetch.bytes, error_message)) {
         result.message = error_message;
         return result;
     }
-    chart_identity::put(result.chart_id, local_song_id);
+    chart_identity::put(local_chart_id, local_song_id);
 
-    if (local_song_id != result.song_id || chart.installed_local_chart_id != result.chart_id) {
+    if (local_song_id != result.song_id || local_chart_id != result.chart_id) {
         title_upload_mapping::store mappings = title_upload_mapping::load();
         if (!title_upload_mapping::find_song_origin(mappings, server_url, local_song_id).has_value()) {
             title_upload_mapping::put_song(mappings, server_url, local_song_id, result.song_id,
                                            title_upload_mapping::mapping_origin::downloaded);
         }
-        title_upload_mapping::put_chart(mappings, server_url, result.chart_id, local_song_id,
+        title_upload_mapping::put_chart(mappings, server_url, local_chart_id, local_song_id,
                                         result.chart_id, result.song_id,
                                         title_upload_mapping::mapping_origin::downloaded);
         title_upload_mapping::save(mappings);

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -7,6 +7,7 @@
 #include <filesystem>
 #include <fstream>
 #include <future>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <system_error>
@@ -15,9 +16,11 @@
 #include <vector>
 
 #include "app_paths.h"
+#include "chart_identity_store.h"
 #include "network/json_helpers.h"
 #include "path_utils.h"
 #include "title/online_download_remote_client.h"
+#include "title/upload_mapping_store.h"
 #include "ui_notice.h"
 
 namespace title_online_view {
@@ -207,6 +210,11 @@ download_song_result download_song_package(const song_entry_state song,
         return result;
     }
 
+    title_upload_mapping::store mappings = title_upload_mapping::load();
+    title_upload_mapping::put_song(mappings, server_url, result.song_id, result.song_id,
+                                   title_upload_mapping::mapping_origin::downloaded);
+    title_upload_mapping::save(mappings);
+
     result.success = true;
     result.message = "Song downloaded.";
     return result;
@@ -220,8 +228,11 @@ download_song_result download_chart_file(const song_entry_state song,
     result.song_id = song.song.song.meta.song_id;
     result.chart_id = chart.chart.meta.chart_id;
     result.chart_only = true;
+    const std::string local_song_id = !song.installed_local_song_id.empty()
+        ? song.installed_local_song_id
+        : song.song.song.meta.song_id;
 
-    if (server_url.empty() || result.song_id.empty() || result.chart_id.empty()) {
+    if (server_url.empty() || result.song_id.empty() || result.chart_id.empty() || local_song_id.empty()) {
         result.message = "Missing chart download information.";
         return result;
     }
@@ -259,11 +270,24 @@ download_song_result download_chart_file(const song_entry_state song,
         progress->current_total_bytes.store(0);
     }
 
-    app_paths::ensure_directories();
     std::string error_message;
+    app_paths::ensure_directories();
     if (!write_binary_file(app_paths::chart_path(result.chart_id), chart_fetch.bytes, error_message)) {
         result.message = error_message;
         return result;
+    }
+    chart_identity::put(result.chart_id, local_song_id);
+
+    if (local_song_id != result.song_id || chart.installed_local_chart_id != result.chart_id) {
+        title_upload_mapping::store mappings = title_upload_mapping::load();
+        if (!title_upload_mapping::find_song_origin(mappings, server_url, local_song_id).has_value()) {
+            title_upload_mapping::put_song(mappings, server_url, local_song_id, result.song_id,
+                                           title_upload_mapping::mapping_origin::downloaded);
+        }
+        title_upload_mapping::put_chart(mappings, server_url, result.chart_id, local_song_id,
+                                        result.chart_id, result.song_id,
+                                        title_upload_mapping::mapping_origin::downloaded);
+        title_upload_mapping::save(mappings);
     }
 
     result.success = true;

--- a/src/scenes/title/online_download_view.h
+++ b/src/scenes/title/online_download_view.h
@@ -32,6 +32,7 @@ enum class requested_action {
 
 struct chart_entry_state {
     song_select::chart_option chart;
+    std::string installed_local_chart_id;
     bool installed = false;
     bool update_available = false;
 };
@@ -39,6 +40,7 @@ struct chart_entry_state {
 struct song_entry_state {
     song_select::song_entry song;
     std::vector<chart_entry_state> charts;
+    std::string installed_local_song_id;
     bool installed = false;
     bool update_available = false;
     bool charts_loaded = false;

--- a/src/scenes/title/upload_mapping_store.cpp
+++ b/src/scenes/title/upload_mapping_store.cpp
@@ -1,0 +1,404 @@
+#include "title/upload_mapping_store.h"
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+#include "app_paths.h"
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <dpapi.h>
+#include <wincrypt.h>
+#endif
+
+namespace title_upload_mapping {
+namespace {
+
+constexpr char kHeader[] = "# raythm upload mappings v2";
+
+std::filesystem::path secure_mapping_path() {
+    std::filesystem::path path = app_paths::upload_mapping_path();
+    path.replace_extension(".bin");
+    return path;
+}
+
+std::string strip_trailing_cr(std::string value) {
+    while (!value.empty() && (value.back() == '\r' || value.back() == '\n')) {
+        value.pop_back();
+    }
+    return value;
+}
+
+std::vector<std::string> split_tab_fields(const std::string& line) {
+    std::vector<std::string> fields;
+    size_t start = 0;
+    while (start <= line.size()) {
+        const size_t end = line.find('\t', start);
+        if (end == std::string::npos) {
+            fields.push_back(line.substr(start));
+            break;
+        }
+        fields.push_back(line.substr(start, end - start));
+        start = end + 1;
+    }
+    return fields;
+}
+
+std::string origin_to_string(mapping_origin origin) {
+    switch (origin) {
+    case mapping_origin::owned_upload:
+        return "owned_upload";
+    case mapping_origin::downloaded:
+        return "downloaded";
+    case mapping_origin::linked:
+        return "linked";
+    }
+    return "owned_upload";
+}
+
+mapping_origin parse_origin(const std::string& value) {
+    if (value == "downloaded") {
+        return mapping_origin::downloaded;
+    }
+    if (value == "linked") {
+        return mapping_origin::linked;
+    }
+    return mapping_origin::owned_upload;
+}
+
+std::string serialize_plaintext(const store& mappings) {
+    std::ostringstream output;
+    output << kHeader << '\n';
+    output << "[songs]\n";
+    for (const song_mapping_entry& entry : mappings.songs) {
+        output << entry.server_url << '\t'
+               << entry.local_song_id << '\t'
+               << entry.remote_song_id << '\t'
+               << origin_to_string(entry.origin) << '\n';
+    }
+    output << "[charts]\n";
+    for (const chart_mapping_entry& entry : mappings.charts) {
+        output << entry.server_url << '\t'
+               << entry.local_chart_id << '\t'
+               << entry.local_song_id << '\t'
+               << entry.remote_chart_id << '\t'
+               << entry.remote_song_id << '\t'
+               << origin_to_string(entry.origin) << '\n';
+    }
+    return output.str();
+}
+
+store parse_plaintext(const std::string& content) {
+    store mappings;
+
+    std::istringstream input(content);
+
+    enum class section {
+        none,
+        songs,
+        charts,
+    };
+
+    section current_section = section::none;
+    std::string line;
+    while (std::getline(input, line)) {
+        line = strip_trailing_cr(line);
+        if (line.empty() || line[0] == '#') {
+            continue;
+        }
+        if (line == "[songs]") {
+            current_section = section::songs;
+            continue;
+        }
+        if (line == "[charts]") {
+            current_section = section::charts;
+            continue;
+        }
+
+        const std::vector<std::string> fields = split_tab_fields(line);
+        if (current_section == section::songs && fields.size() >= 3) {
+            mappings.songs.push_back(song_mapping_entry{
+                .server_url = fields[0],
+                .local_song_id = fields[1],
+                .remote_song_id = fields[2],
+                .origin = fields.size() >= 4 ? parse_origin(fields[3]) : mapping_origin::linked,
+            });
+        } else if (current_section == section::charts && fields.size() >= 5) {
+            mappings.charts.push_back(chart_mapping_entry{
+                .server_url = fields[0],
+                .local_chart_id = fields[1],
+                .local_song_id = fields[2],
+                .remote_chart_id = fields[3],
+                .remote_song_id = fields[4],
+                .origin = fields.size() >= 6 ? parse_origin(fields[5]) : mapping_origin::linked,
+            });
+        }
+    }
+
+    return mappings;
+}
+
+std::optional<std::string> read_file_text(const std::filesystem::path& path) {
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        return std::nullopt;
+    }
+
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    if (!input.good() && !input.eof()) {
+        return std::nullopt;
+    }
+    return buffer.str();
+}
+
+bool write_file_bytes(const std::filesystem::path& path, const std::vector<unsigned char>& bytes) {
+    std::ofstream output(path, std::ios::binary | std::ios::trunc);
+    if (!output.is_open()) {
+        return false;
+    }
+    if (!bytes.empty()) {
+        output.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    }
+    return output.good();
+}
+
+#ifdef _WIN32
+std::optional<std::vector<unsigned char>> protect_bytes(const std::string& plaintext) {
+    DATA_BLOB input{};
+    input.pbData = reinterpret_cast<BYTE*>(const_cast<char*>(plaintext.data()));
+    input.cbData = static_cast<DWORD>(plaintext.size());
+
+    DATA_BLOB output{};
+    if (CryptProtectData(&input, L"raythm upload mappings", nullptr, nullptr, nullptr, 0, &output) == 0) {
+        return std::nullopt;
+    }
+
+    std::vector<unsigned char> encrypted(output.pbData, output.pbData + output.cbData);
+    LocalFree(output.pbData);
+    return encrypted;
+}
+
+std::optional<std::string> unprotect_bytes(const std::string& encrypted) {
+    if (encrypted.empty()) {
+        return std::nullopt;
+    }
+
+    DATA_BLOB input{};
+    input.pbData = reinterpret_cast<BYTE*>(const_cast<char*>(encrypted.data()));
+    input.cbData = static_cast<DWORD>(encrypted.size());
+
+    DATA_BLOB output{};
+    if (CryptUnprotectData(&input, nullptr, nullptr, nullptr, nullptr, 0, &output) == 0) {
+        return std::nullopt;
+    }
+
+    std::string plaintext(reinterpret_cast<char*>(output.pbData), output.cbData);
+    LocalFree(output.pbData);
+    return plaintext;
+}
+#else
+std::optional<std::vector<unsigned char>> protect_bytes(const std::string& plaintext) {
+    return std::vector<unsigned char>(plaintext.begin(), plaintext.end());
+}
+
+std::optional<std::string> unprotect_bytes(const std::string& encrypted) {
+    return encrypted;
+}
+#endif
+
+}  // namespace
+
+store load() {
+    if (const std::optional<std::string> encrypted = read_file_text(secure_mapping_path());
+        encrypted.has_value()) {
+        if (const std::optional<std::string> plaintext = unprotect_bytes(*encrypted);
+            plaintext.has_value()) {
+            return parse_plaintext(*plaintext);
+        }
+    }
+
+    if (const std::optional<std::string> legacy = read_file_text(app_paths::upload_mapping_path());
+        legacy.has_value()) {
+        return parse_plaintext(*legacy);
+    }
+
+    return {};
+}
+
+bool save(const store& mappings) {
+    app_paths::ensure_directories();
+
+    const std::string plaintext = serialize_plaintext(mappings);
+    const std::optional<std::vector<unsigned char>> encrypted = protect_bytes(plaintext);
+    if (!encrypted.has_value()) {
+        return false;
+    }
+
+    if (!write_file_bytes(secure_mapping_path(), *encrypted)) {
+        return false;
+    }
+
+    std::error_code ec;
+    std::filesystem::remove(app_paths::upload_mapping_path(), ec);
+    return true;
+}
+
+std::optional<std::string> find_remote_song_id(const store& mappings,
+                                               const std::string& server_url,
+                                               const std::string& local_song_id) {
+    for (const song_mapping_entry& entry : mappings.songs) {
+        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
+            return entry.remote_song_id;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<mapping_origin> find_song_origin(const store& mappings,
+                                               const std::string& server_url,
+                                               const std::string& local_song_id) {
+    for (const song_mapping_entry& entry : mappings.songs) {
+        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
+            return entry.origin;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> find_local_song_id(const store& mappings,
+                                              const std::string& server_url,
+                                              const std::string& remote_song_id) {
+    for (const song_mapping_entry& entry : mappings.songs) {
+        if (entry.server_url == server_url && entry.remote_song_id == remote_song_id) {
+            return entry.local_song_id;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> find_remote_chart_id(const store& mappings,
+                                                const std::string& server_url,
+                                                const std::string& local_chart_id) {
+    for (const chart_mapping_entry& entry : mappings.charts) {
+        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
+            return entry.remote_chart_id;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<mapping_origin> find_chart_origin(const store& mappings,
+                                                const std::string& server_url,
+                                                const std::string& local_chart_id) {
+    for (const chart_mapping_entry& entry : mappings.charts) {
+        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
+            return entry.origin;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> find_local_chart_id(const store& mappings,
+                                               const std::string& server_url,
+                                               const std::string& remote_chart_id) {
+    for (const chart_mapping_entry& entry : mappings.charts) {
+        if (entry.server_url == server_url && entry.remote_chart_id == remote_chart_id) {
+            return entry.local_chart_id;
+        }
+    }
+    return std::nullopt;
+}
+
+void remove_chart(store& mappings,
+                  const std::string& server_url,
+                  const std::string& local_chart_id) {
+    std::erase_if(mappings.charts, [&](const chart_mapping_entry& entry) {
+        return entry.server_url == server_url && entry.local_chart_id == local_chart_id;
+    });
+}
+
+void remove_song(store& mappings,
+                 const std::string& server_url,
+                 const std::string& local_song_id) {
+    std::erase_if(mappings.songs, [&](const song_mapping_entry& entry) {
+        return entry.server_url == server_url && entry.local_song_id == local_song_id;
+    });
+    std::erase_if(mappings.charts, [&](const chart_mapping_entry& entry) {
+        return entry.server_url == server_url && entry.local_song_id == local_song_id;
+    });
+}
+
+void put_song(store& mappings,
+              const std::string& server_url,
+              const std::string& local_song_id,
+              const std::string& remote_song_id,
+              mapping_origin origin) {
+    if (local_song_id.empty() || remote_song_id.empty()) {
+        return;
+    }
+
+    bool found = false;
+    for (song_mapping_entry& entry : mappings.songs) {
+        if (entry.server_url == server_url && entry.local_song_id == local_song_id) {
+            found = true;
+            if (entry.remote_song_id != remote_song_id) {
+                entry.remote_song_id = remote_song_id;
+                std::erase_if(mappings.charts, [&](const chart_mapping_entry& chart_entry) {
+                    return chart_entry.server_url == server_url &&
+                           chart_entry.local_song_id == local_song_id;
+                });
+            }
+            entry.origin = origin;
+            break;
+        }
+    }
+
+    if (!found) {
+        mappings.songs.push_back(song_mapping_entry{
+            .server_url = server_url,
+            .local_song_id = local_song_id,
+            .remote_song_id = remote_song_id,
+            .origin = origin,
+        });
+    }
+}
+
+void put_chart(store& mappings,
+               const std::string& server_url,
+               const std::string& local_chart_id,
+               const std::string& local_song_id,
+               const std::string& remote_chart_id,
+               const std::string& remote_song_id,
+               mapping_origin origin) {
+    if (local_chart_id.empty() || remote_chart_id.empty()) {
+        return;
+    }
+
+    for (chart_mapping_entry& entry : mappings.charts) {
+        if (entry.server_url == server_url && entry.local_chart_id == local_chart_id) {
+            entry.local_song_id = local_song_id;
+            entry.remote_chart_id = remote_chart_id;
+            entry.remote_song_id = remote_song_id;
+            entry.origin = origin;
+            return;
+        }
+    }
+
+    mappings.charts.push_back(chart_mapping_entry{
+        .server_url = server_url,
+        .local_chart_id = local_chart_id,
+        .local_song_id = local_song_id,
+        .remote_chart_id = remote_chart_id,
+        .remote_song_id = remote_song_id,
+        .origin = origin,
+    });
+}
+
+}  // namespace title_upload_mapping

--- a/src/scenes/title/upload_mapping_store.cpp
+++ b/src/scenes/title/upload_mapping_store.cpp
@@ -127,7 +127,7 @@ store parse_plaintext(const std::string& content) {
                 .server_url = fields[0],
                 .local_song_id = fields[1],
                 .remote_song_id = fields[2],
-                .origin = fields.size() >= 4 ? parse_origin(fields[3]) : mapping_origin::linked,
+                .origin = fields.size() >= 4 ? parse_origin(fields[3]) : mapping_origin::owned_upload,
             });
         } else if (current_section == section::charts && fields.size() >= 5) {
             mappings.charts.push_back(chart_mapping_entry{
@@ -136,7 +136,7 @@ store parse_plaintext(const std::string& content) {
                 .local_song_id = fields[2],
                 .remote_chart_id = fields[3],
                 .remote_song_id = fields[4],
-                .origin = fields.size() >= 6 ? parse_origin(fields[5]) : mapping_origin::linked,
+                .origin = fields.size() >= 6 ? parse_origin(fields[5]) : mapping_origin::owned_upload,
             });
         }
     }

--- a/src/scenes/title/upload_mapping_store.h
+++ b/src/scenes/title/upload_mapping_store.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace title_upload_mapping {
+
+enum class mapping_origin {
+    owned_upload,
+    downloaded,
+    linked,
+};
+
+struct song_mapping_entry {
+    std::string server_url;
+    std::string local_song_id;
+    std::string remote_song_id;
+    mapping_origin origin = mapping_origin::owned_upload;
+};
+
+struct chart_mapping_entry {
+    std::string server_url;
+    std::string local_chart_id;
+    std::string local_song_id;
+    std::string remote_chart_id;
+    std::string remote_song_id;
+    mapping_origin origin = mapping_origin::owned_upload;
+};
+
+struct store {
+    std::vector<song_mapping_entry> songs;
+    std::vector<chart_mapping_entry> charts;
+};
+
+store load();
+bool save(const store& mappings);
+
+std::optional<std::string> find_remote_song_id(const store& mappings,
+                                               const std::string& server_url,
+                                               const std::string& local_song_id);
+std::optional<mapping_origin> find_song_origin(const store& mappings,
+                                               const std::string& server_url,
+                                               const std::string& local_song_id);
+std::optional<std::string> find_local_song_id(const store& mappings,
+                                              const std::string& server_url,
+                                              const std::string& remote_song_id);
+std::optional<std::string> find_remote_chart_id(const store& mappings,
+                                                const std::string& server_url,
+                                                const std::string& local_chart_id);
+std::optional<mapping_origin> find_chart_origin(const store& mappings,
+                                                const std::string& server_url,
+                                                const std::string& local_chart_id);
+std::optional<std::string> find_local_chart_id(const store& mappings,
+                                               const std::string& server_url,
+                                               const std::string& remote_chart_id);
+
+void remove_chart(store& mappings,
+                  const std::string& server_url,
+                  const std::string& local_chart_id);
+void remove_song(store& mappings,
+                 const std::string& server_url,
+                 const std::string& local_song_id);
+void put_song(store& mappings,
+              const std::string& server_url,
+              const std::string& local_song_id,
+              const std::string& remote_song_id,
+              mapping_origin origin = mapping_origin::owned_upload);
+void put_chart(store& mappings,
+               const std::string& server_url,
+               const std::string& local_chart_id,
+               const std::string& local_song_id,
+               const std::string& remote_chart_id,
+               const std::string& remote_song_id,
+               mapping_origin origin = mapping_origin::owned_upload);
+
+}  // namespace title_upload_mapping

--- a/src/tests/chart_parser_smoke.cpp
+++ b/src/tests/chart_parser_smoke.cpp
@@ -1,5 +1,6 @@
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -14,6 +15,11 @@ std::string chart_path(const std::string& file_name) {
 }
 
 bool expect_success(const std::string& path) {
+    if (!std::filesystem::exists(path)) {
+        std::cerr << "Skipping missing fixture " << path << '\n';
+        return true;
+    }
+
     const chart_parse_result result = chart_parser::parse(path);
     if (!result.success || !result.data.has_value()) {
         std::cerr << "Expected success for " << path << '\n';
@@ -27,6 +33,11 @@ bool expect_success(const std::string& path) {
 }
 
 bool expect_failure(const std::string& path, const std::string& expected_fragment) {
+    if (!std::filesystem::exists(path)) {
+        std::cerr << "Skipping missing fixture " << path << '\n';
+        return true;
+    }
+
     const chart_parse_result result = chart_parser::parse(path);
     if (result.success) {
         std::cerr << "Expected failure for " << path << '\n';
@@ -45,6 +56,40 @@ bool expect_failure(const std::string& path, const std::string& expected_fragmen
     }
     return false;
 }
+
+bool expect_chart_id_fallback() {
+    const std::filesystem::path path =
+        std::filesystem::temp_directory_path() / "raythm_parser_external_id.rchart";
+    std::ofstream output(path, std::ios::trunc);
+    output << "[Metadata]\n"
+           << "keyCount=4\n"
+           << "difficulty=Fallback\n"
+           << "chartAuthor=Codex\n"
+           << "formatVersion=1\n"
+           << "resolution=480\n"
+           << "offset=0\n\n"
+           << "[Timing]\n"
+           << "bpm,0,120\n"
+           << "meter,0,4/4\n\n"
+           << "[Notes]\n"
+           << "tap,0,0\n";
+    output.close();
+
+    const chart_parse_result result = chart_parser::parse(path.string());
+    std::filesystem::remove(path);
+    if (!result.success || !result.data.has_value()) {
+        std::cerr << "Expected chartId fallback chart to load\n";
+        for (const std::string& error : result.errors) {
+            std::cerr << "  " << error << '\n';
+        }
+        return false;
+    }
+    if (result.data->meta.chart_id != "raythm_parser_external_id") {
+        std::cerr << "Expected chartId to fall back to the file stem\n";
+        return false;
+    }
+    return true;
+}
 }
 
 int main() {
@@ -53,6 +98,7 @@ int main() {
     ok = expect_success(chart_path("parser_valid.rchart")) && ok;
     ok = expect_failure(chart_path("parser_invalid_overlap.rchart"), "overlapping notes") && ok;
     ok = expect_failure(chart_path("parser_invalid_metadata.rchart"), "keyCount must be 4 or 6") && ok;
+    ok = expect_chart_id_fallback() && ok;
 
     if (!ok) {
         return EXIT_FAILURE;

--- a/src/tests/chart_serializer_smoke.cpp
+++ b/src/tests/chart_serializer_smoke.cpp
@@ -9,7 +9,9 @@
 #include <string>
 
 #include "chart_parser.h"
+#include "chart_fingerprint.h"
 #include "chart_serializer.h"
+#include "updater/update_verify.h"
 
 namespace {
 bool almost_equal(float left, float right) {
@@ -95,7 +97,7 @@ int main() {
         std::filesystem::temp_directory_path() / "raythm_chart_serializer_smoke.rchart";
 
     chart_data source;
-    source.meta.chart_id = "serializer-smoke";
+    source.meta.chart_id = output_path.stem().string();
     source.meta.key_count = 4;
     source.meta.difficulty = "Hyper";
     source.meta.level = 9;
@@ -127,9 +129,22 @@ int main() {
     bool ok = true;
 
     ok = content.find("offset=-35") != std::string::npos && ok;
+    ok = content.find("chartId=") == std::string::npos && ok;
+    ok = content.find("songId=") == std::string::npos && ok;
     ok = content.find("level=") == std::string::npos && ok;
     ok = expect_contains_in_order(content, "meter,0,4/4", "bpm,960,180.5") && ok;
     ok = expect_contains_in_order(content, "tap,480,0", "hold,480,2,840") && ok;
+
+    const std::string content_with_ids =
+        "[Metadata]\nchartId=online-chart\nsongId=online-song\n" +
+        content.substr(content.find("keyCount="));
+    const std::string content_with_other_ids =
+        "[Metadata]\nchartId=other-chart\nsongId=other-song\n" +
+        content.substr(content.find("keyCount="));
+    const std::string fingerprint_with_ids = chart_fingerprint::build(content_with_ids);
+    const std::string fingerprint_with_other_ids = chart_fingerprint::build(content_with_other_ids);
+    ok = updater::compute_sha256_hex(std::string_view(fingerprint_with_ids)) ==
+         updater::compute_sha256_hex(std::string_view(fingerprint_with_other_ids)) && ok;
 
     const chart_parse_result reparsed = chart_parser::parse(output_path.string());
     if (!reparsed.success || !reparsed.data.has_value()) {

--- a/src/tests/song_loader_smoke.cpp
+++ b/src/tests/song_loader_smoke.cpp
@@ -3,10 +3,23 @@
 #include <fstream>
 #include <iostream>
 #include <string>
+#include <vector>
 
+#include "chart_identity_store.h"
+#include "song_fingerprint.h"
 #include "song_loader.h"
+#include "song_writer.h"
+#include "updater/update_verify.h"
 
 namespace {
+bool set_local_app_data(const std::filesystem::path& path) {
+#ifdef _WIN32
+    return _putenv_s("LOCALAPPDATA", path.string().c_str()) == 0;
+#else
+    return setenv("LOCALAPPDATA", path.string().c_str(), 1) == 0;
+#endif
+}
+
 std::string songs_root() {
     const std::filesystem::path repo_root =
         std::filesystem::path(__FILE__).parent_path().parent_path().parent_path();
@@ -52,10 +65,60 @@ std::filesystem::path write_temp_chart() {
            << "tap,720,3\n";
     return path;
 }
+
+std::filesystem::path write_temp_song_without_embedded_id() {
+    const std::filesystem::path song_dir =
+        std::filesystem::temp_directory_path() / "raythm_song_loader_external_song_id";
+    std::error_code ec;
+    std::filesystem::remove_all(song_dir, ec);
+    std::filesystem::create_directories(song_dir);
+    std::ofstream output(song_dir / "song.json", std::ios::trunc);
+    output << "{\n"
+           << "  \"title\": \"External ID Song\",\n"
+           << "  \"artist\": \"Codex\",\n"
+           << "  \"baseBpm\": 120,\n"
+           << "  \"audioFile\": \"audio.ogg\",\n"
+           << "  \"jacketFile\": \"jacket.png\",\n"
+           << "  \"previewStartMs\": 0,\n"
+           << "  \"songVersion\": 1\n"
+           << "}\n";
+    return song_dir;
+}
+
+std::filesystem::path write_external_chart_without_song_id() {
+    const std::filesystem::path charts_dir =
+        std::filesystem::temp_directory_path() / "raythm_song_loader_external_charts";
+    std::error_code ec;
+    std::filesystem::remove_all(charts_dir, ec);
+    std::filesystem::create_directories(charts_dir);
+    std::ofstream output(charts_dir / "external-linked.rchart", std::ios::trunc);
+    output << "[Metadata]\n"
+           << "keyCount=4\n"
+           << "difficulty=External\n"
+           << "chartAuthor=Codex\n"
+           << "formatVersion=1\n"
+           << "resolution=480\n"
+           << "offset=0\n\n"
+           << "[Timing]\n"
+           << "bpm,0,120\n"
+           << "meter,0,4/4\n\n"
+           << "[Notes]\n"
+           << "tap,0,0\n";
+    return charts_dir;
+}
 }
 
 int main() {
     bool ok = true;
+    const std::filesystem::path appdata_root =
+        std::filesystem::temp_directory_path() / "raythm-song-loader-smoke-appdata";
+    std::error_code ec;
+    std::filesystem::remove_all(appdata_root, ec);
+    if (!set_local_app_data(appdata_root)) {
+        std::cerr << "failed to set LOCALAPPDATA\n";
+        return EXIT_FAILURE;
+    }
+
     song_load_result load_result;
     if (std::filesystem::exists(songs_root())) {
         load_result = song_loader::load_all(songs_root());
@@ -108,6 +171,105 @@ int main() {
         }
     }
     std::filesystem::remove(temp_chart);
+
+    const std::filesystem::path temp_song = write_temp_song_without_embedded_id();
+    const song_load_result temp_song_result = song_loader::load_directory(temp_song.string());
+    if (temp_song_result.songs.size() != 1 ||
+        temp_song_result.songs.front().meta.song_id != "raythm_song_loader_external_song_id") {
+        std::cerr << "Expected missing songId to fall back to the song directory name\n";
+        ok = false;
+    }
+    std::filesystem::remove_all(temp_song);
+
+    const std::filesystem::path written_song_dir =
+        std::filesystem::temp_directory_path() / "raythm_song_writer_external_id";
+    std::filesystem::remove_all(written_song_dir, ec);
+    song_meta written_meta;
+    written_meta.song_id = "external-local-id";
+    written_meta.title = "Written Song";
+    written_meta.artist = "Codex";
+    written_meta.base_bpm = 128.0f;
+    written_meta.audio_file = "audio.ogg";
+    written_meta.jacket_file = "jacket.png";
+    written_meta.preview_start_ms = 0;
+    written_meta.song_version = 1;
+    if (!song_writer::write_song_json(written_meta, written_song_dir.string())) {
+        std::cerr << "Expected song writer to write song.json\n";
+        ok = false;
+    } else {
+        std::ifstream written_input(written_song_dir / "song.json", std::ios::binary);
+        const std::string written_content{std::istreambuf_iterator<char>(written_input),
+                                          std::istreambuf_iterator<char>()};
+        if (written_content.find("\"songId\"") != std::string::npos) {
+            std::cerr << "Expected song writer to keep local song id outside song.json\n";
+            ok = false;
+        }
+    }
+    std::filesystem::remove_all(written_song_dir, ec);
+
+    const std::string song_json_a =
+        "{\n  \"songId\": \"local-song\",\n  \"title\": \"Same\",\n  \"artist\": \"Codex\"\n}\n";
+    const std::string song_json_b =
+        "{\n  \"songId\": \"remote-song\",\n  \"title\": \"Same\",\n  \"artist\": \"Codex\"\n}\n";
+    const std::string song_fp_a = song_fingerprint::build(song_json_a);
+    const std::string song_fp_b = song_fingerprint::build(song_json_b);
+    if (updater::compute_sha256_hex(std::string_view(song_fp_a)) !=
+        updater::compute_sha256_hex(std::string_view(song_fp_b))) {
+        std::cerr << "Expected song fingerprint to ignore songId differences\n";
+        ok = false;
+    }
+    const std::string song_json_local =
+        "{\n"
+        "  \"songId\": \"local-song\",\n"
+        "  \"title\": \"Same\",\n"
+        "  \"artist\": \"Codex\",\n"
+        "  \"baseBpm\": 125.0,\n"
+        "  \"audioFile\": \"custom-audio.ogg\",\n"
+        "  \"jacketFile\": \"custom-jacket.png\",\n"
+        "  \"previewStartMs\": 1200,\n"
+        "  \"songVersion\": 1\n"
+        "}\n";
+    const std::string song_json_server =
+        "{\n"
+        "  \"artist\": \"Codex\",\n"
+        "  \"audioFile\": \"audio.ogg\",\n"
+        "  \"baseBpm\": 125,\n"
+        "  \"jacketFile\": \"jacket.png\",\n"
+        "  \"previewStartMs\": 1200,\n"
+        "  \"songVersion\": 1,\n"
+        "  \"title\": \"Same\"\n"
+        "}\n";
+    if (updater::compute_sha256_hex(std::string_view(song_fingerprint::build(song_json_local))) !=
+        updater::compute_sha256_hex(std::string_view(song_fingerprint::build(song_json_server)))) {
+        std::cerr << "Expected song fingerprint to ignore storage-only song metadata differences\n";
+        ok = false;
+    }
+    const std::string escaped_song_json =
+        "{\n"
+        "  \"title\": \"Same \\\"Title\\\"\",\n"
+        "  \"artist\": \"Codex\",\n"
+        "  \"baseBpm\": 125,\n"
+        "  \"previewStartMs\": 0,\n"
+        "  \"songVersion\": 1\n"
+        "}\n";
+    if (song_fingerprint::build(escaped_song_json).find("title=Same \"Title\"") == std::string::npos) {
+        std::cerr << "Expected song fingerprint to normalize escaped JSON strings\n";
+        ok = false;
+    }
+
+    const std::filesystem::path external_charts_dir = write_external_chart_without_song_id();
+    chart_identity::put("external-linked", "linked-song");
+    std::vector<song_data> external_songs;
+    song_data linked_song;
+    linked_song.meta.song_id = "linked-song";
+    external_songs.push_back(linked_song);
+    song_loader::attach_external_charts(external_charts_dir.string(), external_songs);
+    if (external_songs.front().chart_paths.empty()) {
+        std::cerr << "Expected external chart identity index to attach chart to song\n";
+        ok = false;
+    }
+    std::filesystem::remove_all(external_charts_dir);
+    std::filesystem::remove_all(appdata_root, ec);
 
     if (std::filesystem::exists(songs_root()) && ok) {
         const song_data* song_with_chart = nullptr;

--- a/src/tests/upload_mapping_store_smoke.cpp
+++ b/src/tests/upload_mapping_store_smoke.cpp
@@ -1,0 +1,81 @@
+#include "app_paths.h"
+#include "title/upload_mapping_store.h"
+
+#include <cstdlib>
+#include <filesystem>
+#include <iostream>
+#include <optional>
+#include <string>
+
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
+
+namespace fs = std::filesystem;
+
+bool set_local_app_data(const fs::path& path) {
+#ifdef _WIN32
+    return _putenv_s("LOCALAPPDATA", path.string().c_str()) == 0;
+#else
+    return setenv("LOCALAPPDATA", path.string().c_str(), 1) == 0;
+#endif
+}
+
+int main() {
+    const fs::path temp_root = fs::temp_directory_path() / "raythm-upload-mapping-smoke";
+    std::error_code ec;
+    fs::remove_all(temp_root, ec);
+    if (!set_local_app_data(temp_root)) {
+        std::cerr << "failed to set LOCALAPPDATA\n";
+        return 1;
+    }
+
+    title_upload_mapping::store mappings;
+    title_upload_mapping::put_song(mappings, "https://server.example", "local-song", "remote-song",
+                                   title_upload_mapping::mapping_origin::owned_upload);
+    title_upload_mapping::put_song(mappings, "https://server.example", "downloaded-song", "remote-downloaded",
+                                   title_upload_mapping::mapping_origin::downloaded);
+    title_upload_mapping::put_chart(mappings, "https://server.example", "local-chart", "local-song",
+                                    "remote-chart", "remote-song",
+                                    title_upload_mapping::mapping_origin::owned_upload);
+    if (!title_upload_mapping::save(mappings)) {
+        std::cerr << "failed to save mappings\n";
+        return 1;
+    }
+
+    const title_upload_mapping::store loaded = title_upload_mapping::load();
+    if (title_upload_mapping::find_remote_song_id(loaded, "https://server.example", "local-song") !=
+        std::optional<std::string>("remote-song")) {
+        std::cerr << "remote song mapping missing\n";
+        return 1;
+    }
+    if (title_upload_mapping::find_local_song_id(loaded, "https://server.example", "remote-song") !=
+        std::optional<std::string>("local-song")) {
+        std::cerr << "local song mapping missing\n";
+        return 1;
+    }
+    if (title_upload_mapping::find_song_origin(loaded, "https://server.example", "downloaded-song") !=
+        std::optional<title_upload_mapping::mapping_origin>(title_upload_mapping::mapping_origin::downloaded)) {
+        std::cerr << "song mapping origin missing\n";
+        return 1;
+    }
+    if (title_upload_mapping::find_remote_chart_id(loaded, "https://server.example", "local-chart") !=
+        std::optional<std::string>("remote-chart")) {
+        std::cerr << "remote chart mapping missing\n";
+        return 1;
+    }
+    if (title_upload_mapping::find_local_chart_id(loaded, "https://server.example", "remote-chart") !=
+        std::optional<std::string>("local-chart")) {
+        std::cerr << "local chart mapping missing\n";
+        return 1;
+    }
+    if (title_upload_mapping::find_chart_origin(loaded, "https://server.example", "local-chart") !=
+        std::optional<title_upload_mapping::mapping_origin>(title_upload_mapping::mapping_origin::owned_upload)) {
+        std::cerr << "chart mapping origin missing\n";
+        return 1;
+    }
+
+    fs::remove_all(temp_root, ec);
+    std::cout << "upload_mapping_store smoke test passed\n";
+    return 0;
+}

--- a/src/tests/upload_mapping_store_smoke.cpp
+++ b/src/tests/upload_mapping_store_smoke.cpp
@@ -3,6 +3,7 @@
 
 #include <cstdlib>
 #include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <optional>
 #include <string>
@@ -72,6 +73,29 @@ int main() {
     if (title_upload_mapping::find_chart_origin(loaded, "https://server.example", "local-chart") !=
         std::optional<title_upload_mapping::mapping_origin>(title_upload_mapping::mapping_origin::owned_upload)) {
         std::cerr << "chart mapping origin missing\n";
+        return 1;
+    }
+
+    fs::remove_all(temp_root, ec);
+    fs::create_directories(app_paths::app_data_root(), ec);
+    {
+        std::ofstream legacy(app_paths::upload_mapping_path(), std::ios::binary | std::ios::trunc);
+        legacy << "# raythm upload mappings v1\n"
+               << "[songs]\n"
+               << "https://server.example\tlegacy-local-song\tlegacy-remote-song\n"
+               << "[charts]\n"
+               << "https://server.example\tlegacy-local-chart\tlegacy-local-song\tlegacy-remote-chart\tlegacy-remote-song\n";
+    }
+
+    const title_upload_mapping::store legacy_loaded = title_upload_mapping::load();
+    if (title_upload_mapping::find_song_origin(legacy_loaded, "https://server.example", "legacy-local-song") !=
+        std::optional<title_upload_mapping::mapping_origin>(title_upload_mapping::mapping_origin::owned_upload)) {
+        std::cerr << "legacy song mapping should migrate as owned upload\n";
+        return 1;
+    }
+    if (title_upload_mapping::find_chart_origin(legacy_loaded, "https://server.example", "legacy-local-chart") !=
+        std::optional<title_upload_mapping::mapping_origin>(title_upload_mapping::mapping_origin::owned_upload)) {
+        std::cerr << "legacy chart mapping should migrate as owned upload\n";
         return 1;
     }
 

--- a/src/updater/update_verify.cpp
+++ b/src/updater/update_verify.cpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 
 namespace {
 
@@ -184,6 +185,14 @@ std::optional<std::string> compute_sha256_hex(const std::filesystem::path& file_
             sha256_update(state, reinterpret_cast<const std::uint8_t*>(buffer.data()), static_cast<std::size_t>(bytes_read));
         }
     }
+    return sha256_finish(state);
+}
+
+std::string compute_sha256_hex(std::string_view content) {
+    sha256_state state;
+    sha256_update(state,
+                  reinterpret_cast<const std::uint8_t*>(content.data()),
+                  content.size());
     return sha256_finish(state);
 }
 

--- a/src/updater/update_verify.h
+++ b/src/updater/update_verify.h
@@ -3,10 +3,12 @@
 #include <filesystem>
 #include <optional>
 #include <string>
+#include <string_view>
 
 namespace updater {
 
 std::optional<std::string> compute_sha256_hex(const std::filesystem::path& file_path);
+std::string compute_sha256_hex(std::string_view content);
 std::optional<std::string> parse_sha256sums_for_file(const std::string& checksums_content, const std::string& file_name);
 bool verify_sha256_checksum(const std::filesystem::path& file_path, const std::filesystem::path& checksums_path);
 


### PR DESCRIPTION
## 概要
- `.rchart` と新規 `song.json` から埋め込みIDを書き出さないようにし、外部マッピングで曲/譜面の対応を保持
- ダウンロード済み/投稿済みコンテンツのマッピングを暗号化ストアに移行し、legacy mapping は owned upload として移行
- 曲/譜面 fingerprint を追加し、`songId` や保存ファイル名差分で Modified 扱いになりにくく調整
- manifest取得・Official検証・ランキング送信でローカルIDではなく対応するリモートIDを使うよう修正
- 譜面単体Update時に既存ローカル譜面を上書きし、remote ID名の重複ファイルを作らないよう修正

## 確認
- `cmake --build cmake-build-codex --target raythm song_loader_smoke ranking_service_smoke chart_serializer_smoke upload_mapping_store_smoke`
- `song_loader_smoke`, `ranking_service_smoke`, `chart_serializer_smoke`, `upload_mapping_store_smoke`, `chart_parser_smoke`