### PR TITLE
ジャケット画像のクロップ保存を追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/scenes/scene_common.h
         src/scenes/shared/auth_overlay_controller.cpp
         src/scenes/shared/auth_overlay_controller.h
+        src/scenes/shared/square_image_picker.cpp
+        src/scenes/shared/square_image_picker.h
         src/scenes/shared/content_status_badge.h
         src/scenes/title_scene.cpp
         src/scenes/title_scene.h

--- a/src/scenes/play/play_renderer.cpp
+++ b/src/scenes/play/play_renderer.cpp
@@ -34,16 +34,16 @@ constexpr Rectangle kPauseHintRect = {
 };
 constexpr Rectangle kScoreRect = ui::place(kScreenRect, 600.0f, 90.0f,
                                            ui::anchor::top_left, ui::anchor::top_left,
-                                           Vector2{72.0f, 51.0f});
+                                           Vector2{72.0f, 30.0f});
 constexpr Rectangle kTimeRect = ui::place(kScreenRect, 300.0f, 45.0f,
                                           ui::anchor::top_center, ui::anchor::top_center,
                                           Vector2{0.0f, 51.0f});
 constexpr Rectangle kFpsRect = ui::place(kScreenRect, 180.0f, 30.0f,
                                          ui::anchor::bottom_right, ui::anchor::bottom_right,
-                                         Vector2{-30.0f, -183.0f});
+                                         Vector2{-15.0f, 0.0f});
 constexpr Rectangle kSongInfoRect = ui::place(kScreenRect, 540.0f, 144.0f,
-                                              ui::anchor::bottom_right, ui::anchor::bottom_right,
-                                              Vector2{-30.0f, -30.0f});
+                                              ui::anchor::top_right, ui::anchor::top_right,
+                                              Vector2{-30.0f, 30.0f});
 constexpr Rectangle kSongInfoJacketRect = {
     kSongInfoRect.x + 16.0f,
     kSongInfoRect.y + 16.0f,

--- a/src/scenes/shared/square_image_picker.cpp
+++ b/src/scenes/shared/square_image_picker.cpp
@@ -1,0 +1,320 @@
+#include "shared/square_image_picker.h"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <string>
+
+#include "path_utils.h"
+#include "scene_common.h"
+#include "theme.h"
+#include "ui_draw.h"
+#include "ui_hit.h"
+#include "virtual_screen.h"
+
+namespace square_image_picker {
+namespace {
+
+constexpr Rectangle kOverlayRect = {0.0f, 0.0f, static_cast<float>(kScreenWidth), static_cast<float>(kScreenHeight)};
+constexpr Rectangle kDialogRect = {455.0f, 86.0f, 1010.0f, 908.0f};
+constexpr Rectangle kTitleRect = {501.0f, 126.0f, 540.0f, 40.0f};
+constexpr Rectangle kPreviewRect = {565.0f, 188.0f, 790.0f, 630.0f};
+constexpr Rectangle kZoomRowRect = {565.0f, 842.0f, 790.0f, 54.0f};
+constexpr Rectangle kCancelRect = {1067.0f, 918.0f, 132.0f, 48.0f};
+constexpr Rectangle kApplyRect = {1215.0f, 918.0f, 140.0f, 48.0f};
+constexpr float kMinZoom = 1.0f;
+constexpr float kMaxZoom = 4.0f;
+
+Rectangle fit_rect(Rectangle bounds, int width, int height) {
+    if (width <= 0 || height <= 0) {
+        return bounds;
+    }
+
+    const float scale = std::min(bounds.width / static_cast<float>(width),
+                                 bounds.height / static_cast<float>(height));
+    const float draw_w = static_cast<float>(width) * scale;
+    const float draw_h = static_cast<float>(height) * scale;
+    return {
+        bounds.x + (bounds.width - draw_w) * 0.5f,
+        bounds.y + (bounds.height - draw_h) * 0.5f,
+        draw_w,
+        draw_h,
+    };
+}
+
+Rectangle map_source_to_dest(Rectangle source, Rectangle image_dest, int width, int height) {
+    const float scale_x = image_dest.width / static_cast<float>(width);
+    const float scale_y = image_dest.height / static_cast<float>(height);
+    return {
+        image_dest.x + source.x * scale_x,
+        image_dest.y + source.y * scale_y,
+        source.width * scale_x,
+        source.height * scale_y,
+    };
+}
+
+Vector2 map_dest_to_source(Vector2 point, Rectangle image_dest, int width, int height) {
+    return {
+        (point.x - image_dest.x) * static_cast<float>(width) / image_dest.width,
+        (point.y - image_dest.y) * static_cast<float>(height) / image_dest.height,
+    };
+}
+
+float crop_size_for_zoom(int width, int height, float zoom) {
+    return std::max(1.0f, static_cast<float>(std::min(width, height)) / std::max(kMinZoom, zoom));
+}
+
+Rectangle clamped_crop_rect(Rectangle crop, int width, int height) {
+    crop.width = std::clamp(crop.width, 1.0f, static_cast<float>(std::max(1, width)));
+    crop.height = std::clamp(crop.height, 1.0f, static_cast<float>(std::max(1, height)));
+    crop.x = std::clamp(crop.x, 0.0f, static_cast<float>(width) - crop.width);
+    crop.y = std::clamp(crop.y, 0.0f, static_cast<float>(height) - crop.height);
+    return crop;
+}
+
+}  // namespace
+
+state::~state() {
+    unload();
+}
+
+bool state::open(const std::string& source_path, std::string& error_message) {
+    unload();
+    Image image = LoadImage(source_path.c_str());
+    if (image.data == nullptr || image.width <= 0 || image.height <= 0) {
+        error_message = "Failed to load image: " + source_path;
+        if (image.data != nullptr) {
+            UnloadImage(image);
+        }
+        return false;
+    }
+
+    texture_ = LoadTextureFromImage(image);
+    image_width_ = image.width;
+    image_height_ = image.height;
+    UnloadImage(image);
+
+    if (texture_.id == 0) {
+        error_message = "Failed to prepare image preview.";
+        return false;
+    }
+
+    SetTextureFilter(texture_, TEXTURE_FILTER_BILINEAR);
+    source_path_ = source_path;
+    crop_center_ = {static_cast<float>(image_width_) * 0.5f,
+                    static_cast<float>(image_height_) * 0.5f};
+    zoom_ = 1.0f;
+    open_ = true;
+    accepted_ = false;
+    canceled_ = false;
+    dragging_ = false;
+    texture_loaded_ = true;
+    return true;
+}
+
+void state::close() {
+    open_ = false;
+    dragging_ = false;
+}
+
+bool state::is_open() const {
+    return open_;
+}
+
+void state::update() {
+    if (!open_) {
+        return;
+    }
+
+    ui::register_hit_region(kOverlayRect, ui::draw_layer::overlay);
+    ui::register_hit_region(kDialogRect, ui::draw_layer::modal);
+
+    if (IsKeyPressed(KEY_ESCAPE) || ui::is_clicked(kCancelRect, ui::draw_layer::modal)) {
+        canceled_ = true;
+        close();
+        return;
+    }
+    if (ui::is_clicked(kApplyRect, ui::draw_layer::modal)) {
+        accepted_ = true;
+        close();
+        return;
+    }
+
+    const Rectangle image_dest = fit_rect(kPreviewRect, image_width_, image_height_);
+    const Rectangle crop_dest = map_source_to_dest(source_crop_rect(), image_dest, image_width_, image_height_);
+    const Vector2 mouse = virtual_screen::get_virtual_mouse();
+
+    if (IsMouseButtonPressed(MOUSE_BUTTON_LEFT) &&
+        CheckCollisionPointRec(mouse, crop_dest) &&
+        !ui::is_blocked_by_higher_layer(crop_dest, ui::draw_layer::modal)) {
+        dragging_ = true;
+        drag_offset_ = {
+            mouse.x - (crop_dest.x + crop_dest.width * 0.5f),
+            mouse.y - (crop_dest.y + crop_dest.height * 0.5f),
+        };
+    }
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        dragging_ = false;
+    }
+    if (dragging_ && IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        const Vector2 source = map_dest_to_source(
+            {mouse.x - drag_offset_.x, mouse.y - drag_offset_.y},
+            image_dest,
+            image_width_,
+            image_height_);
+        crop_center_ = source;
+        clamp_center();
+    }
+
+    if (IsMouseButtonDown(MOUSE_BUTTON_LEFT) &&
+        ui::is_hovered(kZoomRowRect, ui::draw_layer::modal)) {
+        constexpr float kTrackLeftInset = 160.0f;
+        constexpr float kTrackRightInset = 32.0f;
+        const float track_x = kZoomRowRect.x + kTrackLeftInset;
+        const float track_w = kZoomRowRect.width - kTrackLeftInset - kTrackRightInset;
+        const float ratio = std::clamp((mouse.x - track_x) / track_w, 0.0f, 1.0f);
+        set_zoom(kMinZoom + ratio * (kMaxZoom - kMinZoom));
+    }
+}
+
+void state::draw() const {
+    if (!open_) {
+        return;
+    }
+
+    const auto& t = *g_theme;
+    ui::draw_fullscreen_overlay(with_alpha(BLACK, 145));
+    ui::draw_section(kDialogRect);
+    ui::draw_text_in_rect("Crop Image", 28, kTitleRect, t.text, ui::text_align::left);
+
+    ui::draw_rect_f(kPreviewRect, with_alpha(t.panel, 235));
+    ui::draw_rect_lines(kPreviewRect, 1.5f, t.border_light);
+
+    if (texture_loaded_ && texture_.id != 0) {
+        const Rectangle image_dest = fit_rect(kPreviewRect, image_width_, image_height_);
+        DrawTexturePro(texture_,
+                       {0.0f, 0.0f, static_cast<float>(texture_.width), static_cast<float>(texture_.height)},
+                       image_dest, {0.0f, 0.0f}, 0.0f, WHITE);
+
+        const Rectangle crop_dest = map_source_to_dest(source_crop_rect(), image_dest, image_width_, image_height_);
+        DrawRectangleRec({image_dest.x, image_dest.y, image_dest.width, crop_dest.y - image_dest.y},
+                         with_alpha(BLACK, 105));
+        DrawRectangleRec({image_dest.x, crop_dest.y + crop_dest.height, image_dest.width,
+                          image_dest.y + image_dest.height - crop_dest.y - crop_dest.height},
+                         with_alpha(BLACK, 105));
+        DrawRectangleRec({image_dest.x, crop_dest.y, crop_dest.x - image_dest.x, crop_dest.height},
+                         with_alpha(BLACK, 105));
+        DrawRectangleRec({crop_dest.x + crop_dest.width, crop_dest.y,
+                          image_dest.x + image_dest.width - crop_dest.x - crop_dest.width, crop_dest.height},
+                         with_alpha(BLACK, 105));
+        ui::draw_rect_lines(crop_dest, 3.0f, t.accent);
+        ui::draw_rect_lines(ui::inset(crop_dest, -4.0f), 1.5f, with_alpha(t.bg, 210));
+    }
+
+    ui::draw_slider_relative(kZoomRowRect, "Zoom", TextFormat("%.1fx", zoom_),
+                             (zoom_ - kMinZoom) / (kMaxZoom - kMinZoom),
+                             160.0f, 32.0f, ui::draw_layer::modal,
+                             18, 26.0f, 96.0f);
+    ui::draw_button(kCancelRect, "CANCEL", 14);
+    ui::draw_button_colored(kApplyRect, "APPLY", 14, t.row_active, t.row_hover, t.text);
+}
+
+bool state::consume_accept() {
+    const bool accepted = accepted_;
+    accepted_ = false;
+    return accepted;
+}
+
+bool state::consume_cancel() {
+    const bool canceled = canceled_;
+    canceled_ = false;
+    return canceled;
+}
+
+const std::string& state::source_path() const {
+    return source_path_;
+}
+
+export_result state::export_png(const std::string& destination_path, export_options options) const {
+    return export_square_png(source_path_, destination_path, source_crop_rect(), options);
+}
+
+void state::unload() {
+    if (texture_loaded_) {
+        UnloadTexture(texture_);
+    }
+    texture_ = {};
+    texture_loaded_ = false;
+    image_width_ = 0;
+    image_height_ = 0;
+    source_path_.clear();
+}
+
+Rectangle state::source_crop_rect() const {
+    const float size = crop_size_for_zoom(image_width_, image_height_, zoom_);
+    return clamped_crop_rect({crop_center_.x - size * 0.5f, crop_center_.y - size * 0.5f, size, size},
+                             image_width_, image_height_);
+}
+
+void state::clamp_center() {
+    const float half = crop_size_for_zoom(image_width_, image_height_, zoom_) * 0.5f;
+    crop_center_.x = std::clamp(crop_center_.x, half, static_cast<float>(image_width_) - half);
+    crop_center_.y = std::clamp(crop_center_.y, half, static_cast<float>(image_height_) - half);
+}
+
+void state::set_zoom(float zoom) {
+    zoom_ = std::clamp(zoom, kMinZoom, kMaxZoom);
+    clamp_center();
+}
+
+export_result export_square_png(const std::string& source_path,
+                                const std::string& destination_path,
+                                Rectangle source_crop,
+                                export_options options) {
+    Image image = LoadImage(source_path.c_str());
+    if (image.data == nullptr || image.width <= 0 || image.height <= 0) {
+        if (image.data != nullptr) {
+            UnloadImage(image);
+        }
+        return {false, "Failed to load image: " + source_path};
+    }
+
+    source_crop = clamped_crop_rect(source_crop, image.width, image.height);
+    ImageCrop(&image, source_crop);
+    ImageResize(&image, options.output_size, options.output_size);
+
+    const std::filesystem::path destination = path_utils::from_utf8(destination_path);
+    std::error_code ec;
+    std::filesystem::create_directories(destination.parent_path(), ec);
+
+    const bool exported = ExportImage(image, destination_path.c_str());
+    UnloadImage(image);
+    if (!exported) {
+        return {false, "Failed to write image: " + destination_path};
+    }
+    return {true, {}};
+}
+
+export_result export_center_square_png(const std::string& source_path,
+                                       const std::string& destination_path,
+                                       export_options options) {
+    Image image = LoadImage(source_path.c_str());
+    if (image.data == nullptr || image.width <= 0 || image.height <= 0) {
+        if (image.data != nullptr) {
+            UnloadImage(image);
+        }
+        return {false, "Failed to load image: " + source_path};
+    }
+
+    const float size = static_cast<float>(std::min(image.width, image.height));
+    const Rectangle crop = {
+        (static_cast<float>(image.width) - size) * 0.5f,
+        (static_cast<float>(image.height) - size) * 0.5f,
+        size,
+        size,
+    };
+    UnloadImage(image);
+    return export_square_png(source_path, destination_path, crop, options);
+}
+
+}  // namespace square_image_picker

--- a/src/scenes/shared/square_image_picker.h
+++ b/src/scenes/shared/square_image_picker.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <optional>
+#include <string>
+
+#include "raylib.h"
+
+namespace square_image_picker {
+
+struct export_options {
+    int output_size = 512;
+};
+
+struct export_result {
+    bool success = false;
+    std::string message;
+};
+
+class state {
+public:
+    state() = default;
+    ~state();
+
+    state(const state&) = delete;
+    state& operator=(const state&) = delete;
+
+    state(state&&) = delete;
+    state& operator=(state&&) = delete;
+
+    bool open(const std::string& source_path, std::string& error_message);
+    void close();
+    bool is_open() const;
+
+    void update();
+    void draw() const;
+
+    bool consume_accept();
+    bool consume_cancel();
+
+    const std::string& source_path() const;
+    export_result export_png(const std::string& destination_path,
+                             export_options options = {}) const;
+
+private:
+    void unload();
+    Rectangle source_crop_rect() const;
+    void clamp_center();
+    void set_zoom(float zoom);
+
+    bool open_ = false;
+    bool accepted_ = false;
+    bool canceled_ = false;
+    bool dragging_ = false;
+    Vector2 drag_offset_ = {};
+
+    std::string source_path_;
+    Texture2D texture_ = {};
+    bool texture_loaded_ = false;
+    int image_width_ = 0;
+    int image_height_ = 0;
+    Vector2 crop_center_ = {};
+    float zoom_ = 1.0f;
+};
+
+export_result export_square_png(const std::string& source_path,
+                                const std::string& destination_path,
+                                Rectangle source_crop,
+                                export_options options = {});
+
+export_result export_center_square_png(const std::string& source_path,
+                                       const std::string& destination_path,
+                                       export_options options = {});
+
+}  // namespace square_image_picker

--- a/src/scenes/song_create_scene.cpp
+++ b/src/scenes/song_create_scene.cpp
@@ -157,6 +157,19 @@ void song_create_scene::draw() {
 }
 
 void song_create_scene::update_song_metadata() {
+    if (jacket_picker_.is_open()) {
+        jacket_picker_.update();
+        if (jacket_picker_.consume_accept()) {
+            jacket_path_input_.value = jacket_picker_.source_path();
+            jacket_crop_source_ = jacket_picker_.source_path();
+            error_.clear();
+        } else if (jacket_picker_.consume_cancel()) {
+            jacket_crop_source_.clear();
+            error_.clear();
+        }
+        return;
+    }
+
     if (IsKeyPressed(KEY_ESCAPE)) {
         go_back_to_song_select(editing_song_.has_value() ? editing_song_->meta.song_id : "");
         return;
@@ -209,7 +222,10 @@ void song_create_scene::draw_song_metadata() {
         if (ui::draw_button(browse_rect, "BROWSE", 14).clicked) {
             const std::string path = file_dialog::open_image_file();
             if (!path.empty()) {
-                jacket_path_input_.value = path;
+                if (!jacket_picker_.open(path, error_)) {
+                    jacket_path_input_.value.clear();
+                    jacket_crop_source_.clear();
+                }
             }
         }
     }
@@ -246,6 +262,10 @@ void song_create_scene::draw_song_metadata() {
     if (!error_.empty()) {
         const Rectangle error_rect = {kFormX, button_y + kButtonHeight + kErrorTopGap, kFormWidth, kErrorHeight};
         ui::draw_text_in_rect(error_.c_str(), 14, error_rect, g_theme->error, ui::text_align::left);
+    }
+
+    if (jacket_picker_.is_open()) {
+        jacket_picker_.draw();
     }
 }
 
@@ -336,13 +356,12 @@ bool song_create_scene::create_song() {
     std::string jacket_filename;
     if (!jacket_path_input_.value.empty()) {
         const fs::path jacket_source = path_utils::from_utf8(jacket_path_input_.value);
-        if (fs::exists(jacket_source)) {
-            jacket_filename = path_utils::to_utf8(jacket_source.filename());
-            const fs::path jacket_dest = song_dir / jacket_filename;
-            try {
-                fs::copy_file(jacket_source, jacket_dest, fs::copy_options::overwrite_existing);
-            } catch (...) {
-            }
+        if (!fs::exists(jacket_source)) {
+            error_ = "Jacket file not found: " + jacket_path_input_.value;
+            return false;
+        }
+        if (!export_jacket_image(jacket_source, song_dir, jacket_filename)) {
+            return false;
         }
     }
 
@@ -443,15 +462,12 @@ bool song_create_scene::save_song_edits() {
         const fs::path current_jacket_path = editing_song_->meta.jacket_file.empty()
             ? fs::path()
             : path_utils::join_utf8(editing_song_->directory, editing_song_->meta.jacket_file);
-        if (!editing_song_->meta.jacket_file.empty() && paths_match(jacket_source, current_jacket_path)) {
+        if (!editing_song_->meta.jacket_file.empty() &&
+            paths_match(jacket_source, current_jacket_path) &&
+            jacket_crop_source_ != path_utils::to_utf8(jacket_source)) {
             jacket_filename = editing_song_->meta.jacket_file;
         } else {
-            jacket_filename = path_utils::to_utf8(jacket_source.filename());
-            const fs::path jacket_dest = song_dir / jacket_filename;
-            try {
-                fs::copy_file(jacket_source, jacket_dest, fs::copy_options::overwrite_existing);
-            } catch (const std::exception& e) {
-                error_ = std::string("Failed to copy jacket file: ") + e.what();
+            if (!export_jacket_image(jacket_source, song_dir, jacket_filename)) {
                 return false;
             }
         }
@@ -481,6 +497,29 @@ bool song_create_scene::save_song_edits() {
     created_song_ = *editing_song_;
     error_.clear();
     go_back_to_song_select(meta.song_id);
+    return true;
+}
+
+bool song_create_scene::export_jacket_image(const fs::path& source_path,
+                                            const fs::path& song_dir,
+                                            std::string& jacket_filename) {
+    jacket_filename = "jacket.png";
+    const fs::path jacket_dest = song_dir / jacket_filename;
+    const std::string source_utf8 = path_utils::to_utf8(source_path);
+    const std::string dest_utf8 = path_utils::to_utf8(jacket_dest);
+
+    square_image_picker::export_result result;
+    if (jacket_crop_source_ == source_utf8 && jacket_picker_.source_path() == source_utf8) {
+        result = jacket_picker_.export_png(dest_utf8, {.output_size = 512});
+    } else {
+        result = square_image_picker::export_center_square_png(source_utf8, dest_utf8, {.output_size = 512});
+    }
+
+    if (!result.success) {
+        error_ = result.message.empty() ? "Failed to export jacket image." : result.message;
+        jacket_filename.clear();
+        return false;
+    }
     return true;
 }
 

--- a/src/scenes/song_create_scene.h
+++ b/src/scenes/song_create_scene.h
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <filesystem>
 #include <optional>
 #include <string>
 
 #include "data_models.h"
 #include "scene.h"
+#include "shared/square_image_picker.h"
 #include "ui_text_input.h"
 
 // 新規楽曲作成 + 譜面作成フロー。
@@ -27,6 +29,9 @@ private:
 
     bool create_song();
     bool save_song_edits();
+    bool export_jacket_image(const std::filesystem::path& source_path,
+                             const std::filesystem::path& song_dir,
+                             std::string& jacket_filename);
     void go_back_to_song_select(const std::string& preferred_song_id = "");
     bool is_edit_mode() const;
 
@@ -42,6 +47,8 @@ private:
     ui::text_input_state sns_youtube_input_;
     ui::text_input_state sns_niconico_input_;
     ui::text_input_state sns_x_input_;
+    square_image_picker::state jacket_picker_;
+    std::string jacket_crop_source_;
 
     // Created song data (stored after song creation)
     song_data created_song_;


### PR DESCRIPTION
## 概要
- ジャケット画像選択時に正方形クロップ用モーダルを開くようにしました。
- クロップ結果を 512x512 の PNG として保存する共有モジュールを追加しました。
- 手入力などクロップ設定がない画像も中央正方形で 512x512 に変換します。
- 持ち越し分として、プレイ画面HUDの表示位置調整も含みます。

## 確認
- cmake --build cmake-build-codex --target raythm -j 2
