### PR TITLE
Add song info overlay to play scene

### DIFF
--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -3,6 +3,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <cmath>
+#include <cstdio>
+#include <string>
 
 #include "game_settings.h"
 #include "scene_common.h"
@@ -38,7 +40,28 @@ constexpr Rectangle kTimeRect = ui::place(kScreenRect, 300.0f, 45.0f,
                                           Vector2{0.0f, 51.0f});
 constexpr Rectangle kFpsRect = ui::place(kScreenRect, 180.0f, 30.0f,
                                          ui::anchor::bottom_right, ui::anchor::bottom_right,
-                                         Vector2{-15.0f, 0.0f});
+                                         Vector2{-30.0f, -183.0f});
+constexpr Rectangle kSongInfoRect = ui::place(kScreenRect, 540.0f, 144.0f,
+                                              ui::anchor::bottom_right, ui::anchor::bottom_right,
+                                              Vector2{-30.0f, -30.0f});
+constexpr Rectangle kSongInfoJacketRect = {
+    kSongInfoRect.x + 16.0f,
+    kSongInfoRect.y + 16.0f,
+    112.0f,
+    112.0f
+};
+constexpr Rectangle kSongInfoTitleRect = {
+    kSongInfoRect.x + 148.0f,
+    kSongInfoRect.y + 28.0f,
+    kSongInfoRect.width - 172.0f,
+    45.0f
+};
+constexpr Rectangle kSongInfoDifficultyRect = {
+    kSongInfoRect.x + 148.0f,
+    kSongInfoRect.y + 83.0f,
+    kSongInfoRect.width - 172.0f,
+    34.0f
+};
 constexpr Rectangle kHealthLabelRect = ui::place(kScreenRect, 150.0f, 36.0f,
                                                  ui::anchor::top_right, ui::anchor::top_right,
                                                  Vector2{-72.0f, 51.0f});
@@ -114,6 +137,60 @@ const char* judge_text(judge_result result) {
         case judge_result::miss: return "MISS";
     }
     return "";
+}
+
+std::string difficulty_text(const play_session_state& state) {
+    if (!state.chart_data.has_value()) {
+        return "";
+    }
+
+    const chart_meta& meta = state.chart_data->meta;
+    if (meta.level > 0.0f) {
+        char level_text[32] = {};
+        std::snprintf(level_text, sizeof(level_text), "%.1f", meta.level);
+        return meta.difficulty.empty()
+                   ? std::string("Lv. ") + level_text
+                   : meta.difficulty + "  Lv. " + level_text;
+    }
+    return meta.difficulty;
+}
+
+void draw_song_info_panel(const play_session_state& state, const Texture2D* jacket_texture) {
+    if (!state.song_data.has_value() && !state.chart_data.has_value()) {
+        return;
+    }
+
+    const std::string title =
+        state.song_data.has_value() && !state.song_data->meta.title.empty()
+            ? state.song_data->meta.title
+            : "Unknown Title";
+    const std::string difficulty = difficulty_text(state);
+
+    ui::enqueue_draw_command(ui::draw_layer::base, [title, difficulty, jacket_texture]() {
+        ui::draw_rect_f(kSongInfoRect, with_alpha(g_theme->panel, 212));
+        ui::draw_rect_lines(kSongInfoRect, 2.0f, with_alpha(g_theme->border, 214));
+
+        if (jacket_texture != nullptr && jacket_texture->id != 0) {
+            const Rectangle source = {
+                0.0f,
+                0.0f,
+                static_cast<float>(jacket_texture->width),
+                static_cast<float>(jacket_texture->height)
+            };
+            DrawTexturePro(*jacket_texture, source, kSongInfoJacketRect, {0.0f, 0.0f}, 0.0f, WHITE);
+        } else {
+            ui::draw_rect_f(kSongInfoJacketRect, with_alpha(g_theme->section, 235));
+            ui::draw_rect_lines(kSongInfoJacketRect, 2.0f, with_alpha(g_theme->border_light, 220));
+            ui::draw_text_in_rect("NO JACKET", ui_font(16), kSongInfoJacketRect,
+                                  g_theme->text_muted, ui::text_align::center);
+        }
+
+        draw_marquee_text(title.c_str(), kSongInfoTitleRect, ui_font(25), g_theme->text, GetTime());
+        if (!difficulty.empty()) {
+            draw_marquee_text(difficulty.c_str(), kSongInfoDifficultyRect, ui_font(20),
+                              g_theme->text_secondary, GetTime());
+        }
+    });
 }
 
 void draw_lane_judge_effect_segment(float center_x, float start_z, float end_z,
@@ -318,8 +395,9 @@ void draw_world(const play_session_state& state, const play_note_draw_queue& dra
     DrawCube({0.0f, kJudgeLineGlowY, judgement_z}, total_width + 0.5f, kJudgeLineGlowHeight, 0.38f, g_theme->judge_line_glow);
 }
 
-void draw_overlay(const play_session_state& state) {
+void draw_overlay(const play_session_state& state, const Texture2D* jacket_texture) {
     draw_hud(state);
+    draw_song_info_panel(state, jacket_texture);
     draw_judge_feedback(state);
     if (state.intro_playing) {
         draw_intro_overlay(state);

--- a/src/scenes/play/play_renderer.h
+++ b/src/scenes/play/play_renderer.h
@@ -15,6 +15,6 @@ void draw_status(const play_session_state& state);
 void draw_world_background();
 void draw_world(const play_session_state& state, const play_note_draw_queue& draw_queue,
                 float lane_start_z, float judgement_z, float lane_end_z, double visual_ms);
-void draw_overlay(const play_session_state& state);
+void draw_overlay(const play_session_state& state, const Texture2D* jacket_texture);
 
 }  // namespace play_renderer

--- a/src/scenes/play_scene.cpp
+++ b/src/scenes/play_scene.cpp
@@ -14,6 +14,7 @@
 #include "mv/mv_storage.h"
 #include "mv/mv_runtime.h"
 #include "mv/render/mv_renderer.h"
+#include "path_utils.h"
 #include "play/play_flow_controller.h"
 #include "play/play_renderer.h"
 #include "play/play_session_loader.h"
@@ -157,10 +158,13 @@ play_scene::play_scene(scene_manager& manager, song_data song, chart_data chart,
     request_.start_tick = std::max(0, start_tick);
 }
 
-play_scene::~play_scene() = default;
+play_scene::~play_scene() {
+    unload_jacket_texture();
+}
 
 void play_scene::on_enter() {
     state_ = play_session_loader::load(request_, draw_queue_);
+    load_jacket_texture();
 
     // Try to load MV script for this song
     if (state_.song_data.has_value()) {
@@ -188,6 +192,7 @@ void play_scene::on_enter() {
 void play_scene::on_exit() {
     audio_manager::instance().stop_bgm();
     audio_manager::instance().stop_all_se();
+    unload_jacket_texture();
 }
 
 void play_scene::update(float dt) {
@@ -308,6 +313,36 @@ bool play_scene::get_lane_view_bounds(const Camera3D& camera, float& lane_start_
     return true;
 }
 
+void play_scene::load_jacket_texture() {
+    unload_jacket_texture();
+    if (!state_.song_data.has_value() || state_.song_data->meta.jacket_file.empty()) {
+        return;
+    }
+
+    const std::filesystem::path jacket_path =
+        path_utils::join_utf8(state_.song_data->directory, state_.song_data->meta.jacket_file);
+    if (!std::filesystem::exists(jacket_path) || !std::filesystem::is_regular_file(jacket_path)) {
+        return;
+    }
+
+    const std::string jacket_path_utf8 = path_utils::to_utf8(jacket_path);
+    jacket_texture_ = LoadTexture(jacket_path_utf8.c_str());
+    jacket_texture_loaded_ = jacket_texture_.id != 0;
+    if (jacket_texture_loaded_) {
+        SetTextureFilter(jacket_texture_, TEXTURE_FILTER_BILINEAR);
+    }
+}
+
+void play_scene::unload_jacket_texture() {
+    if (!jacket_texture_loaded_) {
+        return;
+    }
+
+    UnloadTexture(jacket_texture_);
+    jacket_texture_ = {};
+    jacket_texture_loaded_ = false;
+}
+
 void play_scene::draw() {
     if (!state_.initialized) {
         virtual_screen::begin_ui();
@@ -414,7 +449,7 @@ void play_scene::draw() {
 
     rebuild_hit_regions();
     ui::begin_draw_queue();
-    play_renderer::draw_overlay(state_);
+    play_renderer::draw_overlay(state_, jacket_texture_loaded_ ? &jacket_texture_ : nullptr);
     ui::flush_draw_queue();
     virtual_screen::end();
 

--- a/src/scenes/play_scene.h
+++ b/src/scenes/play_scene.h
@@ -30,6 +30,8 @@ public:
 private:
     Camera3D make_play_camera() const;
     bool get_lane_view_bounds(const Camera3D& camera, float& lane_start_z, float& judgement_z, float& lane_end_z) const;
+    void load_jacket_texture();
+    void unload_jacket_texture();
     void rebuild_hit_regions() const;
     double get_visual_ms() const;
     void apply_navigation(play_navigation_request navigation);
@@ -40,4 +42,6 @@ private:
     std::unique_ptr<mv::mv_runtime> mv_runtime_;
     std::vector<float> mv_spectrum_buffer_;
     std::vector<float> mv_oscilloscope_buffer_;
+    Texture2D jacket_texture_{};
+    bool jacket_texture_loaded_ = false;
 };


### PR DESCRIPTION
## Summary
- show song title, difficulty/level, and jacket art in the lower-right play HUD
- load and unload jacket textures with the play scene lifecycle
- keep long titles/difficulties clipped with existing marquee text rendering

## Verification
- g++ -fsyntax-only src/scenes/play/play_renderer.cpp
- g++ -fsyntax-only src/scenes/play_scene.cpp

Note: full local build is blocked in this environment by the existing MinGW assembler error: s: unknown option -- gdwarf-5.