### PR TITLE
Windows releaseのNSIS導入を安定化

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -32,12 +32,11 @@ jobs:
             mingw-w64-ucrt-x86_64-toolchain
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja
+            mingw-w64-ucrt-x86_64-nsis
 
-      - name: Install NSIS
-        shell: powershell
-        run: |
-          choco install nsis --no-progress -y
-          "${env:ProgramFiles(x86)}\NSIS" >> $env:GITHUB_PATH
+      - name: Verify NSIS
+        shell: msys2 {0}
+        run: makensis -VERSION
 
       - name: Compute release metadata
         id: meta


### PR DESCRIPTION
## 概要
- Windows Release workflow の NSIS 導入を Chocolatey から MSYS2 package に変更
- makensis -VERSION で NSIS が使えることを明示確認

## 確認
- git diff --check

## 補足
- Chocolatey community feed の 503 による nsis.install 解決失敗を避けるため、既存の MSYS2 setup に統合しています。