### PR TITLE
Fix title exit audio shutdown

### DIFF
--- a/src/core/scene_manager.cpp
+++ b/src/core/scene_manager.cpp
@@ -22,11 +22,27 @@ void scene_manager::change_scene(std::unique_ptr<scene> next_scene) {
     next_scene_ = std::move(next_scene);
 }
 
+void scene_manager::request_exit() {
+    exit_requested_ = true;
+}
+
+bool scene_manager::exit_requested() const {
+    return exit_requested_;
+}
+
 void scene_manager::set_initial_scene(std::unique_ptr<scene> initial_scene) {
     current_scene_ = std::move(initial_scene);
 
     if (current_scene_ != nullptr) {
         current_scene_->on_enter();
+    }
+}
+
+void scene_manager::shutdown() {
+    next_scene_.reset();
+    if (current_scene_ != nullptr) {
+        current_scene_->on_exit();
+        current_scene_.reset();
     }
 }
 

--- a/src/core/scene_manager.h
+++ b/src/core/scene_manager.h
@@ -12,10 +12,15 @@ public:
     void draw();
     void change_scene(std::unique_ptr<scene> next_scene);
     void set_initial_scene(std::unique_ptr<scene> initial_scene);
+    void request_exit();
+    void shutdown();
+
+    [[nodiscard]] bool exit_requested() const;
 
 private:
     void apply_pending_transition();
 
     std::unique_ptr<scene> current_scene_;
     std::unique_ptr<scene> next_scene_;
+    bool exit_requested_ = false;
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -39,7 +39,7 @@ int main() {
     int applied_target_fps = g_settings.target_fps;
     bool was_window_focused = IsWindowFocused();
 
-    while (!WindowShouldClose()) {
+    while (!WindowShouldClose() && !manager.exit_requested()) {
         windows_input_source::instance().begin_frame();
         if (applied_target_fps != g_settings.target_fps) {
             SetTargetFPS(g_settings.target_fps);
@@ -78,6 +78,7 @@ int main() {
         windows_input_source::instance().end_frame();
     }
 
+    manager.shutdown();
     save_settings(g_settings);
     virtual_screen::cleanup();
     ui::shutdown_text_font();

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -722,7 +722,7 @@ void title_scene::update(float dt) {
     if (quitting_) {
         quit_fade_.update(dt);
         if (quit_fade_.complete()) {
-            CloseWindow();
+            manager_.request_exit();
         }
         return;
     }


### PR DESCRIPTION
## Summary
- route title ESC quit through scene manager exit requests
- run current scene on_exit before audio/window teardown
- stop title BGM/preview before the window is destroyed

## Verification
- cmake --build cmake-build-release --target raythm

Fixes #252