### PR TITLE
テキスト入力外ではIMEを閉じる

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@ int main() {
     bool was_window_focused = IsWindowFocused();
 
     while (!WindowShouldClose()) {
+        windows_input_source::instance().begin_frame();
         if (applied_target_fps != g_settings.target_fps) {
             SetTargetFPS(g_settings.target_fps);
             applied_target_fps = g_settings.target_fps;
@@ -74,6 +75,7 @@ int main() {
             static_cast<float>(GetScreenHeight())
         });
         EndDrawing();
+        windows_input_source::instance().end_frame();
     }
 
     save_settings(g_settings);

--- a/src/platform/windows_input_source.cpp
+++ b/src/platform/windows_input_source.cpp
@@ -93,6 +93,8 @@ public:
     }
 
     void shutdown() {
+        set_ime_context_enabled(true);
+
         std::scoped_lock lock(mutex_);
 
 #ifdef _WIN32
@@ -142,11 +144,11 @@ public:
             std::scoped_lock lock(mutex_);
             ime_requested_this_frame_ = true;
             should_enable_ime = !ime_context_enabled_;
-            ime_context_enabled_ = true;
         }
 
-        if (should_enable_ime) {
-            set_ime_context_enabled(true);
+        if (should_enable_ime && set_ime_context_enabled(true)) {
+            std::scoped_lock lock(mutex_);
+            ime_context_enabled_ = true;
         }
     }
 
@@ -157,13 +159,11 @@ public:
             const bool allow_text_input = ime_requested_this_frame_;
             ime_requested_this_frame_ = false;
             should_disable_ime = !allow_text_input && ime_context_enabled_;
-            if (should_disable_ime) {
-                ime_context_enabled_ = false;
-            }
         }
 
-        if (should_disable_ime) {
-            set_ime_context_enabled(false);
+        if (should_disable_ime && set_ime_context_enabled(false)) {
+            std::scoped_lock lock(mutex_);
+            ime_context_enabled_ = false;
         }
     }
 
@@ -219,15 +219,11 @@ public:
 
 private:
 #ifdef _WIN32
-    using imm_get_context_fn = HIMC(WINAPI*)(HWND);
     using imm_associate_context_fn = HIMC(WINAPI*)(HWND, HIMC);
-    using imm_release_context_fn = BOOL(WINAPI*)(HWND, HIMC);
 
     struct ime_functions {
         HMODULE module = nullptr;
-        imm_get_context_fn get_context = nullptr;
         imm_associate_context_fn associate_context = nullptr;
-        imm_release_context_fn release_context = nullptr;
         bool available = false;
     };
 
@@ -239,28 +235,21 @@ private:
                 return loaded;
             }
 
-            loaded.get_context =
-                reinterpret_cast<imm_get_context_fn>(GetProcAddress(loaded.module, "ImmGetContext"));
             loaded.associate_context =
                 reinterpret_cast<imm_associate_context_fn>(GetProcAddress(loaded.module, "ImmAssociateContext"));
-            loaded.release_context =
-                reinterpret_cast<imm_release_context_fn>(GetProcAddress(loaded.module, "ImmReleaseContext"));
-            loaded.available =
-                loaded.get_context != nullptr &&
-                loaded.associate_context != nullptr &&
-                loaded.release_context != nullptr;
+            loaded.available = loaded.associate_context != nullptr;
             return loaded;
         }();
         return functions;
     }
 
-    void set_ime_context_enabled(bool enabled) {
+    bool set_ime_context_enabled(bool enabled) {
         HWND hwnd = nullptr;
         HIMC restore_context = nullptr;
         {
             std::scoped_lock lock(mutex_);
             if (!installed_ || hwnd_ == nullptr) {
-                return;
+                return false;
             }
             hwnd = hwnd_;
             restore_context = saved_ime_context_;
@@ -269,12 +258,12 @@ private:
         // IME APIs may dispatch window messages. Never hold mutex_ while calling them.
         const ime_functions& functions = loaded_ime_functions();
         if (!functions.available) {
-            return;
+            return false;
         }
 
         if (enabled) {
             if (restore_context == nullptr) {
-                return;
+                return false;
             }
 
             HIMC previous_context = functions.associate_context(hwnd, restore_context);
@@ -284,12 +273,7 @@ private:
                     saved_ime_context_ = previous_context;
                 }
             }
-            return;
-        }
-
-        HIMC current_context = functions.get_context(hwnd);
-        if (current_context != nullptr) {
-            functions.release_context(hwnd, current_context);
+            return true;
         }
 
         HIMC previous_context = functions.associate_context(hwnd, nullptr);
@@ -297,6 +281,7 @@ private:
             std::scoped_lock lock(mutex_);
             saved_ime_context_ = previous_context;
         }
+        return true;
     }
 
     bool try_capture_event(UINT message, WPARAM w_param, LPARAM l_param) {
@@ -398,7 +383,8 @@ private:
     long long qpc_origin_ = 0;
     HIMC saved_ime_context_ = nullptr;
 #else
-    void set_ime_context_enabled(bool) {
+    bool set_ime_context_enabled(bool) {
+        return false;
     }
 #endif
 

--- a/src/platform/windows_input_source.cpp
+++ b/src/platform/windows_input_source.cpp
@@ -82,6 +82,9 @@ public:
         qpc_origin_ = origin.QuadPart;
         queued_events_.clear();
         sequence_ = 0;
+        ime_context_enabled_ = true;
+        ime_requested_this_frame_ = false;
+        saved_ime_context_ = nullptr;
 #else
         (void)native_window_handle;
 #endif
@@ -104,7 +107,7 @@ public:
 
         queued_events_.clear();
         test_mode_ = false;
-        ime_text_input_allowed_ = false;
+        ime_context_enabled_ = true;
         ime_requested_this_frame_ = false;
     }
 
@@ -134,23 +137,33 @@ public:
     }
 
     void request_text_input() {
-        std::scoped_lock lock(mutex_);
-        ime_requested_this_frame_ = true;
-        ime_text_input_allowed_ = true;
+        bool should_enable_ime = false;
+        {
+            std::scoped_lock lock(mutex_);
+            ime_requested_this_frame_ = true;
+            should_enable_ime = !ime_context_enabled_;
+            ime_context_enabled_ = true;
+        }
+
+        if (should_enable_ime) {
+            set_ime_context_enabled(true);
+        }
     }
 
     void end_frame() {
-        bool should_close_ime = false;
+        bool should_disable_ime = false;
         {
             std::scoped_lock lock(mutex_);
             const bool allow_text_input = ime_requested_this_frame_;
             ime_requested_this_frame_ = false;
-            ime_text_input_allowed_ = allow_text_input;
-            should_close_ime = !allow_text_input;
+            should_disable_ime = !allow_text_input && ime_context_enabled_;
+            if (should_disable_ime) {
+                ime_context_enabled_ = false;
+            }
         }
 
-        if (should_close_ime) {
-            close_ime();
+        if (should_disable_ime) {
+            set_ime_context_enabled(false);
         }
     }
 
@@ -207,14 +220,14 @@ public:
 private:
 #ifdef _WIN32
     using imm_get_context_fn = HIMC(WINAPI*)(HWND);
+    using imm_associate_context_fn = HIMC(WINAPI*)(HWND, HIMC);
     using imm_release_context_fn = BOOL(WINAPI*)(HWND, HIMC);
-    using imm_set_open_status_fn = BOOL(WINAPI*)(HIMC, BOOL);
 
     struct ime_functions {
         HMODULE module = nullptr;
         imm_get_context_fn get_context = nullptr;
+        imm_associate_context_fn associate_context = nullptr;
         imm_release_context_fn release_context = nullptr;
-        imm_set_open_status_fn set_open_status = nullptr;
         bool available = false;
     };
 
@@ -228,42 +241,62 @@ private:
 
             loaded.get_context =
                 reinterpret_cast<imm_get_context_fn>(GetProcAddress(loaded.module, "ImmGetContext"));
+            loaded.associate_context =
+                reinterpret_cast<imm_associate_context_fn>(GetProcAddress(loaded.module, "ImmAssociateContext"));
             loaded.release_context =
                 reinterpret_cast<imm_release_context_fn>(GetProcAddress(loaded.module, "ImmReleaseContext"));
-            loaded.set_open_status =
-                reinterpret_cast<imm_set_open_status_fn>(GetProcAddress(loaded.module, "ImmSetOpenStatus"));
             loaded.available =
                 loaded.get_context != nullptr &&
-                loaded.release_context != nullptr &&
-                loaded.set_open_status != nullptr;
+                loaded.associate_context != nullptr &&
+                loaded.release_context != nullptr;
             return loaded;
         }();
         return functions;
     }
 
-    void close_ime() {
+    void set_ime_context_enabled(bool enabled) {
         HWND hwnd = nullptr;
+        HIMC restore_context = nullptr;
         {
             std::scoped_lock lock(mutex_);
             if (!installed_ || hwnd_ == nullptr) {
                 return;
             }
             hwnd = hwnd_;
+            restore_context = saved_ime_context_;
         }
 
-        // ImmSetOpenStatus may dispatch window messages. Never hold mutex_ here.
+        // IME APIs may dispatch window messages. Never hold mutex_ while calling them.
         const ime_functions& functions = loaded_ime_functions();
         if (!functions.available) {
             return;
         }
 
-        HIMC context = functions.get_context(hwnd);
-        if (context == nullptr) {
+        if (enabled) {
+            if (restore_context == nullptr) {
+                return;
+            }
+
+            HIMC previous_context = functions.associate_context(hwnd, restore_context);
+            {
+                std::scoped_lock lock(mutex_);
+                if (previous_context != nullptr && previous_context != restore_context) {
+                    saved_ime_context_ = previous_context;
+                }
+            }
             return;
         }
 
-        functions.set_open_status(context, FALSE);
-        functions.release_context(hwnd, context);
+        HIMC current_context = functions.get_context(hwnd);
+        if (current_context != nullptr) {
+            functions.release_context(hwnd, current_context);
+        }
+
+        HIMC previous_context = functions.associate_context(hwnd, nullptr);
+        if (previous_context != nullptr) {
+            std::scoped_lock lock(mutex_);
+            saved_ime_context_ = previous_context;
+        }
     }
 
     bool try_capture_event(UINT message, WPARAM w_param, LPARAM l_param) {
@@ -363,8 +396,9 @@ private:
     WNDPROC previous_wnd_proc_ = nullptr;
     long long qpc_frequency_ = 0;
     long long qpc_origin_ = 0;
+    HIMC saved_ime_context_ = nullptr;
 #else
-    void close_ime() {
+    void set_ime_context_enabled(bool) {
     }
 #endif
 
@@ -373,7 +407,7 @@ private:
     std::uint64_t sequence_ = 0;
     bool test_mode_ = false;
     bool installed_ = false;
-    bool ime_text_input_allowed_ = false;
+    bool ime_context_enabled_ = true;
     bool ime_requested_this_frame_ = false;
     double test_current_time_ms_ = 0.0;
 };

--- a/src/platform/windows_input_source.cpp
+++ b/src/platform/windows_input_source.cpp
@@ -104,6 +104,8 @@ public:
 
         queued_events_.clear();
         test_mode_ = false;
+        ime_text_input_allowed_ = false;
+        ime_requested_this_frame_ = false;
     }
 
     bool is_available() const {
@@ -124,6 +126,37 @@ public:
 #endif
 
         return test_current_time_ms_;
+    }
+
+    void begin_frame() {
+        std::scoped_lock lock(mutex_);
+        ime_requested_this_frame_ = false;
+        if (!ime_text_input_allowed_) {
+            close_ime_locked();
+        }
+    }
+
+    void request_text_input() {
+        std::scoped_lock lock(mutex_);
+        ime_requested_this_frame_ = true;
+        ime_text_input_allowed_ = true;
+    }
+
+    void end_frame() {
+        std::scoped_lock lock(mutex_);
+        const bool allow_text_input = ime_requested_this_frame_;
+        ime_requested_this_frame_ = false;
+        if (ime_text_input_allowed_ == allow_text_input) {
+            if (!allow_text_input) {
+                close_ime_locked();
+            }
+            return;
+        }
+
+        ime_text_input_allowed_ = allow_text_input;
+        if (!ime_text_input_allowed_) {
+            close_ime_locked();
+        }
     }
 
     std::vector<native_key_event> drain_events() {
@@ -178,6 +211,49 @@ public:
 
 private:
 #ifdef _WIN32
+    using imm_get_context_fn = HIMC(WINAPI*)(HWND);
+    using imm_release_context_fn = BOOL(WINAPI*)(HWND, HIMC);
+    using imm_set_open_status_fn = BOOL(WINAPI*)(HIMC, BOOL);
+
+    void load_ime_functions_locked() {
+        if (ime_load_attempted_) {
+            return;
+        }
+        ime_load_attempted_ = true;
+        imm32_ = LoadLibraryW(L"imm32.dll");
+        if (imm32_ == nullptr) {
+            return;
+        }
+
+        imm_get_context_ = reinterpret_cast<imm_get_context_fn>(GetProcAddress(imm32_, "ImmGetContext"));
+        imm_release_context_ = reinterpret_cast<imm_release_context_fn>(GetProcAddress(imm32_, "ImmReleaseContext"));
+        imm_set_open_status_ = reinterpret_cast<imm_set_open_status_fn>(GetProcAddress(imm32_, "ImmSetOpenStatus"));
+        if (imm_get_context_ == nullptr || imm_release_context_ == nullptr || imm_set_open_status_ == nullptr) {
+            imm_get_context_ = nullptr;
+            imm_release_context_ = nullptr;
+            imm_set_open_status_ = nullptr;
+        }
+    }
+
+    void close_ime_locked() {
+        if (!installed_ || hwnd_ == nullptr) {
+            return;
+        }
+
+        load_ime_functions_locked();
+        if (imm_get_context_ == nullptr || imm_release_context_ == nullptr || imm_set_open_status_ == nullptr) {
+            return;
+        }
+
+        HIMC context = imm_get_context_(hwnd_);
+        if (context == nullptr) {
+            return;
+        }
+
+        imm_set_open_status_(context, FALSE);
+        imm_release_context_(hwnd_, context);
+    }
+
     bool try_capture_event(UINT message, WPARAM w_param, LPARAM l_param) {
         std::scoped_lock lock(mutex_);
         if (!installed_) {
@@ -275,6 +351,14 @@ private:
     WNDPROC previous_wnd_proc_ = nullptr;
     long long qpc_frequency_ = 0;
     long long qpc_origin_ = 0;
+    HMODULE imm32_ = nullptr;
+    imm_get_context_fn imm_get_context_ = nullptr;
+    imm_release_context_fn imm_release_context_ = nullptr;
+    imm_set_open_status_fn imm_set_open_status_ = nullptr;
+    bool ime_load_attempted_ = false;
+#else
+    void close_ime_locked() {
+    }
 #endif
 
     mutable std::mutex mutex_;
@@ -282,6 +366,8 @@ private:
     std::uint64_t sequence_ = 0;
     bool test_mode_ = false;
     bool installed_ = false;
+    bool ime_text_input_allowed_ = false;
+    bool ime_requested_this_frame_ = false;
     double test_current_time_ms_ = 0.0;
 };
 
@@ -306,6 +392,18 @@ bool windows_input_source::is_available() const {
 
 double windows_input_source::current_time_ms() const {
     return windows_input_source_state::instance().current_time_ms();
+}
+
+void windows_input_source::begin_frame() {
+    windows_input_source_state::instance().begin_frame();
+}
+
+void windows_input_source::request_text_input() {
+    windows_input_source_state::instance().request_text_input();
+}
+
+void windows_input_source::end_frame() {
+    windows_input_source_state::instance().end_frame();
 }
 
 std::vector<native_key_event> windows_input_source::drain_events() {

--- a/src/platform/windows_input_source.cpp
+++ b/src/platform/windows_input_source.cpp
@@ -131,9 +131,6 @@ public:
     void begin_frame() {
         std::scoped_lock lock(mutex_);
         ime_requested_this_frame_ = false;
-        if (!ime_text_input_allowed_) {
-            close_ime_locked();
-        }
     }
 
     void request_text_input() {
@@ -143,19 +140,17 @@ public:
     }
 
     void end_frame() {
-        std::scoped_lock lock(mutex_);
-        const bool allow_text_input = ime_requested_this_frame_;
-        ime_requested_this_frame_ = false;
-        if (ime_text_input_allowed_ == allow_text_input) {
-            if (!allow_text_input) {
-                close_ime_locked();
-            }
-            return;
+        bool should_close_ime = false;
+        {
+            std::scoped_lock lock(mutex_);
+            const bool allow_text_input = ime_requested_this_frame_;
+            ime_requested_this_frame_ = false;
+            ime_text_input_allowed_ = allow_text_input;
+            should_close_ime = !allow_text_input;
         }
 
-        ime_text_input_allowed_ = allow_text_input;
-        if (!ime_text_input_allowed_) {
-            close_ime_locked();
+        if (should_close_ime) {
+            close_ime();
         }
     }
 
@@ -215,43 +210,60 @@ private:
     using imm_release_context_fn = BOOL(WINAPI*)(HWND, HIMC);
     using imm_set_open_status_fn = BOOL(WINAPI*)(HIMC, BOOL);
 
-    void load_ime_functions_locked() {
-        if (ime_load_attempted_) {
-            return;
-        }
-        ime_load_attempted_ = true;
-        imm32_ = LoadLibraryW(L"imm32.dll");
-        if (imm32_ == nullptr) {
-            return;
-        }
+    struct ime_functions {
+        HMODULE module = nullptr;
+        imm_get_context_fn get_context = nullptr;
+        imm_release_context_fn release_context = nullptr;
+        imm_set_open_status_fn set_open_status = nullptr;
+        bool available = false;
+    };
 
-        imm_get_context_ = reinterpret_cast<imm_get_context_fn>(GetProcAddress(imm32_, "ImmGetContext"));
-        imm_release_context_ = reinterpret_cast<imm_release_context_fn>(GetProcAddress(imm32_, "ImmReleaseContext"));
-        imm_set_open_status_ = reinterpret_cast<imm_set_open_status_fn>(GetProcAddress(imm32_, "ImmSetOpenStatus"));
-        if (imm_get_context_ == nullptr || imm_release_context_ == nullptr || imm_set_open_status_ == nullptr) {
-            imm_get_context_ = nullptr;
-            imm_release_context_ = nullptr;
-            imm_set_open_status_ = nullptr;
-        }
+    static const ime_functions& loaded_ime_functions() {
+        static const ime_functions functions = [] {
+            ime_functions loaded;
+            loaded.module = LoadLibraryW(L"imm32.dll");
+            if (loaded.module == nullptr) {
+                return loaded;
+            }
+
+            loaded.get_context =
+                reinterpret_cast<imm_get_context_fn>(GetProcAddress(loaded.module, "ImmGetContext"));
+            loaded.release_context =
+                reinterpret_cast<imm_release_context_fn>(GetProcAddress(loaded.module, "ImmReleaseContext"));
+            loaded.set_open_status =
+                reinterpret_cast<imm_set_open_status_fn>(GetProcAddress(loaded.module, "ImmSetOpenStatus"));
+            loaded.available =
+                loaded.get_context != nullptr &&
+                loaded.release_context != nullptr &&
+                loaded.set_open_status != nullptr;
+            return loaded;
+        }();
+        return functions;
     }
 
-    void close_ime_locked() {
-        if (!installed_ || hwnd_ == nullptr) {
+    void close_ime() {
+        HWND hwnd = nullptr;
+        {
+            std::scoped_lock lock(mutex_);
+            if (!installed_ || hwnd_ == nullptr) {
+                return;
+            }
+            hwnd = hwnd_;
+        }
+
+        // ImmSetOpenStatus may dispatch window messages. Never hold mutex_ here.
+        const ime_functions& functions = loaded_ime_functions();
+        if (!functions.available) {
             return;
         }
 
-        load_ime_functions_locked();
-        if (imm_get_context_ == nullptr || imm_release_context_ == nullptr || imm_set_open_status_ == nullptr) {
-            return;
-        }
-
-        HIMC context = imm_get_context_(hwnd_);
+        HIMC context = functions.get_context(hwnd);
         if (context == nullptr) {
             return;
         }
 
-        imm_set_open_status_(context, FALSE);
-        imm_release_context_(hwnd_, context);
+        functions.set_open_status(context, FALSE);
+        functions.release_context(hwnd, context);
     }
 
     bool try_capture_event(UINT message, WPARAM w_param, LPARAM l_param) {
@@ -351,13 +363,8 @@ private:
     WNDPROC previous_wnd_proc_ = nullptr;
     long long qpc_frequency_ = 0;
     long long qpc_origin_ = 0;
-    HMODULE imm32_ = nullptr;
-    imm_get_context_fn imm_get_context_ = nullptr;
-    imm_release_context_fn imm_release_context_ = nullptr;
-    imm_set_open_status_fn imm_set_open_status_ = nullptr;
-    bool ime_load_attempted_ = false;
 #else
-    void close_ime_locked() {
+    void close_ime() {
     }
 #endif
 

--- a/src/platform/windows_input_source.h
+++ b/src/platform/windows_input_source.h
@@ -21,6 +21,10 @@ public:
     bool is_available() const;
     double current_time_ms() const;
 
+    void begin_frame();
+    void request_text_input();
+    void end_frame();
+
     std::vector<native_key_event> drain_events();
 
     void enable_test_mode();

--- a/src/scenes/title/online_download_render.cpp
+++ b/src/scenes/title/online_download_render.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "audio_manager.h"
+#include "platform/windows_input_source.h"
 #include "scene_common.h"
 #include "tween.h"
 #include "title/title_layout.h"
@@ -107,6 +108,8 @@ ui::text_input_result draw_song_search_input(Rectangle rect, ui::text_input_stat
     }
 
     if (state.active) {
+        windows_input_source::instance().request_text_input();
+
         const bool ctrl = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
         const bool shift = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
 

--- a/src/ui/ui_text_editor.cpp
+++ b/src/ui/ui_text_editor.cpp
@@ -6,6 +6,7 @@
 #include <cstdio>
 #include <sstream>
 
+#include "platform/windows_input_source.h"
 #include "ui_font.h"
 #include "ui_coord.h"
 #include "ui_layout.h"
@@ -807,6 +808,8 @@ text_editor_result draw_text_editor(Rectangle rect, text_editor_state& state,
 
     // Keyboard input
     if (state.active) {
+        windows_input_source::instance().request_text_input();
+
         const bool ctrl = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
         const bool shift = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
         const bool has_completion = !completion.items.empty();

--- a/src/ui/ui_text_input.h
+++ b/src/ui/ui_text_input.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <string_view>
 
+#include "platform/windows_input_source.h"
 #include "raylib.h"
 #include "ui_draw.h"
 
@@ -381,6 +382,8 @@ inline text_input_result draw_text_input(Rectangle rect, text_input_state& state
     }
 
     if (state.active) {
+        windows_input_source::instance().request_text_input();
+
         const bool ctrl = IsKeyDown(KEY_LEFT_CONTROL) || IsKeyDown(KEY_RIGHT_CONTROL);
         const bool shift = IsKeyDown(KEY_LEFT_SHIFT) || IsKeyDown(KEY_RIGHT_SHIFT);
 


### PR DESCRIPTION
## 概要
- Windows ではテキスト入力 UI がアクティブなフレームだけ IME を許可するように変更
- プレイ中など入力欄以外では IME を閉じ、半角/全角キーで IME が残ってプレイ入力を妨げる状態を防止
- 通常のテキスト入力、MV テキストエディタ、オンライン検索欄では IME を許可

## 確認
- cmake --build cmake-build-codex --target raythm -j 2
- ctest --test-dir cmake-build-codex --output-on-failure
- git diff --check

補足: audio_manager_smoke は no-audio 環境では skipped