### PR TITLE
初回起動をDarkモードにし判定演出を調整

### DIFF
--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -35,7 +35,7 @@ struct game_settings {
     int windowed_width = 1920;
     int windowed_height = 1080;
     bool fullscreen = false;
-    bool dark_mode = false;
+    bool dark_mode = true;
 };
 
 inline game_settings g_settings;

--- a/src/scenes/play/play_flow_controller.cpp
+++ b/src/scenes/play/play_flow_controller.cpp
@@ -1,6 +1,7 @@
 #include "play_flow_controller.h"
 
 #include <algorithm>
+#include <cstddef>
 
 namespace {
 
@@ -15,12 +16,45 @@ bool is_no_fail_playtest(const play_session_state& state) {
     return state.editor_resume_state.has_value();
 }
 
+void update_visual_effect_timers(play_session_state& state, float dt) {
+    state.judge_feedback_timer = std::max(0.0f, state.judge_feedback_timer - dt);
+    for (lane_judge_effect& effect : state.lane_judge_effects) {
+        effect.timer = std::max(0.0f, effect.timer - dt);
+    }
+}
+
+void update_lane_hold_dimming(play_session_state& state, float dt) {
+    constexpr float kAttackPerSecond = 26.0f;
+    constexpr float kReleasePerSecond = 18.0f;
+
+    for (int lane = 0; lane < state.key_count; ++lane) {
+        float& amount = state.lane_hold_dim_amounts[static_cast<std::size_t>(lane)];
+        const float target = state.input_handler.is_lane_held(lane) ? 1.0f : 0.0f;
+        const float step = dt * (target > amount ? kAttackPerSecond : kReleasePerSecond);
+        if (target > amount) {
+            amount = std::min(target, amount + step);
+        } else {
+            amount = std::max(target, amount - step);
+        }
+    }
+}
+
+void trigger_lane_judge_effect(play_session_state& state, const judge_event& event) {
+    if (event.result == judge_result::miss || event.lane < 0 || event.lane >= state.key_count) {
+        return;
+    }
+
+    lane_judge_effect& effect = state.lane_judge_effects[static_cast<std::size_t>(event.lane)];
+    effect.result = event.result;
+    effect.timer = play_session_constants::kLaneJudgeEffectDurationSeconds;
+}
+
 }  // namespace
 
 play_update_result play_flow_controller::update(play_session_state& state, play_note_draw_queue& draw_queue,
                                                 const play_update_context& context) {
     play_update_result result;
-    state.judge_feedback_timer = std::max(0.0f, state.judge_feedback_timer - context.dt);
+    update_visual_effect_timers(state, context.dt);
 
     if (!state.initialized) {
         if (context.escape_pressed) {
@@ -101,6 +135,7 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
         if (!context.input_already_updated) {
             state.input_handler.update(state.current_ms);
         }
+        update_lane_hold_dimming(state, context.dt);
         if (context.draw_window.has_value()) {
             draw_queue.update_visible_window(state.judge_system.note_states(), static_cast<float>(state.lane_speed),
                                              context.draw_window->judgement_z, context.draw_window->lane_start_z,
@@ -121,6 +156,7 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
     if (!context.input_already_updated) {
         state.input_handler.update(state.current_ms);
     }
+    update_lane_hold_dimming(state, context.dt);
     state.judge_system.update(state.current_ms, state.input_handler);
     const std::vector<judge_event>& judge_events = state.judge_system.get_judge_events();
     state.last_judge = state.judge_system.get_last_judge();
@@ -139,6 +175,7 @@ play_update_result play_flow_controller::update(play_session_state& state, play_
         if (event.show_feedback) {
             state.display_judge = event;
             state.judge_feedback_timer = 1.0f;
+            trigger_lane_judge_effect(state, event);
         }
     }
     state.combo_display = state.score_system.get_combo();

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -1,6 +1,7 @@
 #include "play_renderer.h"
 
 #include <algorithm>
+#include <cstddef>
 #include <cmath>
 
 #include "game_settings.h"
@@ -87,6 +88,23 @@ Color judge_color(judge_result result) {
     return g_theme->text;
 }
 
+Color effect_judge_color(judge_result result) {
+    if (result == judge_result::perfect) {
+        return lerp_color(g_theme->judge_line_glow, WHITE, 0.35f);
+    }
+    return judge_color(result);
+}
+
+float ease_out(float t) {
+    const float clamped = std::clamp(t, 0.0f, 1.0f);
+    return 1.0f - (1.0f - clamped) * (1.0f - clamped);
+}
+
+Color fade_to_alpha(Color color, float alpha) {
+    color.a = static_cast<unsigned char>(std::clamp(alpha, 0.0f, 255.0f));
+    return color;
+}
+
 const char* judge_text(judge_result result) {
     switch (result) {
         case judge_result::perfect: return "PERFECT";
@@ -96,6 +114,56 @@ const char* judge_text(judge_result result) {
         case judge_result::miss: return "MISS";
     }
     return "";
+}
+
+void draw_lane_judge_effect_segment(float center_x, float start_z, float end_z,
+                                    float width, Color color, float remaining) {
+    constexpr int kEffectSegments = 18;
+    const float length = std::fabs(end_z - start_z);
+    if (length <= 0.0f) {
+        return;
+    }
+    const float delta_z = end_z - start_z;
+
+    const float segment_length = length / static_cast<float>(kEffectSegments);
+    for (int segment = 0; segment < kEffectSegments; ++segment) {
+        const float near_t = static_cast<float>(segment) / static_cast<float>(kEffectSegments);
+        const float far_t = static_cast<float>(segment + 1) / static_cast<float>(kEffectSegments);
+        const float fade = 1.0f - near_t;
+        const Color segment_color = fade_to_alpha(color, 214.0f * remaining * fade * fade);
+        const float segment_start_z = start_z + delta_z * near_t;
+        const float segment_end_z = start_z + delta_z * far_t;
+        DrawCube({center_x, kJudgeLineY - 0.018f, (segment_start_z + segment_end_z) * 0.5f},
+                 width * (0.96f - near_t * 0.08f),
+                 0.026f,
+                 segment_length,
+                 segment_color);
+    }
+}
+
+void draw_lane_judge_effect(const play_session_state& state, int lane,
+                            float lane_start_z, float judgement_z, float lane_end_z) {
+    const lane_judge_effect& effect = state.lane_judge_effects[static_cast<std::size_t>(lane)];
+    if (effect.timer <= 0.0f) {
+        return;
+    }
+
+    const float remaining =
+        effect.timer / play_session_constants::kLaneJudgeEffectDurationSeconds;
+    const float age = 1.0f - std::clamp(remaining, 0.0f, 1.0f);
+    const float pop = ease_out(age);
+    const Color color = effect_judge_color(effect.result);
+    const float center_x = lane_center_x(lane, state.key_count);
+    const float lane_width = g_settings.lane_width;
+    const Color bright_color = effect.result == judge_result::perfect
+                                   ? color
+                                   : lerp_color(color, WHITE, 0.12f);
+    const float effect_length = std::max(0.0f, lane_end_z - judgement_z) * 0.10f * (0.72f + pop * 0.28f);
+
+    draw_lane_judge_effect_segment(center_x, judgement_z, judgement_z + effect_length,
+                                   lane_width, bright_color, remaining);
+    draw_lane_judge_effect_segment(center_x, judgement_z, judgement_z - effect_length,
+                                   lane_width, bright_color, remaining);
 }
 
 void draw_hud(const play_session_state& state) {
@@ -202,8 +270,8 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
                 float lane_start_z, float judgement_z, float lane_end_z, double visual_ms) {
     for (int lane = 0; lane < state.key_count; ++lane) {
         const float center_x = lane_center_x(lane, state.key_count);
-        const bool lane_held = state.input_handler.is_lane_held(lane);
-        const Color lane_fill = lane_held ? g_theme->lane_pressed : g_theme->lane;
+        const float lane_dim = std::clamp(state.lane_hold_dim_amounts[static_cast<std::size_t>(lane)], 0.0f, 1.0f);
+        const Color lane_fill = lerp_color(g_theme->lane, g_theme->lane_pressed, lane_dim);
         DrawCube({center_x, -0.08f, (lane_start_z + lane_end_z) * 0.5f}, g_settings.lane_width, 0.05f,
                  lane_end_z - lane_start_z, lane_fill);
         DrawCubeWires({center_x, -0.08f, (lane_start_z + lane_end_z) * 0.5f}, g_settings.lane_width, 0.05f,
@@ -240,6 +308,10 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
                 }
             }
         }
+    }
+
+    for (int lane = 0; lane < state.key_count; ++lane) {
+        draw_lane_judge_effect(state, lane, lane_start_z, judgement_z, lane_end_z);
     }
 
     DrawCube({0.0f, kJudgeLineY, judgement_z}, total_width + 0.9f, 0.01f, 0.62f, g_theme->judge_line);

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -169,6 +169,8 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
     state.status_text.clear();
     state.last_judge.reset();
     state.display_judge.reset();
+    state.lane_hold_dim_amounts.fill(0.0f);
+    state.lane_judge_effects.fill(lane_judge_effect{});
     state.final_result = {};
     state.judge_feedback_timer = 0.0f;
     state.intro_playing = true;

--- a/src/scenes/play/play_session_types.h
+++ b/src/scenes/play/play_session_types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <optional>
 #include <string>
 #include <vector>
@@ -19,6 +20,7 @@ inline constexpr float kFailureHoldDurationSeconds = 1.0f;
 inline constexpr float kFailureTransitionDurationSeconds =
     kFailureFadeDurationSeconds + kFailureHoldDurationSeconds;
 inline constexpr float kResultTransitionDurationSeconds = 1.0f;
+inline constexpr float kLaneJudgeEffectDurationSeconds = 0.28f;
 
 }  // namespace play_session_constants
 
@@ -55,6 +57,11 @@ struct play_draw_window {
     double visual_ms = 0.0;
 };
 
+struct lane_judge_effect {
+    judge_result result = judge_result::miss;
+    float timer = 0.0f;
+};
+
 struct play_session_state {
     int key_count = 4;
     bool initialized = false;
@@ -78,6 +85,8 @@ struct play_session_state {
     std::optional<editor_resume_state> editor_resume_state;
     std::optional<judge_event> last_judge;
     std::optional<judge_event> display_judge;
+    std::array<float, judge_system::kMaxLanes> lane_hold_dim_amounts = {};
+    std::array<lane_judge_effect, judge_system::kMaxLanes> lane_judge_effects = {};
     result_data final_result;
     std::string status_text;
     float judge_feedback_timer = 0.0f;

--- a/src/tests/play_flow_controller_smoke.cpp
+++ b/src/tests/play_flow_controller_smoke.cpp
@@ -172,6 +172,11 @@ int main() {
             std::cerr << "Hold completion should surface perfect feedback\n";
             return EXIT_FAILURE;
         }
+        if (state.lane_judge_effects[0].result != judge_result::perfect ||
+            state.lane_judge_effects[0].timer <= 0.0f) {
+            std::cerr << "Hold completion should trigger lane judge effects\n";
+            return EXIT_FAILURE;
+        }
         if (result.hitsound_count != 0 || state.score_system.get_combo() != 1) {
             std::cerr << "Hold completion should add score effects without replaying hitsounds\n";
             return EXIT_FAILURE;
@@ -211,6 +216,11 @@ int main() {
 
         state.input_handler.update_from_lane_states(std::array<bool, 4>{true, false, false, false}, 500.0);
         const play_update_result result = play_flow_controller::update(state, draw_queue, context);
+        if (state.lane_judge_effects[0].result != judge_result::perfect ||
+            state.lane_judge_effects[0].timer <= 0.0f) {
+            std::cerr << "Tap judgement should trigger lane judge effects\n";
+            return EXIT_FAILURE;
+        }
         if (immediate_hitsound_count != 1 || result.hitsound_count != 0) {
             std::cerr << "Gameplay hitsound should use the immediate callback when available\n";
             return EXIT_FAILURE;


### PR DESCRIPTION
## 概要
- 初回起動時のデフォルトテーマをDarkモードに変更
- 押下中レーン暗転を短めのフェードに調整
- Perfect時の判定ライン下フラッシュを元の紫系に変更
- 成功判定フラッシュを判定線下で前後に短く表示

## 確認
- cmake --build cmake-build-codex --target raythm play_flow_controller_smoke settings_io_smoke -j 2
- play_flow_controller_smoke.exe
- settings_io_smoke.exe