### PR TITLE
タイトルヘッダーの更新導線を整える

### DIFF
--- a/src/scenes/title/online_download_layout.cpp
+++ b/src/scenes/title/online_download_layout.cpp
@@ -26,7 +26,6 @@ constexpr Rectangle kFallbackOriginRect = {1140.0f, 564.0f, 240.0f, 90.0f};
 constexpr float kSearchLeftGap = 36.0f;
 constexpr float kSearchRightGap = 27.0f;
 constexpr float kSearchY = 60.0f;
-constexpr float kSearchMinWidth = 330.0f;
 constexpr float kSearchHeight = 57.0f;
 constexpr Vector2 kSeedBackOffset = {-672.0f, -297.0f};
 constexpr Vector2 kSeedOfficialTabOffset = {-414.0f, -291.0f};
@@ -99,13 +98,13 @@ Rectangle left_pane_full_width_button_rect(Rectangle content_rect,
 }
 
 Rectangle browse_search_rect() {
-    const Rectangle account_rect = title_layout::account_chip_rect();
+    const Rectangle refresh_rect = title_layout::refresh_chip_rect();
     const float left = kOwnedTabRect.x + kOwnedTabRect.width + kSearchLeftGap;
-    const float right = account_rect.x - kSearchRightGap;
+    const float right = refresh_rect.x - kSearchRightGap;
     return {
         left,
         kSearchY,
-        std::max(kSearchMinWidth, right - left),
+        std::max(0.0f, right - left),
         kSearchHeight,
     };
 }

--- a/src/scenes/title/online_download_render.cpp
+++ b/src/scenes/title/online_download_render.cpp
@@ -55,17 +55,19 @@ ui::text_input_result draw_song_search_input(Rectangle rect, ui::text_input_stat
         : hovered ? hover_row_alpha
                   : normal_row_alpha;
     ui::draw_rect_f(visual, with_alpha(state.active ? button_selected : button_base, row_alpha));
-    ui::draw_rect_lines(visual, 1.2f,
+    const Rectangle border_rect = ui::inset(visual, 1.0f);
+    ui::draw_rect_lines(border_rect, 1.2f,
                         with_alpha(state.active ? t.border_active : t.border_light, alpha));
 
     const Rectangle content_rect = ui::inset(visual, ui::edge_insets::symmetric(0.0f, 14.0f));
     constexpr float kLabelWidth = 108.0f;
     constexpr float kLabelGap = 14.0f;
+    const bool show_label = !state.active && state.value.empty();
     const Rectangle label_rect = {content_rect.x, content_rect.y, kLabelWidth, content_rect.height};
     const Rectangle text_rect = {
-        content_rect.x + kLabelWidth + kLabelGap,
+        show_label ? content_rect.x + kLabelWidth + kLabelGap : content_rect.x,
         content_rect.y,
-        std::max(0.0f, content_rect.width - kLabelWidth - kLabelGap),
+        show_label ? std::max(0.0f, content_rect.width - kLabelWidth - kLabelGap) : content_rect.width,
         content_rect.height,
     };
 
@@ -203,8 +205,10 @@ ui::text_input_result draw_song_search_input(Rectangle rect, ui::text_input_stat
 
     ui::update_text_input_scroll(state, text_rect.width - 8.0f, font_size);
 
-    ui::draw_text_in_rect(label, font_size, label_rect,
-                          with_alpha(state.active ? t.text : t.text_secondary, alpha), ui::text_align::left);
+    if (show_label) {
+        ui::draw_text_in_rect(label, font_size, label_rect,
+                              with_alpha(t.text_secondary, alpha), ui::text_align::left);
+    }
 
     std::string display_value = state.value;
     if (display_value.empty() && !state.active && placeholder != nullptr) {

--- a/src/scenes/title/title_header_view.cpp
+++ b/src/scenes/title/title_header_view.cpp
@@ -1,6 +1,7 @@
 #include "title/title_header_view.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "title/title_layout.h"
 #include "theme.h"
@@ -35,6 +36,83 @@ constexpr float kAccountArrowOffsetY = 18.0f;
 constexpr float kAccountArrowWidth = 18.0f;
 constexpr float kAccountArrowHeight = 36.0f;
 constexpr float kSettingsBorderWidth = 3.0f;
+constexpr float kRefreshIconRadius = 20.0f;
+constexpr int kRefreshIconSegments = 24;
+constexpr float kPi = 3.14159265358979323846f;
+constexpr float kRefreshHeadRotation = 75.0f * kPi / 180.0f;
+constexpr int kSettingsGearTeeth = 8;
+
+void draw_chip_background(Rectangle rect, Color bg, Color border, unsigned char alpha) {
+    const bool hovered = ui::is_hovered(rect);
+    const bool pressed = ui::is_pressed(rect);
+    const Rectangle visual = pressed ? ui::inset(rect, 1.5f) : rect;
+    ui::draw_rect_f(visual, with_alpha(hovered ? bg : g_theme->panel, alpha));
+    ui::draw_rect_lines(visual, kSettingsBorderWidth, with_alpha(border, alpha));
+}
+
+void draw_refresh_icon(Rectangle rect, Color color, unsigned char alpha) {
+    const Vector2 center = {rect.x + rect.width * 0.5f, rect.y + rect.height * 0.5f};
+    const Color icon = with_alpha(color, alpha);
+    const float start = -0.30f * kPi;
+    const float end = 1.42f * kPi;
+    Vector2 previous = {
+        center.x + std::cos(start) * kRefreshIconRadius,
+        center.y + std::sin(start) * kRefreshIconRadius
+    };
+
+    for (int i = 1; i <= kRefreshIconSegments; ++i) {
+        const float t = static_cast<float>(i) / static_cast<float>(kRefreshIconSegments);
+        const float angle = start + (end - start) * t;
+        const Vector2 current = {
+            center.x + std::cos(angle) * kRefreshIconRadius,
+            center.y + std::sin(angle) * kRefreshIconRadius
+        };
+        DrawLineEx(previous, current, 3.0f, icon);
+        previous = current;
+    }
+
+    const Vector2 tip = {
+        center.x + std::cos(end) * kRefreshIconRadius,
+        center.y + std::sin(end) * kRefreshIconRadius
+    };
+    constexpr float kHeadLength = 13.0f;
+    constexpr float kHeadSpread = 0.62f;
+    const float head_angle = end + kPi + kRefreshHeadRotation;
+    const Vector2 wing_a = {
+        tip.x + std::cos(head_angle + kHeadSpread) * kHeadLength,
+        tip.y + std::sin(head_angle + kHeadSpread) * kHeadLength
+    };
+    const Vector2 wing_b = {
+        tip.x + std::cos(head_angle - kHeadSpread) * kHeadLength,
+        tip.y + std::sin(head_angle - kHeadSpread) * kHeadLength
+    };
+    DrawLineEx(tip, wing_a, 3.0f, icon);
+    DrawLineEx(tip, wing_b, 3.0f, icon);
+}
+
+void draw_settings_icon(Rectangle rect, Color color, unsigned char alpha) {
+    const Vector2 center = {rect.x + rect.width * 0.5f, rect.y + rect.height * 0.5f};
+    const Color icon = with_alpha(color, alpha);
+    constexpr float ring_radius = 16.0f;
+    constexpr float tooth_inner_radius = 15.0f;
+    constexpr float tooth_outer_radius = 27.0f;
+    constexpr float tooth_width = 10.0f;
+
+    DrawRing(center, ring_radius - 8.0f, ring_radius + 4.0f, 0.0f, 360.0f, 48, icon);
+
+    for (int i = 0; i < kSettingsGearTeeth; ++i) {
+        const float angle = (static_cast<float>(i) / static_cast<float>(kSettingsGearTeeth)) * kPi * 2.0f;
+        const Vector2 a = {
+            center.x + std::cos(angle) * tooth_inner_radius,
+            center.y + std::sin(angle) * tooth_inner_radius
+        };
+        const Vector2 b = {
+            center.x + std::cos(angle) * tooth_outer_radius,
+            center.y + std::sin(angle) * tooth_outer_radius
+        };
+        DrawLineEx(a, b, tooth_width, icon);
+    }
+}
 
 }  // namespace
 
@@ -93,15 +171,19 @@ void draw(const draw_config& config) {
     }
 
     const unsigned char account_alpha = static_cast<unsigned char>(255.0f * std::max(config.menu_t, config.play_t));
-    const bool settings_hovered = ui::is_hovered(config.settings_chip_rect);
-    const bool settings_pressed = ui::is_pressed(config.settings_chip_rect);
-    const Rectangle settings_visual = settings_pressed ? ui::inset(config.settings_chip_rect, 1.5f)
-                                                       : config.settings_chip_rect;
-    const Color settings_bg = settings_hovered ? t.row_hover : t.panel;
-    ui::draw_rect_f(settings_visual, with_alpha(settings_bg, account_alpha));
-    ui::draw_rect_lines(settings_visual, kSettingsBorderWidth, with_alpha(t.border, account_alpha));
-    ui::draw_text_in_rect("SET", 18, settings_visual,
-                          with_alpha(t.text, account_alpha), ui::text_align::center);
+    draw_chip_background(config.settings_chip_rect, t.row_hover, t.border, account_alpha);
+    const Rectangle settings_visual = ui::is_pressed(config.settings_chip_rect)
+        ? ui::inset(config.settings_chip_rect, 1.5f)
+        : config.settings_chip_rect;
+    draw_settings_icon(settings_visual,
+                       ui::is_hovered(config.settings_chip_rect) ? t.text : t.text_secondary,
+                       account_alpha);
+
+    draw_chip_background(config.refresh_chip_rect, t.row_hover, t.border, account_alpha);
+    const Rectangle refresh_visual = ui::is_pressed(config.refresh_chip_rect)
+        ? ui::inset(config.refresh_chip_rect, 1.5f)
+        : config.refresh_chip_rect;
+    draw_refresh_icon(refresh_visual, ui::is_hovered(config.refresh_chip_rect) ? t.text : t.text_secondary, account_alpha);
 
     ui::draw_rect_f(config.account_chip_rect, with_alpha(t.panel, account_alpha));
     ui::draw_rect_lines(config.account_chip_rect, kAccountBorderWidth, with_alpha(t.border, account_alpha));

--- a/src/scenes/title/title_header_view.h
+++ b/src/scenes/title/title_header_view.h
@@ -9,6 +9,7 @@ namespace title_header_view {
 struct draw_config {
     Rectangle closed_header_rect;
     Rectangle open_header_rect;
+    Rectangle refresh_chip_rect;
     Rectangle settings_chip_rect;
     Rectangle account_chip_rect;
     float menu_t = 0.0f;

--- a/src/scenes/title/title_layout.cpp
+++ b/src/scenes/title/title_layout.cpp
@@ -20,6 +20,8 @@ constexpr float kAccountChipHeight = 87.0f;
 constexpr Vector2 kAccountChipOffset = {-42.0f, 30.0f};
 constexpr float kSettingsChipSize = 87.0f;
 constexpr float kSettingsChipGap = 18.0f;
+constexpr float kRefreshChipSize = 87.0f;
+constexpr float kRefreshChipGap = 18.0f;
 
 }  // namespace
 
@@ -62,6 +64,16 @@ Rectangle settings_chip_rect() {
         account.y,
         kSettingsChipSize,
         kSettingsChipSize
+    };
+}
+
+Rectangle refresh_chip_rect() {
+    const Rectangle settings = settings_chip_rect();
+    return {
+        settings.x - kRefreshChipGap - kRefreshChipSize,
+        settings.y,
+        kRefreshChipSize,
+        kRefreshChipSize
     };
 }
 

--- a/src/scenes/title/title_layout.h
+++ b/src/scenes/title/title_layout.h
@@ -9,6 +9,7 @@ Rectangle closed_header_rect();
 Rectangle open_header_rect();
 Rectangle play_header_rect();
 Rectangle spectrum_rect();
+Rectangle refresh_chip_rect();
 Rectangle settings_chip_rect();
 Rectangle account_chip_rect();
 

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -348,6 +348,21 @@ void title_scene::poll_play_catalog_reload() {
     queued_play_catalog_calculate_missing_levels_ = false;
 }
 
+void title_scene::capture_current_play_selection() {
+    const song_select::song_entry* song = song_select::selected_song(play_state_);
+    if (song == nullptr) {
+        return;
+    }
+
+    preferred_song_id_ = song->song.meta.song_id;
+    const auto filtered = song_select::filtered_charts_for_selected_song(play_state_);
+    if (const song_select::chart_option* chart = song_select::selected_chart_for(play_state_, filtered)) {
+        preferred_chart_id_ = chart->meta.chart_id;
+    } else {
+        preferred_chart_id_.clear();
+    }
+}
+
 void title_scene::sync_play_media() {
     title_play_session::sync_preview(play_state_, audio_controller_.preview());
     request_play_ranking_reload();
@@ -520,7 +535,11 @@ void title_scene::poll_create_upload() {
     create_upload_in_progress_ = false;
     song_select::queue_status_message(play_state_, result.message, !result.success);
     if (result.success && result.should_refresh_online_catalog) {
-        title_online_view::reload_catalog(online_state_);
+        capture_current_play_selection();
+        title_online_view::reload_catalog(online_state_, true);
+        request_play_catalog_reload(preferred_song_id_, preferred_chart_id_,
+                                    mode_ == hub_mode::play || mode_ == hub_mode::create,
+                                    true);
     }
 }
 
@@ -1094,6 +1113,23 @@ bool title_scene::handle_settings_button_input() {
     return true;
 }
 
+bool title_scene::handle_refresh_button_input() {
+    if (mode_ == hub_mode::settings || home_menu_anim_ < kAccountChipInteractiveThreshold) {
+        return false;
+    }
+    if (!ui::is_clicked(title_layout::refresh_chip_rect())) {
+        return false;
+    }
+
+    capture_current_play_selection();
+    title_online_view::reload_catalog(online_state_, true);
+    request_play_catalog_reload(preferred_song_id_, preferred_chart_id_,
+                                mode_ == hub_mode::play || mode_ == hub_mode::create,
+                                true);
+    ui::notify("Refreshing catalog...", ui::notice_tone::info, 1.8f);
+    return true;
+}
+
 bool title_scene::handle_login_dialog_input() {
     if (!play_state_.login_dialog.open) {
         return false;
@@ -1478,19 +1514,27 @@ void title_scene::update(float dt) {
         return;
     }
 
+    if (!suppress_home_pointer_this_frame && handle_refresh_button_input()) {
+        return;
+    }
+
     if (!suppress_home_pointer_this_frame && handle_settings_button_input()) {
         return;
     }
 
     const Rectangle account_chip_rect = title_layout::account_chip_rect();
+    const Rectangle refresh_chip_rect = title_layout::refresh_chip_rect();
     const Rectangle settings_chip_rect = title_layout::settings_chip_rect();
     const bool account_hovered =
         home_menu_anim_ >= kAccountChipInteractiveThreshold && ui::is_hovered(account_chip_rect);
+    const bool refresh_hovered =
+        home_menu_anim_ >= kAccountChipInteractiveThreshold && ui::is_hovered(refresh_chip_rect);
     const bool settings_hovered =
         home_menu_anim_ >= kAccountChipInteractiveThreshold && ui::is_hovered(settings_chip_rect);
     const bool left_click_for_home =
         IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
         !account_hovered &&
+        !refresh_hovered &&
         !settings_hovered;
     const bool right_click_for_home = IsMouseButtonPressed(MOUSE_BUTTON_RIGHT);
 
@@ -1591,6 +1635,7 @@ void title_scene::draw() {
     const Rectangle screen_rect = title_layout::screen_rect();
     const Rectangle spectrum_rect = title_layout::spectrum_rect();
     const Rectangle settings_chip_rect = title_layout::settings_chip_rect();
+    const Rectangle refresh_chip_rect = title_layout::refresh_chip_rect();
     const Rectangle account_chip_rect = title_layout::account_chip_rect();
     virtual_screen::begin_ui();
     ClearBackground(t.bg);
@@ -1602,6 +1647,7 @@ void title_scene::draw() {
         title_header_view::draw({
             .closed_header_rect = title_layout::closed_header_rect(),
             .open_header_rect = title_layout::open_header_rect(),
+            .refresh_chip_rect = refresh_chip_rect,
             .settings_chip_rect = settings_chip_rect,
             .account_chip_rect = account_chip_rect,
             .menu_t = menu_t,

--- a/src/scenes/title_scene.h
+++ b/src/scenes/title_scene.h
@@ -76,12 +76,14 @@ private:
     void start_chart_export();
     bool handle_account_input();
     bool handle_settings_button_input();
+    bool handle_refresh_button_input();
     bool handle_login_dialog_input();
     void request_play_catalog_reload(std::string preferred_song_id = "",
                                      std::string preferred_chart_id = "",
                                      bool sync_media_on_apply = false,
                                      bool calculate_missing_levels = false);
     void poll_play_catalog_reload();
+    void capture_current_play_selection();
     void sync_play_media();
     void request_play_ranking_reload();
     void poll_play_ranking_reload();


### PR DESCRIPTION
## 概要
- アップロード成功後にローカルカタログも再読み込みし、Community判定へ反映されるようにしました
- タイトルヘッダーに更新ボタンを追加し、オンライン/ローカルカタログを手動更新できるようにしました
- Browseヘッダーの検索ボックス幅と入力中表示を調整しました
- SET表示を設定アイコンに置き換え、更新アイコンも調整しました

## 確認
- `cmake --build cmake-build-codex --target raythm --config Debug`
- `song_loader_smoke.exe`
- `song_select_state_smoke.exe`
- `ranking_service_smoke.exe`
- `git diff --check`