### PR TITLE
プライバシーポリシーの英語版をデフォルトにする

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/docs/privacy-policy/index.html
+++ b/docs/privacy-policy/index.html
@@ -1,10 +1,12 @@
 <!doctype html>
-<html lang="ja">
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>プライバシーポリシー | raythm</title>
-  <meta name="description" content="raythm のプライバシーポリシーです。">
+  <title>Privacy Policy | raythm</title>
+  <meta name="description" content="Privacy Policy for raythm.">
+  <link rel="alternate" hreflang="en" href="https://rofutok112.github.io/raythm/privacy-policy/">
+  <link rel="alternate" hreflang="ja" href="https://rofutok112.github.io/raythm/privacy-policy/ja/">
   <link rel="stylesheet" href="../styles.css">
   <link rel="icon" href="../assets/raythm-icon.png">
 </head>
@@ -16,7 +18,8 @@
         <span>raythm</span>
       </a>
       <div class="nav-links">
-        <a href="../privacy-policy/">プライバシーポリシー</a>
+        <a href="./">English</a>
+        <a href="./ja/">日本語</a>
         <a href="https://github.com/Rofutok112/raythm">GitHub</a>
       </div>
     </nav>
@@ -34,7 +37,7 @@
         <div class="hero-body">
           <p class="eyebrow">Privacy Policy</p>
           <h1>privacy<span>.txt</span></h1>
-          <p class="lead">raythm は、サービスの提供に必要な範囲でユーザー情報を取り扱い、目的外の利用を行わないよう努めます。</p>
+          <p class="lead">raythm handles user information only within the scope necessary to provide the service and strives not to use it for unrelated purposes.</p>
           <p class="command-line"><span>&gt; scope</span><strong> client / server / pages</strong></p>
         </div>
       </div>
@@ -46,9 +49,9 @@
           <span class="terminal-name">status</span>
         </div>
         <ul class="status-list">
-          <li><span class="status-mark"></span><span>最終更新日: 2026年4月29日</span></li>
-          <li><span class="status-mark"></span><span>適用対象: raythm クライアント、raythm-Server、GitHub Pages 上の本サイト</span></li>
-          <li><span class="status-mark"></span><span>お問い合わせ: GitHub Issues / 個人情報を含む連絡先は正式公開前に設定</span></li>
+          <li><span class="status-mark"></span><span>Last updated: April 29, 2026</span></li>
+          <li><span class="status-mark"></span><span>Applies to: the raythm client, raythm-Server, and this GitHub Pages site</span></li>
+          <li><span class="status-mark"></span><span>Contact: GitHub Issues / a private contact address should be set before public release</span></li>
         </ul>
       </aside>
     </section>
@@ -57,100 +60,100 @@
       <article class="article">
         <div class="article-header">
           <span>&gt; cat privacy-policy.md</span>
-          <span class="meta">制定日: 2026年4月29日 / 最終更新日: 2026年4月29日</span>
+          <span class="meta">Effective date: April 29, 2026 / Last updated: April 29, 2026</span>
         </div>
 
         <section class="section-block">
-          <h2 data-step="01">適用範囲</h2>
-          <p>本ポリシーは、リズムゲーム「raythm」および関連するオンライン機能、raythm-Server、GitHub Pages 上で公開する本サイトに適用されます。</p>
-          <p>ユーザーが外部サイト、外部サービス、または投稿コンテンツ内の外部リンクを利用する場合、その外部サービスにおける情報の取り扱いは各サービスのポリシーに従います。</p>
+          <h2 data-step="01">Scope</h2>
+          <p>This Privacy Policy applies to the rhythm game "raythm", its related online features, raythm-Server, and this site published on GitHub Pages.</p>
+          <p>If users access external websites, external services, or external links included in posted content, the handling of information by those services is governed by their own policies.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="02">取得する情報</h2>
-          <p>raythm は、機能の提供に必要な範囲で次の情報を取得または保存することがあります。</p>
+          <h2 data-step="02">Information We Collect</h2>
+          <p>raythm may collect or store the following information within the scope necessary to provide its features.</p>
           <ul>
-            <li>アカウント情報: メールアドレス、表示名、パスワード、メール認証状態、認証コードの確認結果</li>
-            <li>認証情報: アクセストークン、リフレッシュトークン、信頼済み端末トークン</li>
-            <li>ランキング情報: 譜面 ID、楽曲 ID、プレイ日時、送信日時、判定結果、判定ごとのオフセット、スコア、精度、最大コンボ、クリアランク、フルコンボ状態</li>
-            <li>コミュニティ投稿情報: 楽曲名、アーティスト名、BPM、音声ファイル、ジャケット画像、外部リンク、譜面ファイル、難易度名、譜面作者名、公開状態</li>
-            <li>ダウンロードおよびカタログ情報: 楽曲・譜面の一覧取得、詳細取得、ファイル取得に必要なリクエスト情報</li>
-            <li>通信時に自動的に送信される情報: IP アドレス、User-Agent、アクセス日時、リクエスト先 URL、通信エラー情報など、サーバー運用上一般的に記録される情報</li>
-            <li>ローカル保存情報: 設定、ローカルランキング、インポートした楽曲・譜面・MV、ログインセッション、オンラインコンテンツとの紐付け情報</li>
+            <li>Account information: email address, display name, password, email verification status, and verification code results</li>
+            <li>Authentication information: access tokens, refresh tokens, and trusted device tokens</li>
+            <li>Ranking information: chart ID, song ID, play time, submission time, note judgement results, offset values for each judgement, score, accuracy, max combo, clear rank, and full-combo status</li>
+            <li>Community upload information: song title, artist name, BPM, audio files, jacket images, external links, chart files, difficulty names, chart author names, and visibility status</li>
+            <li>Download and catalog information: request information needed to list, view, and download songs, charts, and related files</li>
+            <li>Information automatically sent during communication: IP address, User-Agent, access time, requested URL, communication error information, and similar information commonly recorded for server operations</li>
+            <li>Locally stored information: settings, local rankings, imported songs, charts, MVs, login sessions, and mappings between local content and online content</li>
           </ul>
-          <p>本サイトは静的ページとして GitHub Pages で配信されます。本サイト自体では独自の入力フォームや独自のアクセス解析を設置していませんが、GitHub によりアクセスに関する情報が処理される場合があります。</p>
+          <p>This site is distributed as a static site through GitHub Pages. This site does not provide its own input forms or independent analytics, but GitHub may process access-related information.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="03">利用目的</h2>
-          <p>取得した情報は、次の目的で利用します。</p>
+          <h2 data-step="03">Purposes of Use</h2>
+          <p>Collected information is used for the following purposes.</p>
           <ul>
-            <li>アカウント登録、ログイン、ログアウト、メール認証、セッション復元、アカウント削除を行うため</li>
-            <li>オンラインランキングの送信、検証、表示、自己ベスト管理を行うため</li>
-            <li>公式譜面の整合性確認、スコアルールの取得、ランキング不正対策を行うため</li>
-            <li>コミュニティ楽曲・譜面の投稿、更新、削除、公開、ダウンロードを行うため</li>
-            <li>プロフィール画面で投稿コンテンツやランキング履歴を表示するため</li>
-            <li>不具合調査、セキュリティ対策、不正利用の防止、サービス改善を行うため</li>
-            <li>お問い合わせへの回答、重要なお知らせ、ポリシー変更の告知を行うため</li>
+            <li>To provide account registration, login, logout, email verification, session restoration, and account deletion</li>
+            <li>To submit, verify, display, and manage online rankings and personal bests</li>
+            <li>To verify official chart integrity, retrieve scoring rules, and help prevent ranking abuse</li>
+            <li>To upload, update, delete, publish, and download community songs and charts</li>
+            <li>To display uploaded content and ranking history in profile views</li>
+            <li>To investigate defects, improve security, prevent misuse, and improve the service</li>
+            <li>To respond to inquiries and provide important notices or policy change notices</li>
           </ul>
         </section>
 
         <section class="section-block">
-          <h2 data-step="04">公開される情報</h2>
-          <p>オンライン機能を利用した場合、次の情報が他のユーザーから閲覧できる状態になることがあります。</p>
+          <h2 data-step="04">Information That May Be Public</h2>
+          <p>When users use online features, the following information may be visible to other users.</p>
           <ul>
-            <li>ランキングに表示される表示名、順位、スコア、精度、最大コンボ、クリアランク、フルコンボ状態、プレイ日時</li>
-            <li>公開状態で投稿した楽曲・譜面のメタデータ、音声ファイル、ジャケット画像、譜面ファイル、外部リンク、投稿者に紐付く情報</li>
+            <li>Ranking information such as display name, placement, score, accuracy, max combo, clear rank, full-combo status, and play time</li>
+            <li>Metadata, audio files, jacket images, chart files, external links, and uploader-related information for songs and charts posted with public visibility</li>
           </ul>
-          <p>メールアドレス、パスワード、認証トークンは、ランキング表示やカタログ表示のために公開しません。</p>
+          <p>Email addresses, passwords, and authentication tokens are not made public for ranking or catalog display.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="05">第三者提供および外部サービス</h2>
-          <p>raythm は、法令に基づく場合、ユーザーの同意がある場合、またはサービス運営に必要な委託先・ホスティング先に必要な範囲で取り扱わせる場合を除き、個人情報を第三者へ提供しません。</p>
-          <p>本サイトは GitHub Pages により配信されます。GitHub による情報の取り扱いについては、GitHub のプライバシー関連文書をご確認ください。</p>
+          <h2 data-step="05">Third-Party Sharing and External Services</h2>
+          <p>raythm does not provide personal information to third parties except when required by law, with user consent, or when information must be handled by service providers or hosting providers within the scope necessary for service operation.</p>
+          <p>This site is hosted through GitHub Pages. Please refer to GitHub's privacy-related documents for information about GitHub's handling of data.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="06">保存期間</h2>
-          <p>アカウント情報、ランキング情報、投稿コンテンツは、サービス提供に必要な期間、またはユーザーから削除依頼・削除操作が行われるまで保存されます。アカウント削除が行われた場合、関連情報はサービス運営上必要な範囲を除き削除または識別できない形にするよう努めます。</p>
-          <p>ローカル保存情報はユーザーの端末に保存されます。アンインストール、端末内のデータ削除、またはゲーム内の削除操作により削除できる場合があります。</p>
+          <h2 data-step="06">Retention Period</h2>
+          <p>Account information, ranking information, and uploaded content are retained for as long as necessary to provide the service, or until the user requests deletion or performs a deletion action. When an account is deleted, related information will be deleted or de-identified except where retention is necessary for service operation.</p>
+          <p>Locally stored information is stored on the user's device. It may be deleted by uninstalling the application, deleting local data on the device, or using deletion features in the game where available.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="07">安全管理</h2>
-          <p>raythm は、取り扱う情報について、不正アクセス、紛失、改ざん、漏えいを防ぐため、必要かつ適切な安全管理に努めます。認証情報やローカルランキングなど、一部のローカル保存情報は端末側の保護機能を利用して保存される場合があります。</p>
-          <p>ただし、インターネット通信や端末上の保存に絶対的な安全性はありません。ユーザーは、パスワードの使い回しを避け、端末とアカウントを適切に管理してください。</p>
+          <h2 data-step="07">Security</h2>
+          <p>raythm strives to take necessary and appropriate measures to prevent unauthorized access, loss, alteration, or leakage of handled information. Some locally stored information, such as authentication information and local rankings, may be stored using device-side protection features.</p>
+          <p>However, no internet communication or device storage can be guaranteed to be absolutely secure. Users should avoid reusing passwords and should manage their devices and accounts appropriately.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="08">ユーザーの操作と請求</h2>
-          <p>ユーザーは、ゲーム内の機能により、ログアウト、アカウント削除、投稿したコミュニティ楽曲・譜面の削除を行える場合があります。</p>
-          <p>自身の情報の確認、訂正、削除、利用停止などを希望する場合は、下記のお問い合わせ先からご連絡ください。本人確認のため、必要な情報の提示をお願いすることがあります。</p>
+          <h2 data-step="08">User Controls and Requests</h2>
+          <p>Users may be able to log out, delete their account, and delete community songs or charts they uploaded through in-game features.</p>
+          <p>If you wish to request access, correction, deletion, suspension of use, or similar handling of your information, please contact us using the contact information below. We may ask you to provide information necessary to verify your identity.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="09">未成年の利用</h2>
-          <p>未成年のユーザーがオンライン機能、アカウント登録、コミュニティ投稿を利用する場合は、保護者の同意を得たうえで利用してください。</p>
+          <h2 data-step="09">Use by Minors</h2>
+          <p>Users who are minors should obtain consent from a parent or guardian before using online features, registering an account, or posting community content.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="10">ポリシーの変更</h2>
-          <p>本ポリシーは、機能追加、法令変更、運用方針の変更に応じて改定されることがあります。重要な変更がある場合は、本サイトまたはゲーム内の表示など、適切な方法でお知らせします。</p>
+          <h2 data-step="10">Changes to This Policy</h2>
+          <p>This Privacy Policy may be updated in response to feature additions, legal changes, or changes in operation policy. If there are important changes, we will provide notice through this site, in-game notices, or another appropriate method.</p>
         </section>
 
         <section class="section-block">
-          <h2 data-step="11">お問い合わせ</h2>
-          <p>本ポリシーおよび個人情報の取り扱いに関するお問い合わせは、以下からご連絡ください。</p>
+          <h2 data-step="11">Contact</h2>
+          <p>For inquiries about this Privacy Policy or the handling of personal information, please contact us through the following channel.</p>
           <ul>
-            <li>GitHub Issues: <a href="https://github.com/Rofutok112/raythm/issues">https://github.com/Rofutok112/raythm/issues</a>。公開される場所のため、メールアドレス、認証情報、その他の個人情報は記載しないでください。</li>
-            <li>個人情報を含むお問い合わせ先: 正式公開前に、運営者が管理するメールアドレス等を設定してください。</li>
+            <li>GitHub Issues: <a href="https://github.com/Rofutok112/raythm/issues">https://github.com/Rofutok112/raythm/issues</a>. This is a public location, so do not include email addresses, authentication information, or other personal information.</li>
+            <li>Contact for inquiries that include personal information: before public release, the operator should set up a managed email address or similar private contact method.</li>
           </ul>
         </section>
 
         <section class="section-block">
           <div class="note">
-          <p>このページは、raythm の現在の実装に基づくドラフトです。正式公開前に、運営者名、個人情報を含む問い合わせ先、サーバー側の保存期間、委託先、メール送信サービスなど、運用実態に合わせて確認してください。</p>
+            <p>This page is a draft based on the current implementation of raythm. Before public release, please verify the operator name, private contact method, server-side retention period, service providers, email delivery services, and other operational details.</p>
           </div>
         </section>
       </article>

--- a/docs/privacy-policy/ja/index.html
+++ b/docs/privacy-policy/ja/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>プライバシーポリシー | raythm</title>
+  <meta name="description" content="raythm のプライバシーポリシーです。">
+  <link rel="alternate" hreflang="en" href="https://rofutok112.github.io/raythm/privacy-policy/">
+  <link rel="alternate" hreflang="ja" href="https://rofutok112.github.io/raythm/privacy-policy/ja/">
+  <link rel="stylesheet" href="../../styles.css">
+  <link rel="icon" href="../../assets/raythm-icon.png">
+</head>
+<body>
+  <header class="site-header">
+    <nav class="nav" aria-label="Main navigation">
+      <a class="brand" href="../../">
+        <img src="../../assets/raythm-icon.png" alt="">
+        <span>raythm</span>
+      </a>
+      <div class="nav-links">
+        <a href="../">English</a>
+        <a href="./">日本語</a>
+        <a href="https://github.com/Rofutok112/raythm">GitHub</a>
+      </div>
+    </nav>
+  </header>
+
+  <main class="page-frame">
+    <section class="hero" aria-label="Privacy policy summary">
+      <div class="terminal-window">
+        <div class="terminal-titlebar">
+          <span class="dot r"></span>
+          <span class="dot y"></span>
+          <span class="dot g"></span>
+          <span class="terminal-name">raythm.policy</span>
+        </div>
+        <div class="hero-body">
+          <p class="eyebrow">Privacy Policy</p>
+          <h1>privacy<span>.txt</span></h1>
+          <p class="lead">raythm は、サービスの提供に必要な範囲でユーザー情報を取り扱い、目的外の利用を行わないよう努めます。</p>
+          <p class="command-line"><span>&gt; scope</span><strong> client / server / pages</strong></p>
+        </div>
+      </div>
+      <aside class="terminal-window hero-panel">
+        <div class="terminal-titlebar">
+          <span class="dot r"></span>
+          <span class="dot y"></span>
+          <span class="dot g"></span>
+          <span class="terminal-name">status</span>
+        </div>
+        <ul class="status-list">
+          <li><span class="status-mark"></span><span>最終更新日: 2026年4月29日</span></li>
+          <li><span class="status-mark"></span><span>適用対象: raythm クライアント、raythm-Server、GitHub Pages 上の本サイト</span></li>
+          <li><span class="status-mark"></span><span>お問い合わせ: GitHub Issues / 個人情報を含む連絡先は正式公開前に設定</span></li>
+        </ul>
+      </aside>
+    </section>
+
+    <section class="content">
+      <article class="article">
+        <div class="article-header">
+          <span>&gt; cat privacy-policy.md</span>
+          <span class="meta">制定日: 2026年4月29日 / 最終更新日: 2026年4月29日</span>
+        </div>
+
+        <section class="section-block">
+          <h2 data-step="01">適用範囲</h2>
+          <p>本ポリシーは、リズムゲーム「raythm」および関連するオンライン機能、raythm-Server、GitHub Pages 上で公開する本サイトに適用されます。</p>
+          <p>ユーザーが外部サイト、外部サービス、または投稿コンテンツ内の外部リンクを利用する場合、その外部サービスにおける情報の取り扱いは各サービスのポリシーに従います。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="02">取得する情報</h2>
+          <p>raythm は、機能の提供に必要な範囲で次の情報を取得または保存することがあります。</p>
+          <ul>
+            <li>アカウント情報: メールアドレス、表示名、パスワード、メール認証状態、認証コードの確認結果</li>
+            <li>認証情報: アクセストークン、リフレッシュトークン、信頼済み端末トークン</li>
+            <li>ランキング情報: 譜面 ID、楽曲 ID、プレイ日時、送信日時、判定結果、判定ごとのオフセット、スコア、精度、最大コンボ、クリアランク、フルコンボ状態</li>
+            <li>コミュニティ投稿情報: 楽曲名、アーティスト名、BPM、音声ファイル、ジャケット画像、外部リンク、譜面ファイル、難易度名、譜面作者名、公開状態</li>
+            <li>ダウンロードおよびカタログ情報: 楽曲・譜面の一覧取得、詳細取得、ファイル取得に必要なリクエスト情報</li>
+            <li>通信時に自動的に送信される情報: IP アドレス、User-Agent、アクセス日時、リクエスト先 URL、通信エラー情報など、サーバー運用上一般的に記録される情報</li>
+            <li>ローカル保存情報: 設定、ローカルランキング、インポートした楽曲・譜面・MV、ログインセッション、オンラインコンテンツとの紐付け情報</li>
+          </ul>
+          <p>本サイトは静的ページとして GitHub Pages で配信されます。本サイト自体では独自の入力フォームや独自のアクセス解析を設置していませんが、GitHub によりアクセスに関する情報が処理される場合があります。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="03">利用目的</h2>
+          <p>取得した情報は、次の目的で利用します。</p>
+          <ul>
+            <li>アカウント登録、ログイン、ログアウト、メール認証、セッション復元、アカウント削除を行うため</li>
+            <li>オンラインランキングの送信、検証、表示、自己ベスト管理を行うため</li>
+            <li>公式譜面の整合性確認、スコアルールの取得、ランキング不正対策を行うため</li>
+            <li>コミュニティ楽曲・譜面の投稿、更新、削除、公開、ダウンロードを行うため</li>
+            <li>プロフィール画面で投稿コンテンツやランキング履歴を表示するため</li>
+            <li>不具合調査、セキュリティ対策、不正利用の防止、サービス改善を行うため</li>
+            <li>お問い合わせへの回答、重要なお知らせ、ポリシー変更の告知を行うため</li>
+          </ul>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="04">公開される情報</h2>
+          <p>オンライン機能を利用した場合、次の情報が他のユーザーから閲覧できる状態になることがあります。</p>
+          <ul>
+            <li>ランキングに表示される表示名、順位、スコア、精度、最大コンボ、クリアランク、フルコンボ状態、プレイ日時</li>
+            <li>公開状態で投稿した楽曲・譜面のメタデータ、音声ファイル、ジャケット画像、譜面ファイル、外部リンク、投稿者に紐付く情報</li>
+          </ul>
+          <p>メールアドレス、パスワード、認証トークンは、ランキング表示やカタログ表示のために公開しません。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="05">第三者提供および外部サービス</h2>
+          <p>raythm は、法令に基づく場合、ユーザーの同意がある場合、またはサービス運営に必要な委託先・ホスティング先に必要な範囲で取り扱わせる場合を除き、個人情報を第三者へ提供しません。</p>
+          <p>本サイトは GitHub Pages により配信されます。GitHub による情報の取り扱いについては、GitHub のプライバシー関連文書をご確認ください。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="06">保存期間</h2>
+          <p>アカウント情報、ランキング情報、投稿コンテンツは、サービス提供に必要な期間、またはユーザーから削除依頼・削除操作が行われるまで保存されます。アカウント削除が行われた場合、関連情報はサービス運営上必要な範囲を除き削除または識別できない形にするよう努めます。</p>
+          <p>ローカル保存情報はユーザーの端末に保存されます。アンインストール、端末内のデータ削除、またはゲーム内の削除操作により削除できる場合があります。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="07">安全管理</h2>
+          <p>raythm は、取り扱う情報について、不正アクセス、紛失、改ざん、漏えいを防ぐため、必要かつ適切な安全管理に努めます。認証情報やローカルランキングなど、一部のローカル保存情報は端末側の保護機能を利用して保存される場合があります。</p>
+          <p>ただし、インターネット通信や端末上の保存に絶対的な安全性はありません。ユーザーは、パスワードの使い回しを避け、端末とアカウントを適切に管理してください。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="08">ユーザーの操作と請求</h2>
+          <p>ユーザーは、ゲーム内の機能により、ログアウト、アカウント削除、投稿したコミュニティ楽曲・譜面の削除を行える場合があります。</p>
+          <p>自身の情報の確認、訂正、削除、利用停止などを希望する場合は、下記のお問い合わせ先からご連絡ください。本人確認のため、必要な情報の提示をお願いすることがあります。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="09">未成年の利用</h2>
+          <p>未成年のユーザーがオンライン機能、アカウント登録、コミュニティ投稿を利用する場合は、保護者の同意を得たうえで利用してください。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="10">ポリシーの変更</h2>
+          <p>本ポリシーは、機能追加、法令変更、運用方針の変更に応じて改定されることがあります。重要な変更がある場合は、本サイトまたはゲーム内の表示など、適切な方法でお知らせします。</p>
+        </section>
+
+        <section class="section-block">
+          <h2 data-step="11">お問い合わせ</h2>
+          <p>本ポリシーおよび個人情報の取り扱いに関するお問い合わせは、以下からご連絡ください。</p>
+          <ul>
+            <li>GitHub Issues: <a href="https://github.com/Rofutok112/raythm/issues">https://github.com/Rofutok112/raythm/issues</a>。公開される場所のため、メールアドレス、認証情報、その他の個人情報は記載しないでください。</li>
+            <li>個人情報を含むお問い合わせ先: 正式公開前に、運営者が管理するメールアドレス等を設定してください。</li>
+          </ul>
+        </section>
+
+        <section class="section-block">
+          <div class="note">
+          <p>このページは、raythm の現在の実装に基づくドラフトです。正式公開前に、運営者名、個人情報を含む問い合わせ先、サーバー側の保存期間、委託先、メール送信サービスなど、運用実態に合わせて確認してください。</p>
+          </div>
+        </section>
+      </article>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <span>&copy; 2026 raythm project.</span>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## 概要
- /privacy-policy/ を英語版に変更
- 既存の日本語版を /privacy-policy/ja/ に移動
- 英語/日本語の切り替えリンクと hreflang を追加
- トップページの html lang を en に変更

## 確認
- Chrome + Playwright で docs/index.html、docs/privacy-policy/index.html、docs/privacy-policy/ja/index.html を 1280x900 / 390x844 で表示確認
- CSS 読み込み、画像読み込み、横スクロールなし、ページエラーなしを確認