### PR TITLE
ローカルコンテンツ管理をSQLiteへ移行する

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,25 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(raylib)
 
+FetchContent_Declare(
+        sqlite3_amalgamation
+        URL https://www.sqlite.org/2026/sqlite-amalgamation-3530000.zip
+        URL_HASH SHA3_256=c2325c53b3b41761469f91cfb078e96882ac5d85bac10c11b0bd8f253b031e5b
+)
+if(POLICY CMP0169)
+    cmake_policy(PUSH)
+    cmake_policy(SET CMP0169 OLD)
+endif()
+FetchContent_GetProperties(sqlite3_amalgamation)
+if(NOT sqlite3_amalgamation_POPULATED)
+    FetchContent_Populate(sqlite3_amalgamation)
+endif()
+if(POLICY CMP0169)
+    cmake_policy(POP)
+endif()
+add_library(sqlite3 STATIC "${sqlite3_amalgamation_SOURCE_DIR}/sqlite3.c")
+target_include_directories(sqlite3 PUBLIC "${sqlite3_amalgamation_SOURCE_DIR}")
+
 if(WIN32)
     if(NOT EXISTS "${RAYTHM_APP_ICON_PNG}")
         message(FATAL_ERROR "Missing required Windows app icon: ${RAYTHM_APP_ICON_PNG}")
@@ -160,6 +179,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/updater/update_verify.h
         src/core/app_paths.cpp
         src/core/app_paths.h
+        src/core/local_sqlite.cpp
+        src/core/local_sqlite.h
         src/core/file_dialog.cpp
         src/core/file_dialog.h
         src/core/window_dialog_support.cpp
@@ -196,6 +217,10 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/title/title_header_view.h
         src/scenes/title/create_upload_client.cpp
         src/scenes/title/create_upload_client.h
+        src/scenes/title/local_content_database.cpp
+        src/scenes/title/local_content_database.h
+        src/scenes/title/local_content_index.cpp
+        src/scenes/title/local_content_index.h
         src/scenes/title/upload_mapping_store.cpp
         src/scenes/title/upload_mapping_store.h
         src/scenes/title/online_download_internal.h
@@ -226,6 +251,10 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/song_create_scene.h
         src/scenes/song_select/song_catalog_service.cpp
         src/scenes/song_select/song_catalog_service.h
+        src/scenes/song_select/content_verification_cache_database.cpp
+        src/scenes/song_select/content_verification_cache_database.h
+        src/scenes/song_select/local_catalog_database.cpp
+        src/scenes/song_select/local_catalog_database.h
         src/scenes/song_select/song_select_confirmation_dialog.cpp
         src/scenes/song_select/song_select_confirmation_dialog.h
         src/scenes/song_select/song_import_export_service.cpp
@@ -445,6 +474,8 @@ add_executable(song_loader_smoke
         src/models/data_models.h
         src/core/app_paths.cpp
         src/core/app_paths.h
+        src/core/local_sqlite.cpp
+        src/core/local_sqlite.h
         src/core/path_utils.h
         src/gameplay/chart_identity_store.cpp
         src/gameplay/chart_identity_store.h
@@ -477,9 +508,31 @@ add_executable(settings_io_smoke
 add_executable(upload_mapping_store_smoke
         src/core/app_paths.cpp
         src/core/app_paths.h
+        src/core/local_sqlite.cpp
+        src/core/local_sqlite.h
+        src/scenes/title/local_content_database.cpp
+        src/scenes/title/local_content_database.h
+        src/scenes/title/local_content_index.cpp
+        src/scenes/title/local_content_index.h
+        src/gameplay/chart_identity_store.cpp
+        src/gameplay/chart_identity_store.h
         src/scenes/title/upload_mapping_store.cpp
         src/scenes/title/upload_mapping_store.h
         src/tests/upload_mapping_store_smoke.cpp)
+
+add_executable(local_catalog_database_smoke
+        src/core/app_paths.cpp
+        src/core/app_paths.h
+        src/core/local_sqlite.cpp
+        src/core/local_sqlite.h
+        src/scenes/song_select/local_catalog_database.cpp
+        src/scenes/song_select/local_catalog_database.h
+        src/scenes/song_select/song_select_state.cpp
+        src/scenes/song_select/song_select_state.h
+        src/scenes/shared/scene_fade.cpp
+        src/scenes/shared/scene_fade.h
+        src/models/data_models.h
+        src/tests/local_catalog_database_smoke.cpp)
 
 add_executable(mv_storage_smoke
         src/core/app_paths.cpp
@@ -525,6 +578,14 @@ add_executable(score_system_smoke
 add_executable(ranking_service_smoke
         src/core/app_paths.cpp
         src/core/app_paths.h
+        src/core/local_sqlite.cpp
+        src/core/local_sqlite.h
+        src/scenes/title/local_content_database.cpp
+        src/scenes/title/local_content_database.h
+        src/scenes/title/local_content_index.cpp
+        src/scenes/title/local_content_index.h
+        src/gameplay/chart_identity_store.cpp
+        src/gameplay/chart_identity_store.h
         src/models/data_models.h
         src/gameplay/chart_fingerprint.cpp
         src/gameplay/chart_fingerprint.h
@@ -601,6 +662,8 @@ add_executable(editor_transport_controller_smoke
 add_executable(editor_flow_controller_smoke
         src/core/app_paths.cpp
         src/core/app_paths.h
+        src/core/local_sqlite.cpp
+        src/core/local_sqlite.h
         src/core/path_utils.h
         src/scenes/editor/editor_command.h
         src/scenes/editor/editor_meter_map.cpp
@@ -775,6 +838,7 @@ target_include_directories(song_loader_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(song_select_state_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(settings_io_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(upload_mapping_store_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
+target_include_directories(local_catalog_database_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(input_handler_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(timing_engine_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(judge_system_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
@@ -793,18 +857,20 @@ target_include_directories(mv_lang_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_api_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_runtime_benchmark_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
 target_include_directories(mv_storage_smoke PRIVATE ${RAYTHM_INCLUDE_DIRS})
-target_link_libraries(raythm PRIVATE raylib ${RAYTHM_BASS_IMPORT_LIB} comdlg32 crypt32 winhttp)
+target_link_libraries(raythm PRIVATE raylib sqlite3 ${RAYTHM_BASS_IMPORT_LIB} comdlg32 crypt32 winhttp)
 target_link_libraries(raythm_launcher PRIVATE winhttp)
 target_link_libraries(raythm_updater PRIVATE winhttp)
 target_link_libraries(update_version_smoke PRIVATE winhttp)
-target_link_libraries(upload_mapping_store_smoke PRIVATE crypt32)
+target_link_libraries(song_loader_smoke PRIVATE sqlite3)
+target_link_libraries(upload_mapping_store_smoke PRIVATE sqlite3 crypt32)
+target_link_libraries(local_catalog_database_smoke PRIVATE sqlite3 raylib)
 target_link_libraries(song_select_state_smoke PRIVATE raylib)
 target_link_libraries(settings_io_smoke PRIVATE raylib)
 target_link_libraries(input_handler_smoke PRIVATE raylib)
 target_link_libraries(judge_system_smoke PRIVATE raylib)
-target_link_libraries(ranking_service_smoke PRIVATE crypt32 winhttp)
+target_link_libraries(ranking_service_smoke PRIVATE sqlite3 crypt32 winhttp)
 target_link_libraries(play_flow_controller_smoke PRIVATE raylib)
-target_link_libraries(editor_flow_controller_smoke PRIVATE raylib)
+target_link_libraries(editor_flow_controller_smoke PRIVATE raylib sqlite3)
 target_link_libraries(editor_timeline_controller_smoke PRIVATE raylib)
 target_link_libraries(editor_panel_controller_smoke PRIVATE raylib)
 target_link_libraries(audio_manager_smoke PRIVATE ${RAYTHM_BASS_IMPORT_LIB})

--- a/src/core/app_paths.cpp
+++ b/src/core/app_paths.cpp
@@ -106,6 +106,10 @@ std::filesystem::path upload_mapping_path() {
     return app_data_root() / "upload_mappings.txt";
 }
 
+std::filesystem::path local_content_db_path() {
+    return app_data_root() / "local_content.db";
+}
+
 std::filesystem::path scoring_ruleset_cache_path() {
     return app_data_root() / "scoring_ruleset_cache.txt";
 }

--- a/src/core/app_paths.h
+++ b/src/core/app_paths.h
@@ -50,6 +50,9 @@ std::filesystem::path auth_device_path();
 // AppData/Local/raythm/upload_mappings.txt
 std::filesystem::path upload_mapping_path();
 
+// AppData/Local/raythm/local_content.db
+std::filesystem::path local_content_db_path();
+
 // AppData/Local/raythm/scoring_ruleset_cache.txt
 std::filesystem::path scoring_ruleset_cache_path();
 

--- a/src/core/local_sqlite.cpp
+++ b/src/core/local_sqlite.cpp
@@ -1,0 +1,151 @@
+#include "local_sqlite.h"
+
+#include <filesystem>
+
+#include "app_paths.h"
+
+namespace local_sqlite {
+
+statement::statement(sqlite3* database, const char* sql) : database_(database) {
+    sqlite3_prepare_v2(database_, sql, -1, &statement_, nullptr);
+}
+
+statement::~statement() {
+    if (statement_ != nullptr) {
+        sqlite3_finalize(statement_);
+    }
+}
+
+bool statement::valid() const {
+    return statement_ != nullptr;
+}
+
+sqlite3_stmt* statement::get() const {
+    return statement_;
+}
+
+database::database() {
+    app_paths::ensure_directories();
+    const std::filesystem::path db_path = app_paths::local_content_db_path();
+    if (sqlite3_open(db_path.string().c_str(), &database_) != SQLITE_OK) {
+        close();
+    }
+    if (database_ != nullptr) {
+        sqlite3_busy_timeout(database_, 5000);
+    }
+}
+
+database::~database() {
+    close();
+}
+
+database::database(database&& other) noexcept : database_(other.database_) {
+    other.database_ = nullptr;
+}
+
+database& database::operator=(database&& other) noexcept {
+    if (this != &other) {
+        close();
+        database_ = other.database_;
+        other.database_ = nullptr;
+    }
+    return *this;
+}
+
+bool database::valid() const {
+    return database_ != nullptr;
+}
+
+sqlite3* database::get() const {
+    return database_;
+}
+
+void database::close() {
+    if (database_ != nullptr) {
+        sqlite3_close(database_);
+        database_ = nullptr;
+    }
+}
+
+transaction::transaction(sqlite3* database) : database_(database) {
+    active_ = database_ != nullptr && exec(database_, "BEGIN IMMEDIATE;");
+}
+
+transaction::~transaction() {
+    if (active_) {
+        exec(database_, "ROLLBACK;");
+    }
+}
+
+bool transaction::active() const {
+    return active_;
+}
+
+bool transaction::commit() {
+    if (!active_) {
+        return false;
+    }
+    active_ = !exec(database_, "COMMIT;");
+    return !active_;
+}
+
+database open_local_content_database() {
+    database db;
+    if (db.valid()) {
+        ensure_common_schema(db.get());
+    }
+    return db;
+}
+
+bool exec(sqlite3* database, const char* sql) {
+    return sqlite3_exec(database, sql, nullptr, nullptr, nullptr) == SQLITE_OK;
+}
+
+bool ensure_common_schema(sqlite3* database) {
+    return exec(database, "PRAGMA foreign_keys = ON;") &&
+           exec(database, "PRAGMA journal_mode = WAL;") &&
+           exec(database,
+                "CREATE TABLE IF NOT EXISTS metadata ("
+                "key TEXT PRIMARY KEY,"
+                "value TEXT NOT NULL"
+                ");");
+}
+
+void bind_text(sqlite3_stmt* statement, int index, const std::string& value) {
+    sqlite3_bind_text(statement, index, value.c_str(), static_cast<int>(value.size()), SQLITE_TRANSIENT);
+}
+
+std::string column_text(sqlite3_stmt* statement, int index) {
+    const unsigned char* text = sqlite3_column_text(statement, index);
+    return text == nullptr ? std::string() : reinterpret_cast<const char*>(text);
+}
+
+bool step_done(sqlite3_stmt* statement) {
+    return sqlite3_step(statement) == SQLITE_DONE;
+}
+
+std::optional<std::string> metadata_value(sqlite3* database, const std::string& key) {
+    statement query(database, "SELECT value FROM metadata WHERE key = ?;");
+    if (!query.valid()) {
+        return std::nullopt;
+    }
+    bind_text(query.get(), 1, key);
+    if (sqlite3_step(query.get()) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    return column_text(query.get(), 0);
+}
+
+void put_metadata(sqlite3* database, const std::string& key, const std::string& value) {
+    statement query(database,
+                    "INSERT INTO metadata(key, value) VALUES(?, ?) "
+                    "ON CONFLICT(key) DO UPDATE SET value = excluded.value;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, key);
+    bind_text(query.get(), 2, value);
+    sqlite3_step(query.get());
+}
+
+}  // namespace local_sqlite

--- a/src/core/local_sqlite.h
+++ b/src/core/local_sqlite.h
@@ -1,0 +1,70 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "sqlite3.h"
+
+namespace local_sqlite {
+
+class statement {
+public:
+    statement(sqlite3* database, const char* sql);
+    ~statement();
+
+    statement(const statement&) = delete;
+    statement& operator=(const statement&) = delete;
+
+    bool valid() const;
+    sqlite3_stmt* get() const;
+
+private:
+    sqlite3* database_ = nullptr;
+    sqlite3_stmt* statement_ = nullptr;
+};
+
+class database {
+public:
+    database();
+    ~database();
+
+    database(const database&) = delete;
+    database& operator=(const database&) = delete;
+    database(database&& other) noexcept;
+    database& operator=(database&& other) noexcept;
+
+    bool valid() const;
+    sqlite3* get() const;
+
+private:
+    void close();
+
+    sqlite3* database_ = nullptr;
+};
+
+class transaction {
+public:
+    explicit transaction(sqlite3* database);
+    ~transaction();
+
+    transaction(const transaction&) = delete;
+    transaction& operator=(const transaction&) = delete;
+
+    bool active() const;
+    bool commit();
+
+private:
+    sqlite3* database_ = nullptr;
+    bool active_ = false;
+};
+
+database open_local_content_database();
+bool exec(sqlite3* database, const char* sql);
+bool ensure_common_schema(sqlite3* database);
+void bind_text(sqlite3_stmt* statement, int index, const std::string& value);
+std::string column_text(sqlite3_stmt* statement, int index);
+bool step_done(sqlite3_stmt* statement);
+std::optional<std::string> metadata_value(sqlite3* database, const std::string& key);
+void put_metadata(sqlite3* database, const std::string& key, const std::string& value);
+
+}  // namespace local_sqlite

--- a/src/gameplay/chart_identity_store.cpp
+++ b/src/gameplay/chart_identity_store.cpp
@@ -1,13 +1,14 @@
 #include "chart_identity_store.h"
 
 #include <algorithm>
-#include <filesystem>
 #include <fstream>
 #include <sstream>
 #include <string>
 #include <vector>
 
 #include "app_paths.h"
+#include "local_sqlite.h"
+#include "sqlite3.h"
 
 namespace chart_identity {
 namespace {
@@ -34,7 +35,7 @@ std::vector<std::string> split_tab_fields(const std::string& line) {
     return fields;
 }
 
-std::vector<entry> load_entries() {
+std::vector<entry> load_legacy_entries() {
     std::ifstream input(app_paths::chart_identity_index_path(), std::ios::binary);
     if (!input.is_open()) {
         return {};
@@ -61,7 +62,7 @@ std::vector<entry> load_entries() {
     return entries;
 }
 
-void save_entries(const std::vector<entry>& entries) {
+void save_legacy_entries(const std::vector<entry>& entries) {
     app_paths::ensure_directories();
     std::ofstream output(app_paths::chart_identity_index_path(), std::ios::binary | std::ios::trunc);
     if (!output.is_open()) {
@@ -74,6 +75,86 @@ void save_entries(const std::vector<entry>& entries) {
     }
 }
 
+using local_sqlite::bind_text;
+using local_sqlite::column_text;
+using local_sqlite::exec;
+using local_sqlite::statement;
+
+bool ensure_schema(sqlite3* database) {
+    return local_sqlite::ensure_common_schema(database) &&
+           exec(database,
+                "CREATE TABLE IF NOT EXISTS chart_song_links ("
+                "chart_id TEXT PRIMARY KEY,"
+                "song_id TEXT NOT NULL,"
+                "updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))"
+                ");");
+}
+
+bool legacy_imported(sqlite3* database) {
+    return local_sqlite::metadata_value(database, "legacy_chart_identity_imported").has_value();
+}
+
+void mark_legacy_imported(sqlite3* database) {
+    local_sqlite::put_metadata(database, "legacy_chart_identity_imported", "1");
+}
+
+int count_links(sqlite3* database) {
+    statement query(database, "SELECT COUNT(*) FROM chart_song_links;");
+    if (!query.valid() || sqlite3_step(query.get()) != SQLITE_ROW) {
+        return 0;
+    }
+    return sqlite3_column_int(query.get(), 0);
+}
+
+bool put_db(sqlite3* database, const std::string& chart_id, const std::string& song_id) {
+    statement query(database,
+                    "INSERT INTO chart_song_links(chart_id, song_id, updated_at) "
+                    "VALUES(?, ?, strftime('%s','now')) "
+                    "ON CONFLICT(chart_id) DO UPDATE SET "
+                    "song_id = excluded.song_id,"
+                    "updated_at = excluded.updated_at;");
+    if (!query.valid()) {
+        return false;
+    }
+    bind_text(query.get(), 1, chart_id);
+    bind_text(query.get(), 2, song_id);
+    return sqlite3_step(query.get()) == SQLITE_DONE;
+}
+
+void import_legacy_if_needed(sqlite3* database) {
+    if (legacy_imported(database) || count_links(database) > 0) {
+        return;
+    }
+
+    const std::vector<entry> legacy = load_legacy_entries();
+    if (legacy.empty()) {
+        mark_legacy_imported(database);
+        return;
+    }
+
+    local_sqlite::transaction transaction(database);
+    if (!transaction.active()) {
+        return;
+    }
+    for (const entry& item : legacy) {
+        put_db(database, item.chart_id, item.song_id);
+    }
+    transaction.commit();
+    mark_legacy_imported(database);
+}
+
+local_sqlite::database open_ready_database() {
+    local_sqlite::database database = local_sqlite::open_local_content_database();
+    if (!database.valid()) {
+        return database;
+    }
+    if (!ensure_schema(database.get())) {
+        return database;
+    }
+    import_legacy_if_needed(database.get());
+    return database;
+}
+
 }  // namespace
 
 std::optional<std::string> find_song_id(const std::string& chart_id) {
@@ -81,12 +162,25 @@ std::optional<std::string> find_song_id(const std::string& chart_id) {
         return std::nullopt;
     }
 
-    for (const entry& item : load_entries()) {
-        if (item.chart_id == chart_id) {
-            return item.song_id;
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        for (const entry& item : load_legacy_entries()) {
+            if (item.chart_id == chart_id) {
+                return item.song_id;
+            }
         }
+        return std::nullopt;
     }
-    return std::nullopt;
+
+    statement query(database.get(), "SELECT song_id FROM chart_song_links WHERE chart_id = ?;");
+    if (!query.valid()) {
+        return std::nullopt;
+    }
+    bind_text(query.get(), 1, chart_id);
+    if (sqlite3_step(query.get()) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    return column_text(query.get(), 0);
 }
 
 void put(const std::string& chart_id, const std::string& song_id) {
@@ -94,11 +188,17 @@ void put(const std::string& chart_id, const std::string& song_id) {
         return;
     }
 
-    std::vector<entry> entries = load_entries();
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        put_db(database.get(), chart_id, song_id);
+        return;
+    }
+
+    std::vector<entry> entries = load_legacy_entries();
     for (entry& item : entries) {
         if (item.chart_id == chart_id) {
             item.song_id = song_id;
-            save_entries(entries);
+            save_legacy_entries(entries);
             return;
         }
     }
@@ -107,7 +207,7 @@ void put(const std::string& chart_id, const std::string& song_id) {
         .chart_id = chart_id,
         .song_id = song_id,
     });
-    save_entries(entries);
+    save_legacy_entries(entries);
 }
 
 void remove(const std::string& chart_id) {
@@ -115,11 +215,21 @@ void remove(const std::string& chart_id) {
         return;
     }
 
-    std::vector<entry> entries = load_entries();
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        statement query(database.get(), "DELETE FROM chart_song_links WHERE chart_id = ?;");
+        if (query.valid()) {
+            bind_text(query.get(), 1, chart_id);
+            sqlite3_step(query.get());
+        }
+        return;
+    }
+
+    std::vector<entry> entries = load_legacy_entries();
     std::erase_if(entries, [&](const entry& item) {
         return item.chart_id == chart_id;
     });
-    save_entries(entries);
+    save_legacy_entries(entries);
 }
 
 void remove_for_song(const std::string& song_id) {
@@ -127,11 +237,21 @@ void remove_for_song(const std::string& song_id) {
         return;
     }
 
-    std::vector<entry> entries = load_entries();
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        statement query(database.get(), "DELETE FROM chart_song_links WHERE song_id = ?;");
+        if (query.valid()) {
+            bind_text(query.get(), 1, song_id);
+            sqlite3_step(query.get());
+        }
+        return;
+    }
+
+    std::vector<entry> entries = load_legacy_entries();
     std::erase_if(entries, [&](const entry& item) {
         return item.song_id == song_id;
     });
-    save_entries(entries);
+    save_legacy_entries(entries);
 }
 
 }  // namespace chart_identity

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -21,7 +21,7 @@
 #include "path_utils.h"
 #include "scoring_ruleset_runtime.h"
 #include "song_fingerprint.h"
-#include "title/upload_mapping_store.h"
+#include "title/local_content_index.h"
 #include "updater/update_verify.h"
 
 #ifdef _WIN32
@@ -586,16 +586,16 @@ std::string lowercase(std::string value) {
 
 std::string expected_remote_song_id(const std::string& server_url,
                                     const std::string& local_song_id) {
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
-    return title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id)
-        .value_or(local_song_id);
+    const std::optional<local_content_index::online_song_binding> binding =
+        local_content_index::find_song_by_local(server_url, local_song_id);
+    return binding.has_value() ? binding->remote_song_id : local_song_id;
 }
 
 std::string expected_remote_chart_id(const std::string& server_url,
                                      const std::string& local_chart_id) {
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
-    return title_upload_mapping::find_remote_chart_id(mappings, server_url, local_chart_id)
-        .value_or(local_chart_id);
+    const std::optional<local_content_index::online_chart_binding> binding =
+        local_content_index::find_chart_by_local(server_url, local_chart_id);
+    return binding.has_value() ? binding->remote_chart_id : local_chart_id;
 }
 
 struct local_manifest_hashes {
@@ -887,8 +887,9 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
             return result;
         }
 
+        const std::string remote_chart_id = expected_remote_chart_id(stored->server_url, chart_id);
         ranking_client::operation_result online_result =
-            ranking_client::fetch_chart_ranking(stored->server_url, stored->access_token, chart_id, limit);
+            ranking_client::fetch_chart_ranking(stored->server_url, stored->access_token, remote_chart_id, limit);
 
         if (online_result.unauthorized) {
             const auth::operation_result restored = auth::restore_saved_session();
@@ -903,7 +904,7 @@ listing load_chart_ranking(const std::string& chart_id, source ranking_source, i
             online_result = ranking_client::fetch_chart_ranking(
                 restored.session_data->server_url,
                 restored.session_data->access_token,
-                chart_id,
+                expected_remote_chart_id(restored.session_data->server_url, chart_id),
                 limit);
         }
 

--- a/src/gameplay/song_fingerprint.cpp
+++ b/src/gameplay/song_fingerprint.cpp
@@ -151,8 +151,6 @@ std::string format_number(double value) {
 std::string canonical_string(std::string_view content) {
     const std::optional<std::string> base_bpm = extract_json_number_token(content, "baseBpm");
     const std::optional<std::string> preview_start_ms = extract_json_number_token(content, "previewStartMs");
-    const std::optional<std::string> chorus_start_seconds = extract_json_number_token(content, "chorusStartSeconds");
-    const std::optional<std::string> preview_start_seconds = extract_json_number_token(content, "previewStartSeconds");
     const std::optional<std::string> song_version = extract_json_number_token(content, "songVersion");
 
     std::string preview_ms = "0";
@@ -161,16 +159,6 @@ std::string canonical_string(std::string_view content) {
             preview_ms = std::to_string(*parsed);
         } else {
             preview_ms = *preview_start_ms;
-        }
-    } else {
-        const std::optional<std::string> seconds =
-            chorus_start_seconds.has_value() ? chorus_start_seconds : preview_start_seconds;
-        if (seconds.has_value()) {
-            if (const std::optional<double> parsed = parse_number(*seconds)) {
-                preview_ms = std::to_string(static_cast<int>(*parsed * 1000.0));
-            } else {
-                preview_ms = *seconds;
-            }
         }
     }
 

--- a/src/gameplay/song_loader.cpp
+++ b/src/gameplay/song_loader.cpp
@@ -187,8 +187,6 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
     const std::optional<std::string> audio_file = extract_json_string(content, "audioFile");
     const std::optional<std::string> jacket_file = extract_json_string(content, "jacketFile");
     const std::optional<std::string> difficulty_bpm = extract_json_number_token(content, "baseBpm");
-    const std::optional<std::string> preview_start_seconds = extract_json_number_token(content, "chorusStartSeconds");
-    const std::optional<std::string> preview_start_seconds_fallback = extract_json_number_token(content, "previewStartSeconds");
     const std::optional<std::string> preview_start_ms = extract_json_number_token(content, "previewStartMs");
     const std::optional<std::string> song_version = extract_json_number_token(content, "songVersion");
 
@@ -233,17 +231,7 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
         }
     }
 
-    const std::optional<std::string> preview_seconds_token =
-        preview_start_seconds.has_value() ? preview_start_seconds : preview_start_seconds_fallback;
-    if (preview_seconds_token.has_value()) {
-        const std::optional<float> parsed = parse_float(*preview_seconds_token);
-        if (!parsed.has_value()) {
-            errors.push_back("chorusStartSeconds must be a number in " + path_utils::to_utf8(song_json_path));
-        } else {
-            meta.preview_start_seconds = *parsed;
-            meta.preview_start_ms = static_cast<int>(*parsed * 1000.0f);
-        }
-    } else if (preview_start_ms.has_value()) {
+    if (preview_start_ms.has_value()) {
         const std::optional<int> parsed = parse_int(*preview_start_ms);
         if (!parsed.has_value()) {
             errors.push_back("previewStartMs must be an integer in " + path_utils::to_utf8(song_json_path));
@@ -252,7 +240,7 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
             meta.preview_start_seconds = static_cast<float>(*parsed) / 1000.0f;
         }
     } else {
-        errors.push_back("Missing required field chorusStartSeconds in " + path_utils::to_utf8(song_json_path));
+        errors.push_back("Missing required field previewStartMs in " + path_utils::to_utf8(song_json_path));
     }
 
     const std::optional<std::string> sns_youtube = extract_json_string(content, "snsYoutube");

--- a/src/scenes/song_select/content_verification_cache_database.cpp
+++ b/src/scenes/song_select/content_verification_cache_database.cpp
@@ -1,0 +1,195 @@
+#include "song_select/content_verification_cache_database.h"
+
+#include "local_sqlite.h"
+#include "sqlite3.h"
+
+namespace song_select::content_verification_cache_database {
+namespace {
+
+using local_sqlite::bind_text;
+using local_sqlite::column_text;
+using local_sqlite::exec;
+using local_sqlite::statement;
+
+std::string status_label(content_status status) {
+    switch (status) {
+    case content_status::official:
+        return "official";
+    case content_status::community:
+        return "community";
+    case content_status::update:
+        return "update";
+    case content_status::modified:
+        return "modified";
+    case content_status::checking:
+        return "checking";
+    case content_status::local:
+    default:
+        return "local";
+    }
+}
+
+content_status parse_status(const std::string& value) {
+    if (value == "official") {
+        return content_status::official;
+    }
+    if (value == "community") {
+        return content_status::community;
+    }
+    if (value == "update") {
+        return content_status::update;
+    }
+    if (value == "modified") {
+        return content_status::modified;
+    }
+    if (value == "checking") {
+        return content_status::checking;
+    }
+    return content_status::local;
+}
+
+std::string cache_key(std::string_view server_url, std::string_view chart_id) {
+    return std::string(server_url) + "\n" + std::string(chart_id);
+}
+
+bool ensure_schema(sqlite3* database) {
+    return local_sqlite::ensure_common_schema(database) &&
+           exec(database,
+                "CREATE TABLE IF NOT EXISTS content_verification_cache ("
+                "server_url TEXT NOT NULL,"
+                "chart_id TEXT NOT NULL,"
+                "song_id TEXT NOT NULL,"
+                "status TEXT NOT NULL,"
+                "content_source TEXT NOT NULL,"
+                "file_signature TEXT NOT NULL,"
+                "local_song_json_sha256 TEXT NOT NULL,"
+                "local_song_json_fingerprint TEXT NOT NULL,"
+                "local_audio_sha256 TEXT NOT NULL,"
+                "local_jacket_sha256 TEXT NOT NULL,"
+                "local_chart_sha256 TEXT NOT NULL,"
+                "local_chart_fingerprint TEXT NOT NULL,"
+                "server_song_json_sha256 TEXT NOT NULL,"
+                "server_song_json_fingerprint TEXT NOT NULL,"
+                "server_audio_sha256 TEXT NOT NULL,"
+                "server_jacket_sha256 TEXT NOT NULL,"
+                "server_chart_sha256 TEXT NOT NULL,"
+                "server_chart_fingerprint TEXT NOT NULL,"
+                "updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now')),"
+                "PRIMARY KEY (server_url, chart_id)"
+                ");");
+}
+
+local_sqlite::database open_ready_database() {
+    local_sqlite::database database = local_sqlite::open_local_content_database();
+    if (database.valid()) {
+        ensure_schema(database.get());
+    }
+    return database;
+}
+
+void bind_hashes(sqlite3_stmt* query, int start_index, const content_hashes& hashes) {
+    bind_text(query, start_index, hashes.song_json_sha256);
+    bind_text(query, start_index + 1, hashes.song_json_fingerprint);
+    bind_text(query, start_index + 2, hashes.audio_sha256);
+    bind_text(query, start_index + 3, hashes.jacket_sha256);
+    bind_text(query, start_index + 4, hashes.chart_sha256);
+    bind_text(query, start_index + 5, hashes.chart_fingerprint);
+}
+
+record read_record(sqlite3_stmt* query) {
+    record item;
+    item.server_url = column_text(query, 0);
+    item.chart_id = column_text(query, 1);
+    item.song_id = column_text(query, 2);
+    item.status = parse_status(column_text(query, 3));
+    item.content_source = column_text(query, 4);
+    item.file_signature = column_text(query, 5);
+    item.local_hashes = {
+        .song_json_sha256 = column_text(query, 6),
+        .song_json_fingerprint = column_text(query, 7),
+        .audio_sha256 = column_text(query, 8),
+        .jacket_sha256 = column_text(query, 9),
+        .chart_sha256 = column_text(query, 10),
+        .chart_fingerprint = column_text(query, 11),
+    };
+    item.server_hashes = {
+        .song_json_sha256 = column_text(query, 12),
+        .song_json_fingerprint = column_text(query, 13),
+        .audio_sha256 = column_text(query, 14),
+        .jacket_sha256 = column_text(query, 15),
+        .chart_sha256 = column_text(query, 16),
+        .chart_fingerprint = column_text(query, 17),
+    };
+    return item;
+}
+
+}  // namespace
+
+cache load() {
+    cache records;
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return records;
+    }
+
+    statement query(database.get(),
+                    "SELECT server_url, chart_id, song_id, status, content_source, file_signature, "
+                    "local_song_json_sha256, local_song_json_fingerprint, local_audio_sha256, "
+                    "local_jacket_sha256, local_chart_sha256, local_chart_fingerprint, "
+                    "server_song_json_sha256, server_song_json_fingerprint, server_audio_sha256, "
+                    "server_jacket_sha256, server_chart_sha256, server_chart_fingerprint "
+                    "FROM content_verification_cache;");
+    if (!query.valid()) {
+        return records;
+    }
+
+    while (sqlite3_step(query.get()) == SQLITE_ROW) {
+        record item = read_record(query.get());
+        if (!item.server_url.empty() && !item.chart_id.empty()) {
+            records[cache_key(item.server_url, item.chart_id)] = std::move(item);
+        }
+    }
+    return records;
+}
+
+void save(const cache& records) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return;
+    }
+
+    local_sqlite::transaction tx(database.get());
+    if (!tx.active()) {
+        return;
+    }
+    exec(database.get(), "DELETE FROM content_verification_cache;");
+
+    statement query(database.get(),
+                    "INSERT INTO content_verification_cache("
+                    "server_url, chart_id, song_id, status, content_source, file_signature, "
+                    "local_song_json_sha256, local_song_json_fingerprint, local_audio_sha256, "
+                    "local_jacket_sha256, local_chart_sha256, local_chart_fingerprint, "
+                    "server_song_json_sha256, server_song_json_fingerprint, server_audio_sha256, "
+                    "server_jacket_sha256, server_chart_sha256, server_chart_fingerprint, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now'));");
+    if (!query.valid()) {
+        return;
+    }
+
+    for (const auto& [_, item] : records) {
+        sqlite3_reset(query.get());
+        sqlite3_clear_bindings(query.get());
+        bind_text(query.get(), 1, item.server_url);
+        bind_text(query.get(), 2, item.chart_id);
+        bind_text(query.get(), 3, item.song_id);
+        bind_text(query.get(), 4, status_label(item.status));
+        bind_text(query.get(), 5, item.content_source);
+        bind_text(query.get(), 6, item.file_signature);
+        bind_hashes(query.get(), 7, item.local_hashes);
+        bind_hashes(query.get(), 13, item.server_hashes);
+        sqlite3_step(query.get());
+    }
+    tx.commit();
+}
+
+}  // namespace song_select::content_verification_cache_database

--- a/src/scenes/song_select/content_verification_cache_database.h
+++ b/src/scenes/song_select/content_verification_cache_database.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "song_select/song_select_state.h"
+
+namespace song_select::content_verification_cache_database {
+
+struct content_hashes {
+    std::string song_json_sha256;
+    std::string song_json_fingerprint;
+    std::string audio_sha256;
+    std::string jacket_sha256;
+    std::string chart_sha256;
+    std::string chart_fingerprint;
+};
+
+struct record {
+    std::string server_url;
+    std::string chart_id;
+    std::string song_id;
+    content_status status = content_status::local;
+    std::string content_source;
+    std::string file_signature;
+    content_hashes local_hashes;
+    content_hashes server_hashes;
+};
+
+using cache = std::unordered_map<std::string, record>;
+
+cache load();
+void save(const cache& records);
+
+}  // namespace song_select::content_verification_cache_database

--- a/src/scenes/song_select/local_catalog_database.cpp
+++ b/src/scenes/song_select/local_catalog_database.cpp
@@ -1,0 +1,359 @@
+#include "song_select/local_catalog_database.h"
+
+#include <filesystem>
+#include <algorithm>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "app_paths.h"
+#include "local_sqlite.h"
+#include "sqlite3.h"
+
+namespace song_select::local_catalog_database {
+namespace {
+
+using local_sqlite::bind_text;
+using local_sqlite::column_text;
+using local_sqlite::exec;
+using local_sqlite::statement;
+
+void ensure_optional_schema(sqlite3* database) {
+    exec(database, "ALTER TABLE local_charts ADD COLUMN min_bpm REAL NOT NULL DEFAULT 0;");
+    exec(database, "ALTER TABLE local_charts ADD COLUMN max_bpm REAL NOT NULL DEFAULT 0;");
+}
+
+bool ensure_schema(sqlite3* database) {
+    const bool ready =
+        local_sqlite::ensure_common_schema(database) &&
+        exec(database,
+             "CREATE TABLE IF NOT EXISTS local_songs ("
+             "song_id TEXT PRIMARY KEY,"
+             "title TEXT NOT NULL,"
+             "artist TEXT NOT NULL,"
+             "directory TEXT NOT NULL,"
+             "audio_file TEXT NOT NULL,"
+             "jacket_file TEXT NOT NULL,"
+             "base_bpm REAL NOT NULL,"
+             "preview_start_ms INTEGER NOT NULL,"
+             "song_version INTEGER NOT NULL,"
+             "status TEXT NOT NULL,"
+             "updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))"
+             ");") &&
+        exec(database,
+             "CREATE TABLE IF NOT EXISTS local_charts ("
+             "chart_id TEXT PRIMARY KEY,"
+             "song_id TEXT NOT NULL,"
+             "path TEXT NOT NULL,"
+             "difficulty TEXT NOT NULL,"
+             "level REAL NOT NULL,"
+             "key_count INTEGER NOT NULL,"
+             "chart_author TEXT NOT NULL,"
+             "format_version INTEGER NOT NULL,"
+             "note_count INTEGER NOT NULL,"
+             "min_bpm REAL NOT NULL DEFAULT 0,"
+             "max_bpm REAL NOT NULL DEFAULT 0,"
+             "status TEXT NOT NULL,"
+             "updated_at INTEGER NOT NULL DEFAULT (strftime('%s','now'))"
+             ");");
+    if (ready) {
+        ensure_optional_schema(database);
+    }
+    return ready;
+}
+
+std::string path_key(const std::filesystem::path& root, const std::filesystem::path& path) {
+    std::error_code ec;
+    const std::filesystem::path relative = std::filesystem::relative(path, root, ec);
+    return ec ? path.string() : relative.generic_string();
+}
+
+void append_tree_signature(std::ostringstream& output, const std::filesystem::path& root, const char* label) {
+    std::error_code ec;
+    if (!std::filesystem::exists(root, ec)) {
+        output << label << ":missing\n";
+        return;
+    }
+
+    std::vector<std::filesystem::path> files;
+    for (const std::filesystem::directory_entry& entry : std::filesystem::recursive_directory_iterator(root, ec)) {
+        if (ec) {
+            break;
+        }
+        if (entry.is_regular_file(ec)) {
+            files.push_back(entry.path());
+        }
+    }
+    std::sort(files.begin(), files.end());
+
+    output << label << ":";
+    for (const std::filesystem::path& file : files) {
+        const auto size = std::filesystem::file_size(file, ec);
+        if (ec) {
+            continue;
+        }
+        const auto write_time = std::filesystem::last_write_time(file, ec);
+        if (ec) {
+            continue;
+        }
+        output << path_key(root, file) << "," << size << "," << write_time.time_since_epoch().count() << ";";
+    }
+    output << "\n";
+}
+
+std::string current_catalog_signature() {
+    std::ostringstream output;
+    append_tree_signature(output, app_paths::songs_root(), "songs");
+    append_tree_signature(output, app_paths::charts_root(), "charts");
+    return output.str();
+}
+
+local_sqlite::database open_ready_database() {
+    local_sqlite::database database = local_sqlite::open_local_content_database();
+    if (database.valid()) {
+        ensure_schema(database.get());
+    }
+    return database;
+}
+
+std::string status_label(content_status status) {
+    switch (status) {
+    case content_status::official:
+        return "official";
+    case content_status::community:
+        return "community";
+    case content_status::update:
+        return "update";
+    case content_status::modified:
+        return "modified";
+    case content_status::checking:
+        return "checking";
+    case content_status::local:
+    default:
+        return "local";
+    }
+}
+
+content_status parse_status(std::string value) {
+    if (value == "official") {
+        return content_status::official;
+    }
+    if (value == "community") {
+        return content_status::community;
+    }
+    if (value == "update") {
+        return content_status::update;
+    }
+    if (value == "modified") {
+        return content_status::modified;
+    }
+    if (value == "checking") {
+        return content_status::checking;
+    }
+    return content_status::local;
+}
+
+void put_song(sqlite3* database, const song_entry& song) {
+    statement query(database,
+                    "INSERT INTO local_songs(song_id, title, artist, directory, audio_file, jacket_file, "
+                    "base_bpm, preview_start_ms, song_version, status, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now')) "
+                    "ON CONFLICT(song_id) DO UPDATE SET "
+                    "title = excluded.title,"
+                    "artist = excluded.artist,"
+                    "directory = excluded.directory,"
+                    "audio_file = excluded.audio_file,"
+                    "jacket_file = excluded.jacket_file,"
+                    "base_bpm = excluded.base_bpm,"
+                    "preview_start_ms = excluded.preview_start_ms,"
+                    "song_version = excluded.song_version,"
+                    "status = excluded.status,"
+                    "updated_at = excluded.updated_at;");
+    if (!query.valid() || song.song.meta.song_id.empty()) {
+        return;
+    }
+
+    bind_text(query.get(), 1, song.song.meta.song_id);
+    bind_text(query.get(), 2, song.song.meta.title);
+    bind_text(query.get(), 3, song.song.meta.artist);
+    bind_text(query.get(), 4, song.song.directory);
+    bind_text(query.get(), 5, song.song.meta.audio_file);
+    bind_text(query.get(), 6, song.song.meta.jacket_file);
+    sqlite3_bind_double(query.get(), 7, song.song.meta.base_bpm);
+    sqlite3_bind_int(query.get(), 8, song.song.meta.preview_start_ms);
+    sqlite3_bind_int(query.get(), 9, song.song.meta.song_version);
+    bind_text(query.get(), 10, status_label(song.status));
+    sqlite3_step(query.get());
+}
+
+void put_chart(sqlite3* database, const chart_option& chart) {
+    statement query(database,
+                    "INSERT INTO local_charts(chart_id, song_id, path, difficulty, level, key_count, "
+                    "chart_author, format_version, note_count, min_bpm, max_bpm, status, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now')) "
+                    "ON CONFLICT(chart_id) DO UPDATE SET "
+                    "song_id = excluded.song_id,"
+                    "path = excluded.path,"
+                    "difficulty = excluded.difficulty,"
+                    "level = excluded.level,"
+                    "key_count = excluded.key_count,"
+                    "chart_author = excluded.chart_author,"
+                    "format_version = excluded.format_version,"
+                    "note_count = excluded.note_count,"
+                    "min_bpm = excluded.min_bpm,"
+                    "max_bpm = excluded.max_bpm,"
+                    "status = excluded.status,"
+                    "updated_at = excluded.updated_at;");
+    if (!query.valid() || chart.meta.chart_id.empty()) {
+        return;
+    }
+
+    bind_text(query.get(), 1, chart.meta.chart_id);
+    bind_text(query.get(), 2, chart.meta.song_id);
+    bind_text(query.get(), 3, chart.path);
+    bind_text(query.get(), 4, chart.meta.difficulty);
+    sqlite3_bind_double(query.get(), 5, chart.meta.level);
+    sqlite3_bind_int(query.get(), 6, chart.meta.key_count);
+    bind_text(query.get(), 7, chart.meta.chart_author);
+    sqlite3_bind_int(query.get(), 8, chart.meta.format_version);
+    sqlite3_bind_int(query.get(), 9, chart.note_count);
+    sqlite3_bind_double(query.get(), 10, chart.min_bpm);
+    sqlite3_bind_double(query.get(), 11, chart.max_bpm);
+    bind_text(query.get(), 12, status_label(chart.status));
+    sqlite3_step(query.get());
+}
+
+}  // namespace
+
+catalog_data load_cached_catalog() {
+    catalog_data catalog;
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return catalog;
+    }
+    if (local_sqlite::metadata_value(database.get(), "local_catalog.signature").value_or("") !=
+        current_catalog_signature()) {
+        return catalog;
+    }
+
+    std::map<std::string, song_entry> by_song_id;
+    statement songs(database.get(),
+                    "SELECT song_id, title, artist, directory, audio_file, jacket_file, base_bpm, "
+                    "preview_start_ms, song_version, status FROM local_songs ORDER BY title, song_id;");
+    if (!songs.valid()) {
+        return catalog;
+    }
+    while (sqlite3_step(songs.get()) == SQLITE_ROW) {
+        song_entry entry;
+        entry.song.meta.song_id = column_text(songs.get(), 0);
+        entry.song.meta.title = column_text(songs.get(), 1);
+        entry.song.meta.artist = column_text(songs.get(), 2);
+        entry.song.directory = column_text(songs.get(), 3);
+        entry.song.meta.audio_file = column_text(songs.get(), 4);
+        entry.song.meta.jacket_file = column_text(songs.get(), 5);
+        entry.song.meta.base_bpm = static_cast<float>(sqlite3_column_double(songs.get(), 6));
+        entry.song.meta.preview_start_ms = sqlite3_column_int(songs.get(), 7);
+        entry.song.meta.preview_start_seconds = static_cast<float>(entry.song.meta.preview_start_ms) / 1000.0f;
+        entry.song.meta.song_version = sqlite3_column_int(songs.get(), 8);
+        entry.status = parse_status(column_text(songs.get(), 9));
+        by_song_id[entry.song.meta.song_id] = std::move(entry);
+    }
+
+    statement charts(database.get(),
+                     "SELECT chart_id, song_id, path, difficulty, level, key_count, chart_author, "
+                     "format_version, note_count, min_bpm, max_bpm, status "
+                     "FROM local_charts ORDER BY song_id, level, difficulty;");
+    if (!charts.valid()) {
+        return catalog;
+    }
+    while (sqlite3_step(charts.get()) == SQLITE_ROW) {
+        const std::string song_id = column_text(charts.get(), 1);
+        auto song_it = by_song_id.find(song_id);
+        if (song_it == by_song_id.end()) {
+            continue;
+        }
+
+        chart_option chart;
+        chart.meta.chart_id = column_text(charts.get(), 0);
+        chart.meta.song_id = song_id;
+        chart.path = column_text(charts.get(), 2);
+        chart.meta.difficulty = column_text(charts.get(), 3);
+        chart.meta.level = static_cast<float>(sqlite3_column_double(charts.get(), 4));
+        chart.meta.key_count = sqlite3_column_int(charts.get(), 5);
+        chart.meta.chart_author = column_text(charts.get(), 6);
+        chart.meta.format_version = sqlite3_column_int(charts.get(), 7);
+        chart.note_count = sqlite3_column_int(charts.get(), 8);
+        chart.min_bpm = static_cast<float>(sqlite3_column_double(charts.get(), 9));
+        chart.max_bpm = static_cast<float>(sqlite3_column_double(charts.get(), 10));
+        chart.status = parse_status(column_text(charts.get(), 11));
+        song_it->second.song.chart_paths.push_back(chart.path);
+        song_it->second.charts.push_back(std::move(chart));
+    }
+
+    catalog.songs.reserve(by_song_id.size());
+    for (auto& [song_id, song] : by_song_id) {
+        (void)song_id;
+        catalog.songs.push_back(std::move(song));
+    }
+    return catalog;
+}
+
+void replace_catalog(const std::vector<song_entry>& songs) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return;
+    }
+
+    local_sqlite::transaction tx(database.get());
+    if (!tx.active()) {
+        return;
+    }
+    exec(database.get(), "DELETE FROM local_charts;");
+    exec(database.get(), "DELETE FROM local_songs;");
+    for (const song_entry& song : songs) {
+        put_song(database.get(), song);
+        for (const chart_option& chart : song.charts) {
+            put_chart(database.get(), chart);
+        }
+    }
+    local_sqlite::put_metadata(database.get(), "local_catalog.signature", current_catalog_signature());
+    tx.commit();
+}
+
+void remove_song(const std::string& song_id) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid() || song_id.empty()) {
+        return;
+    }
+
+    statement charts(database.get(), "DELETE FROM local_charts WHERE song_id = ?;");
+    if (charts.valid()) {
+        bind_text(charts.get(), 1, song_id);
+        sqlite3_step(charts.get());
+    }
+
+    statement songs(database.get(), "DELETE FROM local_songs WHERE song_id = ?;");
+    if (songs.valid()) {
+        bind_text(songs.get(), 1, song_id);
+        sqlite3_step(songs.get());
+    }
+    local_sqlite::put_metadata(database.get(), "local_catalog.signature", current_catalog_signature());
+}
+
+void remove_chart(const std::string& chart_id) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid() || chart_id.empty()) {
+        return;
+    }
+
+    statement charts(database.get(), "DELETE FROM local_charts WHERE chart_id = ?;");
+    if (charts.valid()) {
+        bind_text(charts.get(), 1, chart_id);
+        sqlite3_step(charts.get());
+    }
+    local_sqlite::put_metadata(database.get(), "local_catalog.signature", current_catalog_signature());
+}
+
+}  // namespace song_select::local_catalog_database

--- a/src/scenes/song_select/local_catalog_database.h
+++ b/src/scenes/song_select/local_catalog_database.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include "song_select/song_select_state.h"
+
+namespace song_select::local_catalog_database {
+
+catalog_data load_cached_catalog();
+void replace_catalog(const std::vector<song_entry>& songs);
+void remove_song(const std::string& song_id);
+void remove_chart(const std::string& chart_id);
+
+}  // namespace song_select::local_catalog_database

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -3,15 +3,12 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
-#include <fstream>
 #include <optional>
-#include <sstream>
 #include <system_error>
 #include <unordered_map>
 
 #include "app_paths.h"
 #include "chart_fingerprint.h"
-#include "chart_identity_store.h"
 #include "chart_level_cache.h"
 #include "mv/mv_storage.h"
 #include "network/auth_client.h"
@@ -21,7 +18,9 @@
 #include "ranking_service.h"
 #include "song_loader.h"
 #include "song_fingerprint.h"
-#include "title/upload_mapping_store.h"
+#include "song_select/content_verification_cache_database.h"
+#include "song_select/local_catalog_database.h"
+#include "title/local_content_index.h"
 #include "updater/update_verify.h"
 
 namespace {
@@ -78,28 +77,6 @@ std::string trim(std::string_view value) {
     return std::string(value.substr(start, end - start));
 }
 
-std::string status_label(content_status status) {
-    switch (status) {
-        case content_status::official: return "official";
-        case content_status::community: return "community";
-        case content_status::update: return "update";
-        case content_status::modified: return "modified";
-        case content_status::checking: return "checking";
-        case content_status::local: return "local";
-    }
-    return "local";
-}
-
-content_status parse_status(std::string_view value) {
-    const std::string normalized = trim(value);
-    if (normalized == "official") return content_status::official;
-    if (normalized == "community") return content_status::community;
-    if (normalized == "update") return content_status::update;
-    if (normalized == "modified") return content_status::modified;
-    if (normalized == "checking") return content_status::checking;
-    return content_status::local;
-}
-
 content_status status_for_content_source(std::string value) {
     std::transform(value.begin(), value.end(), value.begin(), [](unsigned char ch) {
         return static_cast<char>(std::tolower(ch));
@@ -123,16 +100,16 @@ std::string current_manifest_server_url() {
 
 std::string expected_remote_song_id(const std::string& server_url,
                                     const std::string& local_song_id) {
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
-    return title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id)
-        .value_or(local_song_id);
+    const std::optional<local_content_index::online_song_binding> binding =
+        local_content_index::find_song_by_local(server_url, local_song_id);
+    return binding.has_value() ? binding->remote_song_id : local_song_id;
 }
 
 std::string expected_remote_chart_id(const std::string& server_url,
                                      const std::string& local_chart_id) {
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
-    return title_upload_mapping::find_remote_chart_id(mappings, server_url, local_chart_id)
-        .value_or(local_chart_id);
+    const std::optional<local_content_index::online_chart_binding> binding =
+        local_content_index::find_chart_by_local(server_url, local_chart_id);
+    return binding.has_value() ? binding->remote_chart_id : local_chart_id;
 }
 
 std::string file_signature(const std::filesystem::path& path) {
@@ -158,14 +135,7 @@ struct local_content_files {
     std::filesystem::path chart_path;
 };
 
-struct content_hashes {
-    std::string song_json_sha256;
-    std::string song_json_fingerprint;
-    std::string audio_sha256;
-    std::string jacket_sha256;
-    std::string chart_sha256;
-    std::string chart_fingerprint;
-};
+using content_hashes = song_select::content_verification_cache_database::content_hashes;
 
 content_hashes manifest_hashes(const ranking_client::chart_manifest& manifest) {
     return {
@@ -284,16 +254,7 @@ std::optional<content_hashes> compute_song_hashes(const song_data& song) {
     return content_hashes{*song_json, *song_json_fingerprint, *audio, *jacket, {}, {}};
 }
 
-struct verification_cache_record {
-    std::string server_url;
-    std::string chart_id;
-    std::string song_id;
-    content_status status = content_status::local;
-    std::string content_source;
-    std::string file_signature;
-    content_hashes local_hashes;
-    content_hashes server_hashes;
-};
+using verification_cache_record = song_select::content_verification_cache_database::record;
 
 std::string cache_key(std::string_view server_url, std::string_view chart_id) {
     return std::string(server_url) + "\n" + std::string(chart_id);
@@ -302,81 +263,11 @@ std::string cache_key(std::string_view server_url, std::string_view chart_id) {
 using verification_cache = std::unordered_map<std::string, verification_cache_record>;
 
 verification_cache load_verification_cache() {
-    verification_cache cache;
-    std::ifstream input(app_paths::source_verification_cache_path(), std::ios::binary);
-    if (!input.is_open()) {
-        return cache;
-    }
-
-    std::string line;
-    while (std::getline(input, line)) {
-        if (line.empty() || line[0] == '#') {
-            continue;
-        }
-        std::istringstream row(line);
-        std::string kind;
-        verification_cache_record record;
-        if (!std::getline(row, kind, '\t') || trim(kind) != "record" ||
-            !std::getline(row, record.server_url, '\t') ||
-            !std::getline(row, record.chart_id, '\t') ||
-            !std::getline(row, record.song_id, '\t')) {
-            continue;
-        }
-
-        std::string status_token;
-        if (!std::getline(row, status_token, '\t') ||
-            !std::getline(row, record.content_source, '\t') ||
-            !std::getline(row, record.file_signature, '\t') ||
-            !std::getline(row, record.local_hashes.song_json_sha256, '\t') ||
-            !std::getline(row, record.local_hashes.audio_sha256, '\t') ||
-            !std::getline(row, record.local_hashes.jacket_sha256, '\t') ||
-            !std::getline(row, record.local_hashes.chart_sha256, '\t') ||
-            !std::getline(row, record.server_hashes.song_json_sha256, '\t') ||
-            !std::getline(row, record.server_hashes.audio_sha256, '\t') ||
-            !std::getline(row, record.server_hashes.jacket_sha256, '\t') ||
-            !std::getline(row, record.server_hashes.chart_sha256, '\t')) {
-            continue;
-        }
-        std::getline(row, record.local_hashes.chart_fingerprint, '\t');
-        std::getline(row, record.server_hashes.chart_fingerprint, '\t');
-        std::getline(row, record.local_hashes.song_json_fingerprint, '\t');
-        std::getline(row, record.server_hashes.song_json_fingerprint);
-        record.status = parse_status(status_token);
-        if (!record.server_url.empty() && !record.chart_id.empty()) {
-            cache[cache_key(record.server_url, record.chart_id)] = std::move(record);
-        }
-    }
-    return cache;
+    return song_select::content_verification_cache_database::load();
 }
 
 void save_verification_cache(const verification_cache& cache) {
-    app_paths::ensure_directories();
-    std::ofstream output(app_paths::source_verification_cache_path(), std::ios::binary | std::ios::trunc);
-    if (!output.is_open()) {
-        return;
-    }
-    output << "# raythm source verification cache v1\n";
-    for (const auto& [_, record] : cache) {
-        output << "record\t"
-               << record.server_url << '\t'
-               << record.chart_id << '\t'
-               << record.song_id << '\t'
-               << status_label(record.status) << '\t'
-               << record.content_source << '\t'
-               << record.file_signature << '\t'
-               << record.local_hashes.song_json_sha256 << '\t'
-               << record.local_hashes.audio_sha256 << '\t'
-               << record.local_hashes.jacket_sha256 << '\t'
-               << record.local_hashes.chart_sha256 << '\t'
-               << record.server_hashes.song_json_sha256 << '\t'
-               << record.server_hashes.audio_sha256 << '\t'
-               << record.server_hashes.jacket_sha256 << '\t'
-               << record.server_hashes.chart_sha256 << '\t'
-               << record.local_hashes.chart_fingerprint << '\t'
-               << record.server_hashes.chart_fingerprint << '\t'
-               << record.local_hashes.song_json_fingerprint << '\t'
-               << record.server_hashes.song_json_fingerprint << '\n';
-    }
+    song_select::content_verification_cache_database::save(cache);
 }
 
 content_status cached_status_for(const verification_cache_record* cached,
@@ -683,6 +574,24 @@ std::pair<float, float> collect_bpm_range(const chart_data& chart) {
 namespace song_select {
 
 catalog_data load_catalog(bool calculate_missing_levels) {
+    if (!calculate_missing_levels) {
+        catalog_data cached_catalog = local_catalog_database::load_cached_catalog();
+        if (!cached_catalog.songs.empty()) {
+            const player_chart_offset_map chart_offsets = load_player_chart_offsets();
+            for (song_entry& song : cached_catalog.songs) {
+                for (chart_option& chart : song.charts) {
+                    chart.local_note_offset_ms = chart_offsets.contains(chart.meta.chart_id)
+                        ? chart_offsets.at(chart.meta.chart_id)
+                        : 0;
+                    chart.best_local_rank = load_best_local_rank(chart.meta.chart_id);
+                }
+                std::sort(song.charts.begin(), song.charts.end(), chart_source_less);
+            }
+            std::sort(cached_catalog.songs.begin(), cached_catalog.songs.end(), song_source_less);
+            return cached_catalog;
+        }
+    }
+
     catalog_data catalog;
     const player_chart_offset_map chart_offsets = load_player_chart_offsets();
     const std::string manifest_server_url = current_manifest_server_url();
@@ -741,6 +650,7 @@ catalog_data load_catalog(bool calculate_missing_levels) {
 
     std::sort(catalog.songs.begin(), catalog.songs.end(), song_source_less);
 
+    local_catalog_database::replace_catalog(catalog.songs);
     save_verification_cache(verification_cache);
     return catalog;
 }
@@ -778,7 +688,8 @@ delete_result delete_song(const state& state, int song_index) {
 
             std::string linked_song_id = parse_result.data->meta.song_id;
             if (linked_song_id.empty()) {
-                linked_song_id = chart_identity::find_song_id(parse_result.data->meta.chart_id).value_or("");
+                linked_song_id = local_content_index::linked_song_for_chart(parse_result.data->meta.chart_id)
+                    .value_or("");
             }
 
             if (linked_song_id == entry.song.meta.song_id) {
@@ -797,7 +708,7 @@ delete_result delete_song(const state& state, int song_index) {
             result.message = "Failed to delete a linked chart file.";
             return result;
         }
-        chart_identity::remove(chart_target.chart_id);
+        local_content_index::unlink_chart(chart_target.chart_id);
     }
 
     for (const auto& package : mv::load_all_packages()) {
@@ -817,7 +728,9 @@ delete_result delete_song(const state& state, int song_index) {
         result.message = "Failed to delete the song directory.";
         return result;
     }
-    chart_identity::remove_for_song(entry.song.meta.song_id);
+    local_content_index::unlink_charts_for_song(entry.song.meta.song_id);
+    local_content_index::remove_song_bindings(entry.song.meta.song_id);
+    local_catalog_database::remove_song(entry.song.meta.song_id);
 
     result.success = true;
     result.message = "Song deleted.";
@@ -850,7 +763,10 @@ delete_result delete_chart(const state& state, int song_index, int chart_index) 
         result.message = "Failed to delete the chart file.";
         return result;
     }
-    chart_identity::remove(charts[static_cast<size_t>(chart_index)].meta.chart_id);
+    const std::string deleted_chart_id = charts[static_cast<size_t>(chart_index)].meta.chart_id;
+    local_content_index::unlink_chart(deleted_chart_id);
+    local_content_index::remove_chart_bindings(deleted_chart_id);
+    local_catalog_database::remove_chart(deleted_chart_id);
 
     result.success = true;
     result.message = "Chart deleted.";

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -584,7 +584,6 @@ upload_request_result send_song_upload_request(const auth::session& session,
     }
 
     std::vector<multipart_field> fields;
-    fields.push_back({"songId", meta.song_id});
     fields.push_back({"title", meta.title});
     fields.push_back({"artist", meta.artist});
     {
@@ -654,50 +653,6 @@ std::optional<std::string> resolve_remote_song_id_for_chart_upload(const auth::s
     return lookup.song.id;
 }
 
-std::optional<bool> remote_song_exists_for_local_id(const auth::session& session,
-                                                    const song_select::song_entry& song) {
-    if (song.song.meta.song_id.empty()) {
-        return false;
-    }
-
-    const title_online_view::remote_song_lookup_result lookup =
-        title_online_view::fetch_remote_song_by_id(song.song.meta.song_id, session.server_url);
-    if (!lookup.success && !lookup.not_found) {
-        return std::nullopt;
-    }
-    return lookup.success && !lookup.not_found && !lookup.song.id.empty();
-}
-
-std::optional<bool> remote_chart_exists_for_local_id(const auth::session& session,
-                                                     const std::string& remote_song_id,
-                                                     const song_select::chart_option& chart) {
-    if (remote_song_id.empty() || chart.meta.chart_id.empty()) {
-        return false;
-    }
-
-    constexpr int kChartLookupPageSize = 50;
-    int page = 1;
-    while (true) {
-        const title_online_view::remote_chart_page_fetch_result page_result =
-            title_online_view::fetch_remote_chart_page(session.server_url, remote_song_id, page, kChartLookupPageSize);
-        if (!page_result.success) {
-            return std::nullopt;
-        }
-        const auto found = std::find_if(page_result.charts.begin(), page_result.charts.end(),
-                                        [&](const title_online_view::remote_chart_payload& remote_chart) {
-                                            return remote_chart.id == chart.meta.chart_id;
-                                        });
-        if (found != page_result.charts.end()) {
-            return true;
-        }
-        if (page_result.charts.empty() ||
-            page * kChartLookupPageSize >= page_result.total) {
-            return false;
-        }
-        ++page;
-    }
-}
-
 upload_request_result send_chart_upload_request(const auth::session& session,
                                                 const song_select::song_entry& song,
                                                 const song_select::chart_option& chart,
@@ -717,7 +672,6 @@ upload_request_result send_chart_upload_request(const auth::session& session,
     }
 
     std::vector<multipart_field> fields;
-    fields.push_back({"chartId", chart.meta.chart_id});
     fields.push_back({"songId", remote_song_id});
     fields.push_back({"visibility", "public"});
 
@@ -767,18 +721,6 @@ upload_result upload_song(const song_select::song_entry& song) {
         result.message = "This song is linked to online content but was not uploaded from this client.";
         return result;
     }
-    if (!existing_remote_song_id.has_value()) {
-        const std::optional<bool> remote_exists = remote_song_exists_for_local_id(session, song);
-        if (!remote_exists.has_value()) {
-            result.message = "Could not verify whether this song already exists on the server.";
-            return result;
-        }
-        if (*remote_exists) {
-            result.message = "This song already exists on the server. Downloaded Community/Official songs cannot be uploaded again.";
-            return result;
-        }
-    }
-
     upload_request_result request_result =
         send_song_upload_request(session, song, existing_remote_song_id);
     if (request_result.unauthorized) {
@@ -853,18 +795,6 @@ upload_result upload_chart(const song_select::song_entry& song,
             title_upload_mapping::mapping_origin::owned_upload
         ? existing_remote_chart_id
         : std::nullopt;
-    if (!existing_remote_chart_id.has_value()) {
-        const std::optional<bool> remote_chart_exists =
-            remote_chart_exists_for_local_id(session, *remote_song_id, chart);
-        if (!remote_chart_exists.has_value()) {
-            result.message = "Could not verify whether this chart already exists on the server.";
-            return result;
-        }
-        if (*remote_chart_exists) {
-            result.message = "This chart already exists on the server. Downloaded Community/Official charts cannot be uploaded again.";
-            return result;
-        }
-    }
     if (existing_remote_chart_id.has_value() && !updatable_remote_chart_id.has_value()) {
         result.message = "This chart is linked to online content but was not uploaded from this client.";
         return result;

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -14,8 +14,7 @@
 #include "network/auth_client.h"
 #include "network/json_helpers.h"
 #include "path_utils.h"
-#include "title/online_download_remote_client.h"
-#include "title/upload_mapping_store.h"
+#include "title/local_content_index.h"
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -630,27 +629,10 @@ upload_request_result send_song_upload_request(const auth::session& session,
 }
 
 std::optional<std::string> resolve_remote_song_id_for_chart_upload(const auth::session& session,
-                                                                   title_upload_mapping::store& store,
                                                                    const song_select::song_entry& song) {
-    if (const std::optional<std::string> mapped = title_upload_mapping::find_remote_song_id(
-            store, session.server_url, song.song.meta.song_id);
-        mapped.has_value()) {
-        return mapped;
-    }
-
-    if (song.song.meta.song_id.empty()) {
-        return std::nullopt;
-    }
-
-    const title_online_view::remote_song_lookup_result lookup =
-        title_online_view::fetch_remote_song_by_id(song.song.meta.song_id, session.server_url);
-    if (!lookup.success || lookup.not_found || lookup.song.id.empty()) {
-        return std::nullopt;
-    }
-
-    title_upload_mapping::put_song(store, session.server_url, song.song.meta.song_id, lookup.song.id,
-                                   title_upload_mapping::mapping_origin::linked);
-    return lookup.song.id;
+    const std::optional<local_content_index::online_song_binding> binding =
+        local_content_index::find_song_by_local(session.server_url, song.song.meta.song_id);
+    return binding.has_value() ? std::optional<std::string>(binding->remote_song_id) : std::nullopt;
 }
 
 upload_request_result send_chart_upload_request(const auth::session& session,
@@ -710,14 +692,14 @@ upload_result upload_song(const song_select::song_entry& song) {
     }
     auth::session session = *session_opt;
 
-    title_upload_mapping::store store = title_upload_mapping::load();
+    const std::optional<local_content_index::online_song_binding> existing_song_binding =
+        local_content_index::find_song_by_local(session.server_url, song.song.meta.song_id);
     const std::optional<std::string> existing_remote_song_id =
-        title_upload_mapping::find_remote_song_id(store, session.server_url, song.song.meta.song_id);
-    const std::optional<title_upload_mapping::mapping_origin> existing_song_origin =
-        title_upload_mapping::find_song_origin(store, session.server_url, song.song.meta.song_id);
-    if (existing_remote_song_id.has_value() &&
-        existing_song_origin.value_or(title_upload_mapping::mapping_origin::owned_upload) !=
-            title_upload_mapping::mapping_origin::owned_upload) {
+        existing_song_binding.has_value()
+            ? std::optional<std::string>(existing_song_binding->remote_song_id)
+            : std::nullopt;
+    if (existing_song_binding.has_value() &&
+        existing_song_binding->origin != local_content_index::online_origin::owned_upload) {
         result.message = "This song is linked to online content but was not uploaded from this client.";
         return result;
     }
@@ -734,8 +716,7 @@ upload_result upload_song(const song_select::song_entry& song) {
         request_result = send_song_upload_request(session, song, existing_remote_song_id);
     }
     if (request_result.not_found && existing_remote_song_id.has_value()) {
-        title_upload_mapping::remove_song(store, session.server_url, song.song.meta.song_id);
-        title_upload_mapping::save(store);
+        local_content_index::remove_song_binding(session.server_url, song.song.meta.song_id);
         request_result = send_song_upload_request(session, song, std::nullopt);
         if (request_result.unauthorized) {
             std::string restore_error;
@@ -756,11 +737,13 @@ upload_result upload_song(const song_select::song_entry& song) {
         return result;
     }
 
-    title_upload_mapping::put_song(store, session.server_url, song.song.meta.song_id, request_result.remote_song_id,
-                                   title_upload_mapping::mapping_origin::owned_upload);
-    if (!title_upload_mapping::save(store)) {
-        result.message += " Local upload mapping was not saved.";
-    } else if (!request_result.updated_existing) {
+    local_content_index::put_song_binding({
+        .server_url = session.server_url,
+        .local_song_id = song.song.meta.song_id,
+        .remote_song_id = request_result.remote_song_id,
+        .origin = local_content_index::online_origin::owned_upload,
+    });
+    if (!request_result.updated_existing) {
         result.message += " Charts for this song can now be uploaded.";
     }
 
@@ -779,20 +762,21 @@ upload_result upload_chart(const song_select::song_entry& song,
     }
     auth::session session = *session_opt;
 
-    title_upload_mapping::store store = title_upload_mapping::load();
-    const std::optional<std::string> remote_song_id = resolve_remote_song_id_for_chart_upload(session, store, song);
+    const std::optional<std::string> remote_song_id = resolve_remote_song_id_for_chart_upload(session, song);
     if (!remote_song_id.has_value()) {
         result.message = "Upload the song first so the server can assign a song ID.";
         return result;
     }
 
+    const std::optional<local_content_index::online_chart_binding> existing_chart_binding =
+        local_content_index::find_chart_by_local(session.server_url, chart.meta.chart_id);
     const std::optional<std::string> existing_remote_chart_id =
-        title_upload_mapping::find_remote_chart_id(store, session.server_url, chart.meta.chart_id);
-    const std::optional<title_upload_mapping::mapping_origin> existing_chart_origin =
-        title_upload_mapping::find_chart_origin(store, session.server_url, chart.meta.chart_id);
+        existing_chart_binding.has_value()
+            ? std::optional<std::string>(existing_chart_binding->remote_chart_id)
+            : std::nullopt;
     const std::optional<std::string> updatable_remote_chart_id =
-        existing_chart_origin.value_or(title_upload_mapping::mapping_origin::owned_upload) ==
-            title_upload_mapping::mapping_origin::owned_upload
+        (!existing_chart_binding.has_value() ||
+         existing_chart_binding->origin == local_content_index::online_origin::owned_upload)
         ? existing_remote_chart_id
         : std::nullopt;
     if (existing_remote_chart_id.has_value() && !updatable_remote_chart_id.has_value()) {
@@ -813,8 +797,7 @@ upload_result upload_chart(const song_select::song_entry& song,
         request_result = send_chart_upload_request(session, song, chart, *remote_song_id, updatable_remote_chart_id);
     }
     if (request_result.not_found && existing_remote_chart_id.has_value()) {
-        title_upload_mapping::remove_chart(store, session.server_url, chart.meta.chart_id);
-        title_upload_mapping::save(store);
+        local_content_index::remove_chart_binding(session.server_url, chart.meta.chart_id);
         request_result =
             send_chart_upload_request(session, song, chart, *remote_song_id, std::nullopt);
         if (request_result.unauthorized) {
@@ -837,16 +820,22 @@ upload_result upload_chart(const song_select::song_entry& song,
         return result;
     }
 
-    if (!title_upload_mapping::find_song_origin(store, session.server_url, song.song.meta.song_id).has_value()) {
-        title_upload_mapping::put_song(store, session.server_url, song.song.meta.song_id, *remote_song_id,
-                                       title_upload_mapping::mapping_origin::linked);
+    if (!local_content_index::find_song_by_local(session.server_url, song.song.meta.song_id).has_value()) {
+        local_content_index::put_song_binding({
+            .server_url = session.server_url,
+            .local_song_id = song.song.meta.song_id,
+            .remote_song_id = *remote_song_id,
+            .origin = local_content_index::online_origin::linked,
+        });
     }
-    title_upload_mapping::put_chart(store, session.server_url, chart.meta.chart_id, song.song.meta.song_id,
-                                    request_result.remote_chart_id, *remote_song_id,
-                                    title_upload_mapping::mapping_origin::owned_upload);
-    if (!title_upload_mapping::save(store)) {
-        result.message += " Local upload mapping was not saved.";
-    }
+    local_content_index::put_chart_binding({
+        .server_url = session.server_url,
+        .local_chart_id = chart.meta.chart_id,
+        .local_song_id = song.song.meta.song_id,
+        .remote_chart_id = request_result.remote_chart_id,
+        .remote_song_id = *remote_song_id,
+        .origin = local_content_index::online_origin::owned_upload,
+    });
 
     return result;
 }

--- a/src/scenes/title/local_content_database.cpp
+++ b/src/scenes/title/local_content_database.cpp
@@ -1,0 +1,508 @@
+#include "title/local_content_database.h"
+
+#include <ctime>
+#include <cstdint>
+#include <optional>
+#include <string>
+
+#include "local_sqlite.h"
+#include "sqlite3.h"
+
+namespace local_content_database {
+namespace {
+
+int origin_to_int(title_upload_mapping::mapping_origin origin) {
+    switch (origin) {
+    case title_upload_mapping::mapping_origin::downloaded:
+        return 1;
+    case title_upload_mapping::mapping_origin::linked:
+        return 2;
+    case title_upload_mapping::mapping_origin::owned_upload:
+    default:
+        return 0;
+    }
+}
+
+title_upload_mapping::mapping_origin origin_from_int(int value) {
+    switch (value) {
+    case 1:
+        return title_upload_mapping::mapping_origin::downloaded;
+    case 2:
+        return title_upload_mapping::mapping_origin::linked;
+    case 0:
+    default:
+        return title_upload_mapping::mapping_origin::owned_upload;
+    }
+}
+
+title_upload_mapping::mapping_origin merge_origin(title_upload_mapping::mapping_origin current,
+                                                  title_upload_mapping::mapping_origin incoming) {
+    if (current == title_upload_mapping::mapping_origin::owned_upload) {
+        return current;
+    }
+    if (current == title_upload_mapping::mapping_origin::downloaded &&
+        incoming == title_upload_mapping::mapping_origin::linked) {
+        return current;
+    }
+    return incoming;
+}
+
+std::int64_t now_unix_seconds() {
+    return static_cast<std::int64_t>(std::time(nullptr));
+}
+
+using local_sqlite::bind_text;
+using local_sqlite::column_text;
+using local_sqlite::exec;
+using local_sqlite::statement;
+using local_sqlite::step_done;
+
+bool ensure_schema(sqlite3* database) {
+    return local_sqlite::ensure_common_schema(database) &&
+           exec(database,
+                "CREATE TABLE IF NOT EXISTS song_bindings ("
+                "server_url TEXT NOT NULL,"
+                "local_song_id TEXT NOT NULL,"
+                "remote_song_id TEXT NOT NULL,"
+                "origin INTEGER NOT NULL,"
+                "updated_at INTEGER NOT NULL,"
+                "PRIMARY KEY (server_url, local_song_id)"
+                ");") &&
+           exec(database,
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_song_bindings_remote "
+                "ON song_bindings(server_url, remote_song_id);") &&
+           exec(database,
+                "CREATE TABLE IF NOT EXISTS chart_bindings ("
+                "server_url TEXT NOT NULL,"
+                "local_chart_id TEXT NOT NULL,"
+                "local_song_id TEXT NOT NULL,"
+                "remote_chart_id TEXT NOT NULL,"
+                "remote_song_id TEXT NOT NULL,"
+                "origin INTEGER NOT NULL,"
+                "updated_at INTEGER NOT NULL,"
+                "PRIMARY KEY (server_url, local_chart_id)"
+                ");") &&
+           exec(database,
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_bindings_remote "
+                "ON chart_bindings(server_url, remote_chart_id);") &&
+           exec(database,
+                "INSERT INTO metadata(key, value) VALUES('schema_version', '1') "
+                "ON CONFLICT(key) DO UPDATE SET value = excluded.value;");
+}
+
+int count_rows(sqlite3* database, const char* table_name) {
+    const std::string sql = std::string("SELECT COUNT(*) FROM ") + table_name + ";";
+    statement query(database, sql.c_str());
+    if (!query.valid() || sqlite3_step(query.get()) != SQLITE_ROW) {
+        return 0;
+    }
+    return sqlite3_column_int(query.get(), 0);
+}
+
+std::optional<title_upload_mapping::mapping_origin> current_song_origin(sqlite3* database,
+                                                                        const std::string& server_url,
+                                                                        const std::string& local_song_id) {
+    statement query(database,
+                    "SELECT origin FROM song_bindings WHERE server_url = ? AND local_song_id = ?;");
+    if (!query.valid()) {
+        return std::nullopt;
+    }
+    bind_text(query.get(), 1, server_url);
+    bind_text(query.get(), 2, local_song_id);
+    if (sqlite3_step(query.get()) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    return origin_from_int(sqlite3_column_int(query.get(), 0));
+}
+
+std::optional<title_upload_mapping::mapping_origin> current_chart_origin(sqlite3* database,
+                                                                         const std::string& server_url,
+                                                                         const std::string& local_chart_id) {
+    statement query(database,
+                    "SELECT origin FROM chart_bindings WHERE server_url = ? AND local_chart_id = ?;");
+    if (!query.valid()) {
+        return std::nullopt;
+    }
+    bind_text(query.get(), 1, server_url);
+    bind_text(query.get(), 2, local_chart_id);
+    if (sqlite3_step(query.get()) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    return origin_from_int(sqlite3_column_int(query.get(), 0));
+}
+
+void put_song(sqlite3* database, const title_upload_mapping::song_mapping_entry& binding) {
+    if (binding.server_url.empty() || binding.local_song_id.empty() || binding.remote_song_id.empty()) {
+        return;
+    }
+
+    const std::optional<title_upload_mapping::mapping_origin> current_origin =
+        current_song_origin(database, binding.server_url, binding.local_song_id);
+    const title_upload_mapping::mapping_origin origin = current_origin.has_value()
+        ? merge_origin(*current_origin, binding.origin)
+        : binding.origin;
+
+    statement query(database,
+                    "INSERT INTO song_bindings(server_url, local_song_id, remote_song_id, origin, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?) "
+                    "ON CONFLICT(server_url, local_song_id) DO UPDATE SET "
+                    "remote_song_id = excluded.remote_song_id,"
+                    "origin = excluded.origin,"
+                    "updated_at = excluded.updated_at;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, binding.server_url);
+    bind_text(query.get(), 2, binding.local_song_id);
+    bind_text(query.get(), 3, binding.remote_song_id);
+    sqlite3_bind_int(query.get(), 4, origin_to_int(origin));
+    sqlite3_bind_int64(query.get(), 5, now_unix_seconds());
+    step_done(query.get());
+}
+
+void put_chart(sqlite3* database, const title_upload_mapping::chart_mapping_entry& binding) {
+    if (binding.server_url.empty() || binding.local_chart_id.empty() || binding.local_song_id.empty() ||
+        binding.remote_chart_id.empty() || binding.remote_song_id.empty()) {
+        return;
+    }
+
+    const std::optional<title_upload_mapping::mapping_origin> current_origin =
+        current_chart_origin(database, binding.server_url, binding.local_chart_id);
+    const title_upload_mapping::mapping_origin origin = current_origin.has_value()
+        ? merge_origin(*current_origin, binding.origin)
+        : binding.origin;
+
+    statement query(database,
+                    "INSERT INTO chart_bindings(server_url, local_chart_id, local_song_id, remote_chart_id, "
+                    "remote_song_id, origin, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?) "
+                    "ON CONFLICT(server_url, local_chart_id) DO UPDATE SET "
+                    "local_song_id = excluded.local_song_id,"
+                    "remote_chart_id = excluded.remote_chart_id,"
+                    "remote_song_id = excluded.remote_song_id,"
+                    "origin = excluded.origin,"
+                    "updated_at = excluded.updated_at;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, binding.server_url);
+    bind_text(query.get(), 2, binding.local_chart_id);
+    bind_text(query.get(), 3, binding.local_song_id);
+    bind_text(query.get(), 4, binding.remote_chart_id);
+    bind_text(query.get(), 5, binding.remote_song_id);
+    sqlite3_bind_int(query.get(), 6, origin_to_int(origin));
+    sqlite3_bind_int64(query.get(), 7, now_unix_seconds());
+    step_done(query.get());
+}
+
+bool imported_legacy(sqlite3* database) {
+    return local_sqlite::metadata_value(database, "legacy_upload_mappings_imported").has_value();
+}
+
+void mark_legacy_imported(sqlite3* database) {
+    local_sqlite::put_metadata(database, "legacy_upload_mappings_imported", "1");
+}
+
+void import_legacy_if_needed(sqlite3* database) {
+    if (imported_legacy(database) ||
+        count_rows(database, "song_bindings") > 0 ||
+        count_rows(database, "chart_bindings") > 0) {
+        return;
+    }
+
+    const title_upload_mapping::store legacy = title_upload_mapping::load();
+    if (legacy.songs.empty() && legacy.charts.empty()) {
+        mark_legacy_imported(database);
+        return;
+    }
+
+    local_sqlite::transaction transaction(database);
+    if (!transaction.active()) {
+        return;
+    }
+    for (const title_upload_mapping::song_mapping_entry& song : legacy.songs) {
+        put_song(database, song);
+    }
+    for (const title_upload_mapping::chart_mapping_entry& chart : legacy.charts) {
+        put_chart(database, chart);
+    }
+    transaction.commit();
+    mark_legacy_imported(database);
+}
+
+local_sqlite::database open_ready_database() {
+    local_sqlite::database database = local_sqlite::open_local_content_database();
+    if (!database.valid()) {
+        return database;
+    }
+    if (!ensure_schema(database.get())) {
+        return database;
+    }
+    import_legacy_if_needed(database.get());
+    return database;
+}
+
+std::optional<title_upload_mapping::song_mapping_entry> read_song(sqlite3_stmt* statement) {
+    return title_upload_mapping::song_mapping_entry{
+        .server_url = column_text(statement, 0),
+        .local_song_id = column_text(statement, 1),
+        .remote_song_id = column_text(statement, 2),
+        .origin = origin_from_int(sqlite3_column_int(statement, 3)),
+    };
+}
+
+std::optional<title_upload_mapping::chart_mapping_entry> read_chart(sqlite3_stmt* statement) {
+    return title_upload_mapping::chart_mapping_entry{
+        .server_url = column_text(statement, 0),
+        .local_chart_id = column_text(statement, 1),
+        .local_song_id = column_text(statement, 2),
+        .remote_chart_id = column_text(statement, 3),
+        .remote_song_id = column_text(statement, 4),
+        .origin = origin_from_int(sqlite3_column_int(statement, 5)),
+    };
+}
+
+std::optional<title_upload_mapping::song_mapping_entry> find_song(sqlite3* database,
+                                                                  const char* sql,
+                                                                  const std::string& server_url,
+                                                                  const std::string& id) {
+    statement query(database, sql);
+    if (!query.valid()) {
+        return std::nullopt;
+    }
+    bind_text(query.get(), 1, server_url);
+    bind_text(query.get(), 2, id);
+    if (sqlite3_step(query.get()) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    return read_song(query.get());
+}
+
+std::optional<title_upload_mapping::chart_mapping_entry> find_chart(sqlite3* database,
+                                                                    const char* sql,
+                                                                    const std::string& server_url,
+                                                                    const std::string& id) {
+    statement query(database, sql);
+    if (!query.valid()) {
+        return std::nullopt;
+    }
+    bind_text(query.get(), 1, server_url);
+    bind_text(query.get(), 2, id);
+    if (sqlite3_step(query.get()) != SQLITE_ROW) {
+        return std::nullopt;
+    }
+    return read_chart(query.get());
+}
+
+}  // namespace
+
+title_upload_mapping::store load_mappings() {
+    title_upload_mapping::store mappings;
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return title_upload_mapping::load();
+    }
+
+    statement songs(database.get(),
+                    "SELECT server_url, local_song_id, remote_song_id, origin FROM song_bindings "
+                    "ORDER BY server_url, local_song_id;");
+    if (songs.valid()) {
+        while (sqlite3_step(songs.get()) == SQLITE_ROW) {
+            mappings.songs.push_back({
+                .server_url = column_text(songs.get(), 0),
+                .local_song_id = column_text(songs.get(), 1),
+                .remote_song_id = column_text(songs.get(), 2),
+                .origin = origin_from_int(sqlite3_column_int(songs.get(), 3)),
+            });
+        }
+    }
+
+    statement charts(database.get(),
+                     "SELECT server_url, local_chart_id, local_song_id, remote_chart_id, remote_song_id, origin "
+                     "FROM chart_bindings ORDER BY server_url, local_chart_id;");
+    if (charts.valid()) {
+        while (sqlite3_step(charts.get()) == SQLITE_ROW) {
+            mappings.charts.push_back({
+                .server_url = column_text(charts.get(), 0),
+                .local_chart_id = column_text(charts.get(), 1),
+                .local_song_id = column_text(charts.get(), 2),
+                .remote_chart_id = column_text(charts.get(), 3),
+                .remote_song_id = column_text(charts.get(), 4),
+                .origin = origin_from_int(sqlite3_column_int(charts.get(), 5)),
+            });
+        }
+    }
+
+    return mappings;
+}
+
+std::optional<title_upload_mapping::song_mapping_entry> find_song_by_local(const std::string& server_url,
+                                                                           const std::string& local_song_id) {
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        return find_song(database.get(),
+                         "SELECT server_url, local_song_id, remote_song_id, origin FROM song_bindings "
+                         "WHERE server_url = ? AND local_song_id = ?;",
+                         server_url,
+                         local_song_id);
+    }
+
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const std::optional<std::string> remote_id =
+        title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id);
+    const std::optional<title_upload_mapping::mapping_origin> origin =
+        title_upload_mapping::find_song_origin(mappings, server_url, local_song_id);
+    if (!remote_id.has_value()) {
+        return std::nullopt;
+    }
+    return title_upload_mapping::song_mapping_entry{
+        .server_url = server_url,
+        .local_song_id = local_song_id,
+        .remote_song_id = *remote_id,
+        .origin = origin.value_or(title_upload_mapping::mapping_origin::owned_upload),
+    };
+}
+
+std::optional<title_upload_mapping::song_mapping_entry> find_song_by_remote(const std::string& server_url,
+                                                                            const std::string& remote_song_id) {
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        return find_song(database.get(),
+                         "SELECT server_url, local_song_id, remote_song_id, origin FROM song_bindings "
+                         "WHERE server_url = ? AND remote_song_id = ?;",
+                         server_url,
+                         remote_song_id);
+    }
+
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const std::optional<std::string> local_id =
+        title_upload_mapping::find_local_song_id(mappings, server_url, remote_song_id);
+    if (!local_id.has_value()) {
+        return std::nullopt;
+    }
+    return find_song_by_local(server_url, *local_id);
+}
+
+std::optional<title_upload_mapping::chart_mapping_entry> find_chart_by_local(const std::string& server_url,
+                                                                             const std::string& local_chart_id) {
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        return find_chart(database.get(),
+                          "SELECT server_url, local_chart_id, local_song_id, remote_chart_id, remote_song_id, origin "
+                          "FROM chart_bindings WHERE server_url = ? AND local_chart_id = ?;",
+                          server_url,
+                          local_chart_id);
+    }
+
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const std::optional<std::string> remote_id =
+        title_upload_mapping::find_remote_chart_id(mappings, server_url, local_chart_id);
+    const std::optional<title_upload_mapping::mapping_origin> origin =
+        title_upload_mapping::find_chart_origin(mappings, server_url, local_chart_id);
+    if (!remote_id.has_value()) {
+        return std::nullopt;
+    }
+    for (const title_upload_mapping::chart_mapping_entry& chart : mappings.charts) {
+        if (chart.server_url == server_url && chart.local_chart_id == local_chart_id) {
+            return title_upload_mapping::chart_mapping_entry{
+                .server_url = server_url,
+                .local_chart_id = local_chart_id,
+                .local_song_id = chart.local_song_id,
+                .remote_chart_id = *remote_id,
+                .remote_song_id = chart.remote_song_id,
+                .origin = origin.value_or(title_upload_mapping::mapping_origin::owned_upload),
+            };
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<title_upload_mapping::chart_mapping_entry> find_chart_by_remote(const std::string& server_url,
+                                                                              const std::string& remote_chart_id) {
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        return find_chart(database.get(),
+                          "SELECT server_url, local_chart_id, local_song_id, remote_chart_id, remote_song_id, origin "
+                          "FROM chart_bindings WHERE server_url = ? AND remote_chart_id = ?;",
+                          server_url,
+                          remote_chart_id);
+    }
+
+    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const std::optional<std::string> local_id =
+        title_upload_mapping::find_local_chart_id(mappings, server_url, remote_chart_id);
+    if (!local_id.has_value()) {
+        return std::nullopt;
+    }
+    return find_chart_by_local(server_url, *local_id);
+}
+
+void put_song(const title_upload_mapping::song_mapping_entry& binding) {
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        put_song(database.get(), binding);
+    }
+}
+
+void put_chart(const title_upload_mapping::chart_mapping_entry& binding) {
+    local_sqlite::database database = open_ready_database();
+    if (database.valid()) {
+        put_chart(database.get(), binding);
+    }
+}
+
+void remove_song(const std::string& server_url, const std::string& local_song_id) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return;
+    }
+    statement query(database.get(), "DELETE FROM song_bindings WHERE server_url = ? AND local_song_id = ?;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, server_url);
+    bind_text(query.get(), 2, local_song_id);
+    step_done(query.get());
+}
+
+void remove_chart(const std::string& server_url, const std::string& local_chart_id) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return;
+    }
+    statement query(database.get(), "DELETE FROM chart_bindings WHERE server_url = ? AND local_chart_id = ?;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, server_url);
+    bind_text(query.get(), 2, local_chart_id);
+    step_done(query.get());
+}
+
+void remove_song_bindings(const std::string& local_song_id) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return;
+    }
+    statement query(database.get(), "DELETE FROM song_bindings WHERE local_song_id = ?;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, local_song_id);
+    step_done(query.get());
+}
+
+void remove_chart_bindings(const std::string& local_chart_id) {
+    local_sqlite::database database = open_ready_database();
+    if (!database.valid()) {
+        return;
+    }
+    statement query(database.get(), "DELETE FROM chart_bindings WHERE local_chart_id = ?;");
+    if (!query.valid()) {
+        return;
+    }
+    bind_text(query.get(), 1, local_chart_id);
+    step_done(query.get());
+}
+
+}  // namespace local_content_database

--- a/src/scenes/title/local_content_database.h
+++ b/src/scenes/title/local_content_database.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "title/upload_mapping_store.h"
+
+namespace local_content_database {
+
+title_upload_mapping::store load_mappings();
+std::optional<title_upload_mapping::song_mapping_entry> find_song_by_local(const std::string& server_url,
+                                                                           const std::string& local_song_id);
+std::optional<title_upload_mapping::song_mapping_entry> find_song_by_remote(const std::string& server_url,
+                                                                            const std::string& remote_song_id);
+std::optional<title_upload_mapping::chart_mapping_entry> find_chart_by_local(const std::string& server_url,
+                                                                             const std::string& local_chart_id);
+std::optional<title_upload_mapping::chart_mapping_entry> find_chart_by_remote(const std::string& server_url,
+                                                                              const std::string& remote_chart_id);
+
+void put_song(const title_upload_mapping::song_mapping_entry& binding);
+void put_chart(const title_upload_mapping::chart_mapping_entry& binding);
+
+void remove_song(const std::string& server_url, const std::string& local_song_id);
+void remove_chart(const std::string& server_url, const std::string& local_chart_id);
+void remove_song_bindings(const std::string& local_song_id);
+void remove_chart_bindings(const std::string& local_chart_id);
+
+}  // namespace local_content_database

--- a/src/scenes/title/local_content_index.cpp
+++ b/src/scenes/title/local_content_index.cpp
@@ -1,0 +1,169 @@
+#include "title/local_content_index.h"
+
+#include "chart_identity_store.h"
+#include "title/local_content_database.h"
+
+namespace local_content_index {
+namespace {
+
+online_song_binding to_index_binding(const title_upload_mapping::song_mapping_entry& entry) {
+    return {
+        .server_url = entry.server_url,
+        .local_song_id = entry.local_song_id,
+        .remote_song_id = entry.remote_song_id,
+        .origin = entry.origin,
+    };
+}
+
+online_chart_binding to_index_binding(const title_upload_mapping::chart_mapping_entry& entry) {
+    return {
+        .server_url = entry.server_url,
+        .local_chart_id = entry.local_chart_id,
+        .local_song_id = entry.local_song_id,
+        .remote_chart_id = entry.remote_chart_id,
+        .remote_song_id = entry.remote_song_id,
+        .origin = entry.origin,
+    };
+}
+
+}  // namespace
+
+std::optional<std::string> linked_song_for_chart(const std::string& local_chart_id) {
+    return chart_identity::find_song_id(local_chart_id);
+}
+
+void link_chart_to_song(const std::string& local_chart_id, const std::string& local_song_id) {
+    chart_identity::put(local_chart_id, local_song_id);
+}
+
+void unlink_chart(const std::string& local_chart_id) {
+    chart_identity::remove(local_chart_id);
+}
+
+void unlink_charts_for_song(const std::string& local_song_id) {
+    chart_identity::remove_for_song(local_song_id);
+}
+
+snapshot load_snapshot() {
+    const title_upload_mapping::store mappings = local_content_database::load_mappings();
+    snapshot index;
+    index.songs.reserve(mappings.songs.size());
+    for (const title_upload_mapping::song_mapping_entry& entry : mappings.songs) {
+        index.songs.push_back(to_index_binding(entry));
+    }
+    index.charts.reserve(mappings.charts.size());
+    for (const title_upload_mapping::chart_mapping_entry& entry : mappings.charts) {
+        index.charts.push_back(to_index_binding(entry));
+    }
+    return index;
+}
+
+std::optional<online_song_binding> find_song_by_local(const snapshot& index,
+                                                      const std::string& server_url,
+                                                      const std::string& local_song_id) {
+    for (const online_song_binding& binding : index.songs) {
+        if (binding.server_url == server_url && binding.local_song_id == local_song_id) {
+            return binding;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<online_song_binding> find_song_by_remote(const snapshot& index,
+                                                       const std::string& server_url,
+                                                       const std::string& remote_song_id) {
+    for (const online_song_binding& binding : index.songs) {
+        if (binding.server_url == server_url && binding.remote_song_id == remote_song_id) {
+            return binding;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<online_chart_binding> find_chart_by_local(const snapshot& index,
+                                                        const std::string& server_url,
+                                                        const std::string& local_chart_id) {
+    for (const online_chart_binding& binding : index.charts) {
+        if (binding.server_url == server_url && binding.local_chart_id == local_chart_id) {
+            return binding;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<online_chart_binding> find_chart_by_remote(const snapshot& index,
+                                                         const std::string& server_url,
+                                                         const std::string& remote_chart_id) {
+    for (const online_chart_binding& binding : index.charts) {
+        if (binding.server_url == server_url && binding.remote_chart_id == remote_chart_id) {
+            return binding;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<online_song_binding> find_song_by_local(const std::string& server_url,
+                                                      const std::string& local_song_id) {
+    const std::optional<title_upload_mapping::song_mapping_entry> binding =
+        local_content_database::find_song_by_local(server_url, local_song_id);
+    return binding.has_value() ? std::optional<online_song_binding>(to_index_binding(*binding)) : std::nullopt;
+}
+
+std::optional<online_song_binding> find_song_by_remote(const std::string& server_url,
+                                                       const std::string& remote_song_id) {
+    const std::optional<title_upload_mapping::song_mapping_entry> binding =
+        local_content_database::find_song_by_remote(server_url, remote_song_id);
+    return binding.has_value() ? std::optional<online_song_binding>(to_index_binding(*binding)) : std::nullopt;
+}
+
+std::optional<online_chart_binding> find_chart_by_local(const std::string& server_url,
+                                                        const std::string& local_chart_id) {
+    const std::optional<title_upload_mapping::chart_mapping_entry> binding =
+        local_content_database::find_chart_by_local(server_url, local_chart_id);
+    return binding.has_value() ? std::optional<online_chart_binding>(to_index_binding(*binding)) : std::nullopt;
+}
+
+std::optional<online_chart_binding> find_chart_by_remote(const std::string& server_url,
+                                                         const std::string& remote_chart_id) {
+    const std::optional<title_upload_mapping::chart_mapping_entry> binding =
+        local_content_database::find_chart_by_remote(server_url, remote_chart_id);
+    return binding.has_value() ? std::optional<online_chart_binding>(to_index_binding(*binding)) : std::nullopt;
+}
+
+void put_song_binding(const online_song_binding& binding) {
+    local_content_database::put_song({
+        .server_url = binding.server_url,
+        .local_song_id = binding.local_song_id,
+        .remote_song_id = binding.remote_song_id,
+        .origin = binding.origin,
+    });
+}
+
+void put_chart_binding(const online_chart_binding& binding) {
+    local_content_database::put_chart({
+        .server_url = binding.server_url,
+        .local_chart_id = binding.local_chart_id,
+        .local_song_id = binding.local_song_id,
+        .remote_chart_id = binding.remote_chart_id,
+        .remote_song_id = binding.remote_song_id,
+        .origin = binding.origin,
+    });
+}
+
+void remove_song_binding(const std::string& server_url, const std::string& local_song_id) {
+    local_content_database::remove_song(server_url, local_song_id);
+}
+
+void remove_chart_binding(const std::string& server_url, const std::string& local_chart_id) {
+    local_content_database::remove_chart(server_url, local_chart_id);
+}
+
+void remove_song_bindings(const std::string& local_song_id) {
+    local_content_database::remove_song_bindings(local_song_id);
+}
+
+void remove_chart_bindings(const std::string& local_chart_id) {
+    local_content_database::remove_chart_bindings(local_chart_id);
+}
+
+}  // namespace local_content_index

--- a/src/scenes/title/local_content_index.h
+++ b/src/scenes/title/local_content_index.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "title/upload_mapping_store.h"
+
+namespace local_content_index {
+
+using online_origin = title_upload_mapping::mapping_origin;
+
+struct online_song_binding {
+    std::string server_url;
+    std::string local_song_id;
+    std::string remote_song_id;
+    online_origin origin = online_origin::owned_upload;
+};
+
+struct online_chart_binding {
+    std::string server_url;
+    std::string local_chart_id;
+    std::string local_song_id;
+    std::string remote_chart_id;
+    std::string remote_song_id;
+    online_origin origin = online_origin::owned_upload;
+};
+
+struct snapshot {
+    std::vector<online_song_binding> songs;
+    std::vector<online_chart_binding> charts;
+};
+
+std::optional<std::string> linked_song_for_chart(const std::string& local_chart_id);
+void link_chart_to_song(const std::string& local_chart_id, const std::string& local_song_id);
+void unlink_chart(const std::string& local_chart_id);
+void unlink_charts_for_song(const std::string& local_song_id);
+
+snapshot load_snapshot();
+std::optional<online_song_binding> find_song_by_local(const snapshot& index,
+                                                      const std::string& server_url,
+                                                      const std::string& local_song_id);
+std::optional<online_song_binding> find_song_by_remote(const snapshot& index,
+                                                       const std::string& server_url,
+                                                       const std::string& remote_song_id);
+std::optional<online_chart_binding> find_chart_by_local(const snapshot& index,
+                                                        const std::string& server_url,
+                                                        const std::string& local_chart_id);
+std::optional<online_chart_binding> find_chart_by_remote(const snapshot& index,
+                                                         const std::string& server_url,
+                                                         const std::string& remote_chart_id);
+std::optional<online_song_binding> find_song_by_local(const std::string& server_url,
+                                                      const std::string& local_song_id);
+std::optional<online_song_binding> find_song_by_remote(const std::string& server_url,
+                                                       const std::string& remote_song_id);
+std::optional<online_chart_binding> find_chart_by_local(const std::string& server_url,
+                                                        const std::string& local_chart_id);
+std::optional<online_chart_binding> find_chart_by_remote(const std::string& server_url,
+                                                         const std::string& remote_chart_id);
+
+void put_song_binding(const online_song_binding& binding);
+void put_chart_binding(const online_chart_binding& binding);
+void remove_song_binding(const std::string& server_url, const std::string& local_song_id);
+void remove_chart_binding(const std::string& server_url, const std::string& local_chart_id);
+void remove_song_bindings(const std::string& local_song_id);
+void remove_chart_bindings(const std::string& local_chart_id);
+
+}  // namespace local_content_index

--- a/src/scenes/title/online_download_catalog.cpp
+++ b/src/scenes/title/online_download_catalog.cpp
@@ -14,8 +14,8 @@
 
 #include "path_utils.h"
 #include "song_select/song_catalog_service.h"
+#include "title/local_content_index.h"
 #include "title/online_download_remote_client.h"
-#include "title/upload_mapping_store.h"
 
 namespace title_online_view {
 namespace {
@@ -32,9 +32,9 @@ struct local_song_ref {
 using local_song_lookup = std::unordered_map<std::string, local_song_ref>;
 
 local_song_lookup build_local_lookup(const std::vector<song_select::song_entry>& local_songs,
-                                     const std::string& server_url) {
+                                     const std::string& server_url,
+                                     const local_content_index::snapshot& index) {
     local_song_lookup lookup;
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
     for (const song_select::song_entry& song : local_songs) {
         const std::string& local_song_id = song.song.meta.song_id;
         lookup[local_song_id] = local_song_ref{
@@ -42,10 +42,10 @@ local_song_lookup build_local_lookup(const std::vector<song_select::song_entry>&
             .local_song_id = local_song_id,
         };
 
-        const std::optional<std::string> remote_song_id =
-            title_upload_mapping::find_remote_song_id(mappings, server_url, local_song_id);
-        if (remote_song_id.has_value() && !remote_song_id->empty()) {
-            lookup[*remote_song_id] = local_song_ref{
+        const std::optional<local_content_index::online_song_binding> binding =
+            local_content_index::find_song_by_local(index, server_url, local_song_id);
+        if (binding.has_value() && !binding->remote_song_id.empty()) {
+            lookup[binding->remote_song_id] = local_song_ref{
                 .song = &song,
                 .local_song_id = local_song_id,
             };
@@ -105,9 +105,11 @@ song_entry_state build_song_state(const remote_song_payload& remote_song,
 
 song_entry_state build_owned_song_state(const song_select::song_entry& local_song,
                                         const remote_song_payload& remote_song,
-                                        const std::string& server_url) {
+                                        const std::string& server_url,
+                                        const local_content_index::snapshot& index) {
     song_entry_state state_entry;
     state_entry.song = local_song;
+    state_entry.song.song.meta.song_id = remote_song.id;
     state_entry.song.song.meta.audio_url = make_absolute_remote_url(server_url, remote_song.audio_url);
     state_entry.song.song.meta.jacket_url = make_absolute_remote_url(server_url, remote_song.jacket_url);
     state_entry.song.song.meta.preview_start_ms = remote_song.preview_start_ms;
@@ -124,8 +126,15 @@ song_entry_state build_owned_song_state(const song_select::song_entry& local_son
     state_entry.next_chart_page = 1;
     state_entry.charts.reserve(local_song.charts.size());
     for (const song_select::chart_option& chart : local_song.charts) {
+        song_select::chart_option remote_chart = chart;
+        remote_chart.meta.song_id = remote_song.id;
+        const std::optional<local_content_index::online_chart_binding> binding =
+            local_content_index::find_chart_by_local(index, server_url, chart.meta.chart_id);
+        remote_chart.meta.chart_id = binding.has_value() && !binding->remote_chart_id.empty()
+            ? binding->remote_chart_id
+            : chart.meta.chart_id;
         state_entry.charts.push_back({
-            chart,
+            remote_chart,
             chart.meta.chart_id,
             true,
             false,
@@ -148,7 +157,7 @@ void append_song_page(std::vector<song_entry_state>& target, std::vector<song_en
 void append_chart_page(song_entry_state& song_state,
                        const std::vector<song_select::song_entry>& local_songs,
                        const remote_chart_page_fetch_result& page_result) {
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const local_content_index::snapshot index = local_content_index::load_snapshot();
     const std::string local_song_id = !song_state.installed_local_song_id.empty()
         ? song_state.installed_local_song_id
         : song_state.song.song.meta.song_id;
@@ -162,8 +171,10 @@ void append_chart_page(song_entry_state& song_state,
             continue;
         }
 
+        const std::optional<local_content_index::online_chart_binding> binding =
+            local_content_index::find_chart_by_remote(index, page_result.server_url, chart.id);
         const std::optional<std::string> mapped_local_chart_id =
-            title_upload_mapping::find_local_chart_id(mappings, page_result.server_url, chart.id);
+            binding.has_value() ? std::optional<std::string>(binding->local_chart_id) : std::nullopt;
         std::string installed_local_chart_id;
         const bool local_chart_installed = local_song != nullptr &&
             std::any_of(local_song->charts.begin(), local_song->charts.end(),
@@ -410,24 +421,22 @@ std::vector<song_entry_state> load_owned_songs(const std::vector<song_select::so
         return owned;
     }
 
-    const title_upload_mapping::store mappings = title_upload_mapping::load();
+    const local_content_index::snapshot index = local_content_index::load_snapshot();
     owned.reserve(local_songs.size());
     for (const song_select::song_entry& local_song : local_songs) {
-        const std::optional<title_upload_mapping::mapping_origin> origin =
-            title_upload_mapping::find_song_origin(mappings, server_url, local_song.song.meta.song_id);
-        if (origin.value_or(title_upload_mapping::mapping_origin::downloaded) !=
-            title_upload_mapping::mapping_origin::owned_upload) {
+        const std::optional<local_content_index::online_song_binding> binding =
+            local_content_index::find_song_by_local(index, server_url, local_song.song.meta.song_id);
+        if (!binding.has_value() || binding->origin != local_content_index::online_origin::owned_upload ||
+            binding->remote_song_id.empty()) {
             continue;
         }
 
-        const std::string remote_song_id = title_upload_mapping::find_remote_song_id(
-            mappings, server_url, local_song.song.meta.song_id).value_or(local_song.song.meta.song_id);
         const remote_song_lookup_result remote_song =
-            fetch_remote_song_by_id(remote_song_id, server_url);
+            fetch_remote_song_by_id(binding->remote_song_id, server_url);
         if (!remote_song.success) {
             continue;
         }
-        owned.push_back(build_owned_song_state(local_song, remote_song.song, remote_song.server_url));
+        owned.push_back(build_owned_song_state(local_song, remote_song.song, remote_song.server_url, index));
     }
 
     std::sort(owned.begin(), owned.end(), [](const song_entry_state& left, const song_entry_state& right) {
@@ -455,8 +464,11 @@ catalog_load_result load_catalog_result() {
     result.community_has_more = community_page.success &&
                                 static_cast<int>(community_page.songs.size()) < community_page.total;
 
-    const local_song_lookup official_lookup = build_local_lookup(local_catalog.songs, official_page.server_url);
-    const local_song_lookup community_lookup = build_local_lookup(local_catalog.songs, community_page.server_url);
+    const local_content_index::snapshot index = local_content_index::load_snapshot();
+    const local_song_lookup official_lookup =
+        build_local_lookup(local_catalog.songs, official_page.server_url, index);
+    const local_song_lookup community_lookup =
+        build_local_lookup(local_catalog.songs, community_page.server_url, index);
     for (const remote_song_payload& song : official_page.songs) {
         result.official_songs.push_back(build_song_state(song, official_page.server_url, official_lookup));
     }
@@ -694,7 +706,8 @@ bool poll_song_page(state& state) {
         return true;
     }
 
-    const local_song_lookup local_lookup = build_local_lookup(state.local_songs, page_result.server_url);
+    const local_content_index::snapshot index = local_content_index::load_snapshot();
+    const local_song_lookup local_lookup = build_local_lookup(state.local_songs, page_result.server_url, index);
     std::vector<song_entry_state> page_items;
     page_items.reserve(page_result.songs.size());
     for (const remote_song_payload& song : page_result.songs) {

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -16,11 +16,10 @@
 #include <vector>
 
 #include "app_paths.h"
-#include "chart_identity_store.h"
 #include "network/json_helpers.h"
 #include "path_utils.h"
+#include "title/local_content_index.h"
 #include "title/online_download_remote_client.h"
-#include "title/upload_mapping_store.h"
 #include "ui_notice.h"
 
 namespace title_online_view {
@@ -114,8 +113,11 @@ download_song_result download_song_package(const song_entry_state song,
                                            const std::shared_ptr<download_progress_state>& progress) {
     download_song_result result;
     result.song_id = song.song.song.meta.song_id;
+    const std::string local_song_id = song.installed_local_song_id.empty()
+        ? result.song_id
+        : song.installed_local_song_id;
 
-    if (server_url.empty() || result.song_id.empty()) {
+    if (server_url.empty() || result.song_id.empty() || local_song_id.empty()) {
         result.message = "Missing song download information.";
         return result;
     }
@@ -189,7 +191,7 @@ download_song_result download_song_package(const song_entry_state song,
     }
 
     app_paths::ensure_directories();
-    const std::filesystem::path song_dir = app_paths::song_dir(result.song_id);
+    const std::filesystem::path song_dir = app_paths::song_dir(local_song_id);
     const std::filesystem::path song_json_path = song_dir / "song.json";
     const std::filesystem::path audio_path = song_dir / path_utils::from_utf8(audio_file);
     const std::filesystem::path jacket_path = song_dir / path_utils::from_utf8(jacket_file);
@@ -210,10 +212,18 @@ download_song_result download_song_package(const song_entry_state song,
         return result;
     }
 
-    title_upload_mapping::store mappings = title_upload_mapping::load();
-    title_upload_mapping::put_song(mappings, server_url, result.song_id, result.song_id,
-                                   title_upload_mapping::mapping_origin::downloaded);
-    title_upload_mapping::save(mappings);
+    const local_content_index::online_origin origin =
+        [&]() {
+            const std::optional<local_content_index::online_song_binding> binding =
+                local_content_index::find_song_by_local(server_url, local_song_id);
+            return binding.has_value() ? binding->origin : local_content_index::online_origin::downloaded;
+        }();
+    local_content_index::put_song_binding({
+        .server_url = server_url,
+        .local_song_id = local_song_id,
+        .remote_song_id = result.song_id,
+        .origin = origin,
+    });
 
     result.success = true;
     result.message = "Song downloaded.";
@@ -280,19 +290,24 @@ download_song_result download_chart_file(const song_entry_state song,
         result.message = error_message;
         return result;
     }
-    chart_identity::put(local_chart_id, local_song_id);
+    local_content_index::link_chart_to_song(local_chart_id, local_song_id);
 
-    if (local_song_id != result.song_id || local_chart_id != result.chart_id) {
-        title_upload_mapping::store mappings = title_upload_mapping::load();
-        if (!title_upload_mapping::find_song_origin(mappings, server_url, local_song_id).has_value()) {
-            title_upload_mapping::put_song(mappings, server_url, local_song_id, result.song_id,
-                                           title_upload_mapping::mapping_origin::downloaded);
-        }
-        title_upload_mapping::put_chart(mappings, server_url, local_chart_id, local_song_id,
-                                        result.chart_id, result.song_id,
-                                        title_upload_mapping::mapping_origin::downloaded);
-        title_upload_mapping::save(mappings);
+    if (!local_content_index::find_song_by_local(server_url, local_song_id).has_value()) {
+        local_content_index::put_song_binding({
+            .server_url = server_url,
+            .local_song_id = local_song_id,
+            .remote_song_id = result.song_id,
+            .origin = local_content_index::online_origin::downloaded,
+        });
     }
+    local_content_index::put_chart_binding({
+        .server_url = server_url,
+        .local_chart_id = local_chart_id,
+        .local_song_id = local_song_id,
+        .remote_chart_id = result.chart_id,
+        .remote_song_id = result.song_id,
+        .origin = local_content_index::online_origin::downloaded,
+    });
 
     result.success = true;
     result.message = "Chart downloaded.";

--- a/src/scenes/title/upload_mapping_store.cpp
+++ b/src/scenes/title/upload_mapping_store.cpp
@@ -72,6 +72,16 @@ mapping_origin parse_origin(const std::string& value) {
     return mapping_origin::owned_upload;
 }
 
+mapping_origin merge_origin(mapping_origin current, mapping_origin incoming) {
+    if (current == mapping_origin::owned_upload) {
+        return current;
+    }
+    if (current == mapping_origin::downloaded && incoming == mapping_origin::linked) {
+        return current;
+    }
+    return incoming;
+}
+
 std::string serialize_plaintext(const store& mappings) {
     std::ostringstream output;
     output << kHeader << '\n';
@@ -355,7 +365,7 @@ void put_song(store& mappings,
                            chart_entry.local_song_id == local_song_id;
                 });
             }
-            entry.origin = origin;
+            entry.origin = merge_origin(entry.origin, origin);
             break;
         }
     }
@@ -386,7 +396,7 @@ void put_chart(store& mappings,
             entry.local_song_id = local_song_id;
             entry.remote_chart_id = remote_chart_id;
             entry.remote_song_id = remote_song_id;
-            entry.origin = origin;
+            entry.origin = merge_origin(entry.origin, origin);
             return;
         }
     }

--- a/src/scenes/virtual_screen.cpp
+++ b/src/scenes/virtual_screen.cpp
@@ -94,6 +94,29 @@ void draw_to_screen(bool use_alpha) {
     const Rectangle source = {0.0f, 0.0f, source_w, -source_h};
     const Rectangle dest = {offset_x, offset_y, dest_w, dest_h};
 
+    if (!use_alpha) {
+        if (offset_y > 0.0f) {
+            DrawTexturePro(target.texture,
+                           {0.0f, 0.0f, source_w, -1.0f},
+                           {0.0f, 0.0f, screen_w, offset_y},
+                           {0.0f, 0.0f}, 0.0f, WHITE);
+            DrawTexturePro(target.texture,
+                           {0.0f, source_h - 1.0f, source_w, -1.0f},
+                           {0.0f, offset_y + dest_h, screen_w, screen_h - offset_y - dest_h},
+                           {0.0f, 0.0f}, 0.0f, WHITE);
+        }
+        if (offset_x > 0.0f) {
+            DrawTexturePro(target.texture,
+                           {0.0f, 0.0f, 1.0f, -source_h},
+                           {0.0f, offset_y, offset_x, dest_h},
+                           {0.0f, 0.0f}, 0.0f, WHITE);
+            DrawTexturePro(target.texture,
+                           {source_w - 1.0f, 0.0f, 1.0f, -source_h},
+                           {offset_x + dest_w, offset_y, screen_w - offset_x - dest_w, dest_h},
+                           {0.0f, 0.0f}, 0.0f, WHITE);
+        }
+    }
+
     const Color tint = use_alpha ? WHITE : WHITE;
     DrawTexturePro(target.texture, source, dest, {0.0f, 0.0f}, 0.0f, tint);
 }

--- a/src/tests/local_catalog_database_smoke.cpp
+++ b/src/tests/local_catalog_database_smoke.cpp
@@ -1,0 +1,95 @@
+#include "app_paths.h"
+#include "song_select/local_catalog_database.h"
+
+#include <cassert>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+
+#ifdef _WIN32
+#include <stdlib.h>
+#endif
+
+namespace fs = std::filesystem;
+
+bool set_local_app_data(const fs::path& path) {
+#ifdef _WIN32
+    return _putenv_s("LOCALAPPDATA", path.string().c_str()) == 0;
+#else
+    return setenv("LOCALAPPDATA", path.string().c_str(), 1) == 0;
+#endif
+}
+
+song_select::chart_option make_chart(const char* chart_id, const char* song_id, const fs::path& path) {
+    song_select::chart_option chart;
+    chart.path = path.string();
+    chart.meta.chart_id = chart_id;
+    chart.meta.song_id = song_id;
+    chart.meta.difficulty = "Hard";
+    chart.meta.level = 7.5f;
+    chart.meta.key_count = 4;
+    chart.meta.chart_author = "tester";
+    chart.meta.format_version = 2;
+    chart.note_count = 123;
+    chart.min_bpm = 140.0f;
+    chart.max_bpm = 190.0f;
+    chart.status = content_status::community;
+    return chart;
+}
+
+song_select::song_entry make_song(const fs::path& song_dir, const fs::path& chart_path) {
+    song_select::song_entry song;
+    song.song.meta.song_id = "song-a";
+    song.song.meta.title = "Alpha";
+    song.song.meta.artist = "Artist";
+    song.song.meta.audio_file = "audio.ogg";
+    song.song.meta.jacket_file = "jacket.png";
+    song.song.meta.base_bpm = 128.0f;
+    song.song.meta.preview_start_ms = 12000;
+    song.song.meta.preview_start_seconds = 12.0f;
+    song.song.meta.song_version = 3;
+    song.song.directory = song_dir.string();
+    song.status = content_status::community;
+    song.charts.push_back(make_chart("chart-a", "song-a", chart_path));
+    song.song.chart_paths.push_back(chart_path.string());
+    return song;
+}
+
+int main() {
+    const fs::path temp_root = fs::temp_directory_path() / "raythm-local-catalog-db-smoke";
+    std::error_code ec;
+    fs::remove_all(temp_root, ec);
+    assert(set_local_app_data(temp_root));
+
+    const fs::path song_dir = app_paths::song_dir("song-a");
+    const fs::path chart_dir = song_dir / "charts";
+    const fs::path chart_path = chart_dir / "chart-a.rchart";
+    fs::create_directories(chart_dir, ec);
+    {
+        std::ofstream(song_dir / "song.json") << "{}";
+        std::ofstream(song_dir / "audio.ogg") << "audio";
+        std::ofstream(song_dir / "jacket.png") << "jacket";
+        std::ofstream(chart_path) << "chart";
+    }
+
+    song_select::local_catalog_database::replace_catalog({make_song(song_dir, chart_path)});
+
+    song_select::catalog_data cached = song_select::local_catalog_database::load_cached_catalog();
+    assert(cached.songs.size() == 1);
+    assert(cached.songs[0].song.meta.song_id == "song-a");
+    assert(cached.songs[0].song.meta.preview_start_seconds == 12.0f);
+    assert(cached.songs[0].status == content_status::community);
+    assert(cached.songs[0].charts.size() == 1);
+    assert(cached.songs[0].charts[0].meta.chart_id == "chart-a");
+    assert(cached.songs[0].charts[0].min_bpm == 140.0f);
+    assert(cached.songs[0].charts[0].max_bpm == 190.0f);
+    assert(cached.songs[0].charts[0].status == content_status::community);
+    assert(cached.songs[0].song.chart_paths.size() == 1);
+
+    std::ofstream(chart_dir / "chart-b.rchart") << "new chart";
+    cached = song_select::local_catalog_database::load_cached_catalog();
+    assert(cached.songs.empty());
+
+    fs::remove_all(temp_root, ec);
+    return 0;
+}

--- a/src/tests/song_loader_smoke.cpp
+++ b/src/tests/song_loader_smoke.cpp
@@ -85,6 +85,26 @@ std::filesystem::path write_temp_song_without_embedded_id() {
     return song_dir;
 }
 
+std::filesystem::path write_temp_song_with_legacy_preview_fields() {
+    const std::filesystem::path song_dir =
+        std::filesystem::temp_directory_path() / "raythm_song_loader_legacy_preview";
+    std::error_code ec;
+    std::filesystem::remove_all(song_dir, ec);
+    std::filesystem::create_directories(song_dir);
+    std::ofstream output(song_dir / "song.json", std::ios::trunc);
+    output << "{\n"
+           << "  \"title\": \"Preview Priority Song\",\n"
+           << "  \"artist\": \"Codex\",\n"
+           << "  \"baseBpm\": 120,\n"
+           << "  \"audioFile\": \"audio.ogg\",\n"
+           << "  \"jacketFile\": \"jacket.png\",\n"
+           << "  \"chorusStartSeconds\": 9,\n"
+           << "  \"previewStartSeconds\": 8,\n"
+           << "  \"songVersion\": 1\n"
+           << "}\n";
+    return song_dir;
+}
+
 std::filesystem::path write_external_chart_without_song_id() {
     const std::filesystem::path charts_dir =
         std::filesystem::temp_directory_path() / "raythm_song_loader_external_charts";
@@ -180,6 +200,15 @@ int main() {
         ok = false;
     }
     std::filesystem::remove_all(temp_song);
+
+    const std::filesystem::path legacy_preview_song = write_temp_song_with_legacy_preview_fields();
+    const song_load_result legacy_preview_result = song_loader::load_directory(legacy_preview_song.string());
+    if (!legacy_preview_result.songs.empty() ||
+        legacy_preview_result.errors.empty()) {
+        std::cerr << "Expected legacy preview fields without previewStartMs to be rejected\n";
+        ok = false;
+    }
+    std::filesystem::remove_all(legacy_preview_song);
 
     const std::filesystem::path written_song_dir =
         std::filesystem::temp_directory_path() / "raythm_song_writer_external_id";

--- a/src/tests/upload_mapping_store_smoke.cpp
+++ b/src/tests/upload_mapping_store_smoke.cpp
@@ -1,4 +1,5 @@
 #include "app_paths.h"
+#include "title/local_content_index.h"
 #include "title/upload_mapping_store.h"
 
 #include <cstdlib>
@@ -96,6 +97,72 @@ int main() {
     if (title_upload_mapping::find_chart_origin(legacy_loaded, "https://server.example", "legacy-local-chart") !=
         std::optional<title_upload_mapping::mapping_origin>(title_upload_mapping::mapping_origin::owned_upload)) {
         std::cerr << "legacy chart mapping should migrate as owned upload\n";
+        return 1;
+    }
+
+    local_content_index::put_song_binding({
+        .server_url = "https://server.example",
+        .local_song_id = "facade-local-song",
+        .remote_song_id = "facade-remote-song",
+        .origin = local_content_index::online_origin::downloaded,
+    });
+    local_content_index::put_song_binding({
+        .server_url = "https://mirror.example",
+        .local_song_id = "facade-local-song",
+        .remote_song_id = "mirror-remote-song",
+        .origin = local_content_index::online_origin::linked,
+    });
+    local_content_index::put_chart_binding({
+        .server_url = "https://server.example",
+        .local_chart_id = "facade-local-chart",
+        .local_song_id = "facade-local-song",
+        .remote_chart_id = "facade-remote-chart",
+        .remote_song_id = "facade-remote-song",
+        .origin = local_content_index::online_origin::downloaded,
+    });
+    local_content_index::put_chart_binding({
+        .server_url = "https://mirror.example",
+        .local_chart_id = "facade-local-chart",
+        .local_song_id = "facade-local-song",
+        .remote_chart_id = "mirror-remote-chart",
+        .remote_song_id = "mirror-remote-song",
+        .origin = local_content_index::online_origin::linked,
+    });
+    local_content_index::link_chart_to_song("facade-local-chart", "facade-local-song");
+
+    const std::optional<local_content_index::online_song_binding> facade_song =
+        local_content_index::find_song_by_local("https://server.example", "facade-local-song");
+    if (!facade_song.has_value() || facade_song->remote_song_id != "facade-remote-song" ||
+        facade_song->origin != local_content_index::online_origin::downloaded) {
+        std::cerr << "facade song mapping missing\n";
+        return 1;
+    }
+
+    const std::optional<local_content_index::online_chart_binding> facade_chart =
+        local_content_index::find_chart_by_remote("https://server.example", "facade-remote-chart");
+    if (!facade_chart.has_value() || facade_chart->local_chart_id != "facade-local-chart" ||
+        facade_chart->remote_song_id != "facade-remote-song") {
+        std::cerr << "facade chart mapping missing\n";
+        return 1;
+    }
+
+    if (local_content_index::linked_song_for_chart("facade-local-chart") !=
+        std::optional<std::string>("facade-local-song")) {
+        std::cerr << "facade chart identity missing\n";
+        return 1;
+    }
+
+    local_content_index::remove_chart_bindings("facade-local-chart");
+    if (local_content_index::find_chart_by_local("https://server.example", "facade-local-chart").has_value() ||
+        local_content_index::find_chart_by_local("https://mirror.example", "facade-local-chart").has_value()) {
+        std::cerr << "facade chart mapping should be removed from all servers\n";
+        return 1;
+    }
+
+    local_content_index::remove_song_bindings("facade-local-song");
+    if (local_content_index::find_song_by_local("https://server.example", "facade-local-song").has_value() ||
+        local_content_index::find_song_by_local("https://mirror.example", "facade-local-song").has_value()) {
+        std::cerr << "facade song mapping should be removed from all servers\n";
         return 1;
     }
 


### PR DESCRIPTION
## 概要
- ローカルコンテンツ管理用のSQLite基盤を追加
- 楽曲/譜面カタログ、オンライン紐づけ、譜面と楽曲の対応、コンテンツ検証キャッシュをDB管理へ移行
- 単体参照系をDB直引きへ変更し、全件ロード依存を削減
- 曲選択キャッシュ復元時のBPM欠落とOfficial順ソート崩れを修正
- PreviewTime仕様を`previewStartMs`へ一本化

## 確認
- `cmake --build cmake-build-codex --target raythm local_catalog_database_smoke song_loader_smoke upload_mapping_store_smoke ranking_service_smoke editor_flow_controller_smoke --config Debug`
- `./cmake-build-codex/local_catalog_database_smoke.exe`
- `./cmake-build-codex/song_loader_smoke.exe`
- `./cmake-build-codex/upload_mapping_store_smoke.exe`
- `./cmake-build-codex/ranking_service_smoke.exe`
- `./cmake-build-codex/editor_flow_controller_smoke.exe`
- `git diff --check`