### PR TITLE
プライバシーポリシーの連絡先メールを設定

### DIFF
--- a/docs/privacy-policy/index.html
+++ b/docs/privacy-policy/index.html
@@ -51,7 +51,7 @@
         <ul class="status-list">
           <li><span class="status-mark"></span><span>Last updated: April 29, 2026</span></li>
           <li><span class="status-mark"></span><span>Applies to: the raythm client, raythm-Server, and this GitHub Pages site</span></li>
-          <li><span class="status-mark"></span><span>Contact: GitHub Issues / a private contact address should be set before public release</span></li>
+          <li><span class="status-mark"></span><span>Contact: GitHub Issues / raythm.game@gmail.com for inquiries that include personal information</span></li>
         </ul>
       </aside>
     </section>
@@ -147,13 +147,13 @@
           <p>For inquiries about this Privacy Policy or the handling of personal information, please contact us through the following channel.</p>
           <ul>
             <li>GitHub Issues: <a href="https://github.com/Rofutok112/raythm/issues">https://github.com/Rofutok112/raythm/issues</a>. This is a public location, so do not include email addresses, authentication information, or other personal information.</li>
-            <li>Contact for inquiries that include personal information: before public release, the operator should set up a managed email address or similar private contact method.</li>
+            <li>Contact for inquiries that include personal information: <a href="mailto:raythm.game@gmail.com">raythm.game@gmail.com</a></li>
           </ul>
         </section>
 
         <section class="section-block">
           <div class="note">
-            <p>This page is a draft based on the current implementation of raythm. Before public release, please verify the operator name, private contact method, server-side retention period, service providers, email delivery services, and other operational details.</p>
+            <p>This page is a draft based on the current implementation of raythm. Before public release, please verify the operator name, server-side retention period, service providers, email delivery services, and other operational details.</p>
           </div>
         </section>
       </article>

--- a/docs/privacy-policy/ja/index.html
+++ b/docs/privacy-policy/ja/index.html
@@ -51,7 +51,7 @@
         <ul class="status-list">
           <li><span class="status-mark"></span><span>最終更新日: 2026年4月29日</span></li>
           <li><span class="status-mark"></span><span>適用対象: raythm クライアント、raythm-Server、GitHub Pages 上の本サイト</span></li>
-          <li><span class="status-mark"></span><span>お問い合わせ: GitHub Issues / 個人情報を含む連絡先は正式公開前に設定</span></li>
+          <li><span class="status-mark"></span><span>お問い合わせ: GitHub Issues / 個人情報を含む連絡は raythm.game@gmail.com</span></li>
         </ul>
       </aside>
     </section>
@@ -147,13 +147,13 @@
           <p>本ポリシーおよび個人情報の取り扱いに関するお問い合わせは、以下からご連絡ください。</p>
           <ul>
             <li>GitHub Issues: <a href="https://github.com/Rofutok112/raythm/issues">https://github.com/Rofutok112/raythm/issues</a>。公開される場所のため、メールアドレス、認証情報、その他の個人情報は記載しないでください。</li>
-            <li>個人情報を含むお問い合わせ先: 正式公開前に、運営者が管理するメールアドレス等を設定してください。</li>
+            <li>個人情報を含むお問い合わせ先: <a href="mailto:raythm.game@gmail.com">raythm.game@gmail.com</a></li>
           </ul>
         </section>
 
         <section class="section-block">
           <div class="note">
-          <p>このページは、raythm の現在の実装に基づくドラフトです。正式公開前に、運営者名、個人情報を含む問い合わせ先、サーバー側の保存期間、委託先、メール送信サービスなど、運用実態に合わせて確認してください。</p>
+          <p>このページは、raythm の現在の実装に基づくドラフトです。正式公開前に、運営者名、サーバー側の保存期間、委託先、メール送信サービスなど、運用実態に合わせて確認してください。</p>
           </div>
         </section>
       </article>


### PR DESCRIPTION
## 概要
- 英語版プライバシーポリシーに raythm.game@gmail.com を連絡先として設定
- 日本語版プライバシーポリシーにも同じ連絡先を設定
- 未設定のドラフト文言を整理

## 確認
- Chrome + Playwright で英語版 / 日本語版を 1280x900 / 390x844 で表示確認
- mailto:raythm.game@gmail.com、横スクロールなし、ページエラーなしを確認