### PR TITLE
サーバー環境切り替えを追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,6 +179,8 @@ add_executable(raythm WIN32 src/main.cpp
         src/network/json_helpers.h
         src/network/ranking_client.cpp
         src/network/ranking_client.h
+        src/network/server_environment.cpp
+        src/network/server_environment.h
         src/updater/update_verify.cpp
         src/updater/update_verify.h
         src/core/app_paths.cpp
@@ -520,6 +522,8 @@ add_executable(settings_io_smoke
         src/core/app_paths.h
         src/gameplay/settings_io.cpp
         src/gameplay/settings_io.h
+        src/network/server_environment.cpp
+        src/network/server_environment.h
         src/tests/settings_io_smoke.cpp)
 
 add_executable(local_catalog_database_smoke
@@ -619,6 +623,8 @@ add_executable(ranking_service_smoke
         src/network/json_helpers.h
         src/network/ranking_client.cpp
         src/network/ranking_client.h
+        src/network/server_environment.cpp
+        src/network/server_environment.h
         src/updater/update_verify.cpp
         src/updater/update_verify.h
         src/tests/ranking_service_smoke.cpp)

--- a/src/gameplay/game_settings.h
+++ b/src/gameplay/game_settings.h
@@ -1,6 +1,9 @@
 #pragma once
 
+#include <string>
+
 #include "input_handler.h"
+#include "network/server_environment.h"
 
 // 解像度プリセット
 struct resolution_preset {
@@ -36,6 +39,8 @@ struct game_settings {
     int windowed_height = 1080;
     bool fullscreen = false;
     bool dark_mode = true;
+    server_environment::environment server_env = server_environment::environment::production;
+    std::string custom_server_url = server_environment::kDefaultCustomServerUrl;
 };
 
 inline game_settings g_settings;

--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -18,6 +18,7 @@
 #include "chart_fingerprint.h"
 #include "network/auth_client.h"
 #include "network/ranking_client.h"
+#include "network/server_environment.h"
 #include "path_utils.h"
 #include "scoring_ruleset_runtime.h"
 #include "song_fingerprint.h"
@@ -382,7 +383,7 @@ std::string display_ruleset_server_url() {
         return auth::normalize_server_url(summary.server_url);
     }
 
-    return auth::normalize_server_url(auth::kDefaultServerUrl);
+    return server_environment::active_server_url_from_settings();
 }
 
 struct cached_scoring_ruleset_state {

--- a/src/gameplay/settings_io.cpp
+++ b/src/gameplay/settings_io.cpp
@@ -33,6 +33,34 @@ std::string read_file(const fs::path& path) {
     return buffer.str();
 }
 
+std::string escape_json_string(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (char ch : value) {
+        switch (ch) {
+        case '\\':
+            escaped += "\\\\";
+            break;
+        case '"':
+            escaped += "\\\"";
+            break;
+        case '\n':
+            escaped += "\\n";
+            break;
+        case '\r':
+            escaped += "\\r";
+            break;
+        case '\t':
+            escaped += "\\t";
+            break;
+        default:
+            escaped += ch;
+            break;
+        }
+    }
+    return escaped;
+}
+
 // JSON から文字列値を取り出す。
 std::optional<std::string> extract_string(const std::string& content, const std::string& key) {
     const std::string token = "\"" + key + "\"";
@@ -154,6 +182,10 @@ void load_settings(game_settings& settings) {
         settings.fullscreen = *v;
     if (auto v = extract_bool(content, "darkMode"))
         settings.dark_mode = *v;
+    if (auto v = extract_string(content, "serverEnvironment"))
+        settings.server_env = server_environment::parse(*v);
+    if (auto v = extract_string(content, "customServerUrl"))
+        settings.custom_server_url = *v;
 
     if (auto v = extract_string(content, "keys4"))
         parse_key_array(*v, settings.keys.keys_4);
@@ -191,6 +223,8 @@ void save_settings(const game_settings& settings) {
     out << "  \"windowedHeight\": " << settings.windowed_height << ",\n";
     out << "  \"fullscreen\": " << (settings.fullscreen ? "true" : "false") << ",\n";
     out << "  \"darkMode\": " << (settings.dark_mode ? "true" : "false") << ",\n";
+    out << "  \"serverEnvironment\": \"" << server_environment::key(settings.server_env) << "\",\n";
+    out << "  \"customServerUrl\": \"" << escape_json_string(settings.custom_server_url) << "\",\n";
     out << "  \"keys4\": \"" << keys_to_csv(settings.keys.keys_4) << "\",\n";
     out << "  \"keys6\": \"" << keys_to_csv(settings.keys.keys_6) << "\"\n";
     out << "}\n";

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -246,15 +246,6 @@ void push_candidate_server_url(std::vector<std::string>& urls, const std::string
 std::vector<std::string> candidate_server_urls(const std::string& server_url) {
     std::vector<std::string> urls;
     push_candidate_server_url(urls, server_url);
-
-    const std::string normalized = auth::normalize_server_url(server_url);
-    if (normalized == auth::normalize_server_url(auth::kDefaultServerUrl)) {
-        push_candidate_server_url(urls, auth::kLanServerUrl);
-    } else if (normalized == auth::normalize_server_url(auth::kLanServerUrl) ||
-               normalized == auth::normalize_server_url(auth::kLegacyLanServerUrl)) {
-        push_candidate_server_url(urls, auth::kDefaultServerUrl);
-    }
-
     return urls;
 }
 

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -4,11 +4,13 @@
 #include <string>
 #include <vector>
 
+#include "network/server_environment.h"
+
 namespace auth {
 
-inline constexpr const char* kDefaultServerUrl = "https://api.raythm.net";
-inline constexpr const char* kLanServerUrl = "http://192.168.11.33";
-inline constexpr const char* kLegacyLanServerUrl = "http://192.168.11.33";
+inline constexpr const char* kProductionServerUrl = server_environment::kProductionServerUrl;
+inline constexpr const char* kDevelopmentServerUrl = server_environment::kDevelopmentServerUrl;
+inline constexpr const char* kDefaultServerUrl = kProductionServerUrl;
 
 struct public_user {
     std::string id;

--- a/src/network/server_environment.cpp
+++ b/src/network/server_environment.cpp
@@ -1,0 +1,88 @@
+#include "network/server_environment.h"
+
+#include <cctype>
+#include <filesystem>
+#include <fstream>
+#include <optional>
+#include <sstream>
+#include <string>
+
+#include "app_paths.h"
+
+namespace {
+
+std::string trim(std::string value) {
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.front()))) {
+        value.erase(value.begin());
+    }
+    while (!value.empty() && std::isspace(static_cast<unsigned char>(value.back()))) {
+        value.pop_back();
+    }
+    return value;
+}
+
+std::string read_file(const std::filesystem::path& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        return {};
+    }
+    std::ostringstream buffer;
+    buffer << input.rdbuf();
+    return buffer.str();
+}
+
+std::optional<std::string> extract_string(const std::string& content, const std::string& key) {
+    const std::string token = "\"" + key + "\"";
+    const size_t key_pos = content.find(token);
+    if (key_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    const size_t colon_pos = content.find(':', key_pos + token.size());
+    if (colon_pos == std::string::npos) {
+        return std::nullopt;
+    }
+
+    size_t start = colon_pos + 1;
+    while (start < content.size() && std::isspace(static_cast<unsigned char>(content[start]))) {
+        ++start;
+    }
+    if (start >= content.size() || content[start] != '"') {
+        return std::nullopt;
+    }
+    ++start;
+
+    std::string result;
+    for (size_t i = start; i < content.size(); ++i) {
+        if (content[i] == '"') {
+            return result;
+        }
+        if (content[i] == '\\' && i + 1 < content.size()) {
+            result += content[++i];
+        } else {
+            result += content[i];
+        }
+    }
+    return std::nullopt;
+}
+
+}  // namespace
+
+namespace server_environment {
+
+std::string normalize_url(const std::string& server_url) {
+    std::string normalized = trim(server_url);
+    while (!normalized.empty() && normalized.back() == '/') {
+        normalized.pop_back();
+    }
+    return normalized;
+}
+
+std::string active_server_url_from_settings() {
+    const std::string content = read_file(app_paths::settings_path());
+    const environment env = parse(extract_string(content, "serverEnvironment").value_or(""));
+    const std::string custom_url = extract_string(content, "customServerUrl").value_or(kDefaultCustomServerUrl);
+    return normalize_url(configured_url(env, custom_url));
+}
+
+}  // namespace server_environment

--- a/src/network/server_environment.h
+++ b/src/network/server_environment.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <string>
+
+namespace server_environment {
+
+enum class environment {
+    production,
+    development,
+    custom,
+};
+
+inline constexpr const char* kProductionServerUrl = "https://api.raythm.net";
+inline constexpr const char* kDevelopmentServerUrl = "https://dev-api.raythm.net";
+inline constexpr const char* kDefaultCustomServerUrl = "http://localhost:3000";
+
+inline const char* key(environment value) {
+    switch (value) {
+    case environment::development:
+        return "development";
+    case environment::custom:
+        return "custom";
+    case environment::production:
+    default:
+        return "production";
+    }
+}
+
+inline const char* label(environment value) {
+    switch (value) {
+    case environment::development:
+        return "Development";
+    case environment::custom:
+        return "Custom";
+    case environment::production:
+    default:
+        return "Production";
+    }
+}
+
+inline environment parse(std::string value) {
+    if (value == "development" || value == "dev") {
+        return environment::development;
+    }
+    if (value == "custom") {
+        return environment::custom;
+    }
+    return environment::production;
+}
+
+inline environment next(environment value) {
+    switch (value) {
+    case environment::production:
+        return environment::development;
+    case environment::development:
+        return environment::custom;
+    case environment::custom:
+    default:
+        return environment::production;
+    }
+}
+
+inline environment previous(environment value) {
+    switch (value) {
+    case environment::production:
+        return environment::custom;
+    case environment::development:
+        return environment::production;
+    case environment::custom:
+    default:
+        return environment::development;
+    }
+}
+
+inline std::string configured_url(environment value, const std::string& custom_url) {
+    switch (value) {
+    case environment::development:
+        return kDevelopmentServerUrl;
+    case environment::custom:
+        return custom_url.empty() ? std::string(kDefaultCustomServerUrl) : custom_url;
+    case environment::production:
+    default:
+        return kProductionServerUrl;
+    }
+}
+
+std::string normalize_url(const std::string& server_url);
+std::string active_server_url_from_settings();
+
+}  // namespace server_environment

--- a/src/scenes/settings/settings_layout.h
+++ b/src/scenes/settings/settings_layout.h
@@ -12,7 +12,7 @@
 
 namespace settings {
 
-enum class page_id { gameplay, audio, video, key_config };
+enum class page_id { gameplay, audio, video, network, key_config };
 
 struct page_descriptor {
     const char* navigation_label;
@@ -21,7 +21,7 @@ struct page_descriptor {
 };
 
 inline constexpr ui::draw_layer kLayer = ui::draw_layer::base;
-inline constexpr int kPageCount = 4;
+inline constexpr int kPageCount = 5;
 inline constexpr float kSliderLeftInset = 327.0f;
 inline constexpr float kSliderRightInset = 63.0f;
 inline constexpr float kSliderTopOffset = 39.0f;
@@ -62,6 +62,7 @@ inline constexpr std::array<page_descriptor, kPageCount> kPageDescriptors = {{
     {"Gameplay", "Gameplay", "Play feel and lane settings"},
     {"Audio", "Audio", "BGM and sound effect volume"},
     {"Video", "Video", "Display and frame rate settings"},
+    {"Network", "Network", "Server environment"},
     {"Key Config", "Key Config", "Per-lane keyboard bindings"},
 }};
 
@@ -74,7 +75,9 @@ inline const Rectangle kSidebarHeaderRect = ui::place(kSidebarRect, kSidebarItem
                                                       ui::anchor::top_left, ui::anchor::top_left, kSidebarHeaderOffset);
 inline const Rectangle kSidebarHintRect = ui::place(kSidebarRect, kSidebarItemWidth, kSidebarHintHeight,
                                                     ui::anchor::top_left, ui::anchor::top_left, kSidebarHintOffset);
-inline const Rectangle kTabArea = ui::place(kSidebarRect, kSidebarItemWidth, 4.0f * kTabRowHeight + 3.0f * kTabRowGap,
+inline const Rectangle kTabArea = ui::place(kSidebarRect, kSidebarItemWidth,
+                                            static_cast<float>(kPageCount) * kTabRowHeight +
+                                                static_cast<float>(kPageCount - 1) * kTabRowGap,
                                             ui::anchor::top_center, ui::anchor::top_center, kTabAreaOffset);
 inline const Rectangle kBackRect = ui::place(kSidebarRect, kSidebarItemWidth, kBackHeight,
                                              ui::anchor::bottom_center, ui::anchor::bottom_center, kBackOffset);

--- a/src/scenes/settings/settings_pages.cpp
+++ b/src/scenes/settings/settings_pages.cpp
@@ -6,8 +6,11 @@
 #include <string>
 
 #include "raylib.h"
+#include "network/auth_client.h"
+#include "network/server_environment.h"
 #include "settings/settings_layout.h"
 #include "ui_draw.h"
+#include "ui_text_input.h"
 
 namespace {
 
@@ -20,6 +23,17 @@ constexpr float kNoteSpeedDisplayScale = 10.0f;
 
 std::string format_offset_label(int offset_ms) {
     return (offset_ms > 0 ? "+" : "") + std::to_string(offset_ms) + " ms";
+}
+
+std::string active_server_url(const game_settings& settings) {
+    return auth::normalize_server_url(
+        server_environment::configured_url(settings.server_env, settings.custom_server_url));
+}
+
+void clear_session_if_server_changed(const std::string& previous_url, const game_settings& settings) {
+    if (previous_url != active_server_url(settings)) {
+        auth::clear_saved_session();
+    }
 }
 
 }  // namespace
@@ -214,6 +228,66 @@ void settings_video_page::draw() const {
                              settings::kLayer, 22, settings::kSliderTopOffset);
     ui::draw_value_selector(settings::kGeneralRows[1], "Display", settings_.fullscreen ? "Fullscreen" : "Windowed", settings::kLayer);
     ui::draw_value_selector(settings::kGeneralRows[2], "Theme", settings_.dark_mode ? "Dark" : "Light", settings::kLayer);
+}
+
+settings_network_page::settings_network_page(game_settings& settings) : settings_(settings) {
+    custom_url_input_.value = settings_.custom_server_url;
+    custom_url_input_.cursor = ui::utf8_codepoint_count(custom_url_input_.value);
+}
+
+void settings_network_page::reset_interaction() {
+    custom_url_input_.active = false;
+    ui::clear_text_input_selection(custom_url_input_);
+}
+
+void settings_network_page::update() {
+    const std::string previous_url = active_server_url(settings_);
+    if (ui::is_clicked(settings::arrow_left_rect(settings::kGeneralRows[0]), settings::kLayer)) {
+        settings_.server_env = server_environment::previous(settings_.server_env);
+    } else if (ui::is_clicked(settings::arrow_right_rect(settings::kGeneralRows[0]), settings::kLayer)) {
+        settings_.server_env = server_environment::next(settings_.server_env);
+    }
+    clear_session_if_server_changed(previous_url, settings_);
+}
+
+void settings_network_page::draw() const {
+    ui::draw_value_selector(settings::kGeneralRows[0], "Server", server_environment::label(settings_.server_env),
+                            settings::kLayer);
+
+    const ui::text_input_result result = ui::draw_text_input(
+        settings::kGeneralRows[1],
+        custom_url_input_,
+        "Custom URL",
+        server_environment::kDefaultCustomServerUrl,
+        nullptr,
+        settings::kLayer,
+        18,
+        128,
+        ui::default_text_input_filter,
+        180.0f);
+    if (result.changed) {
+        const std::string previous_url = active_server_url(settings_);
+        settings_.custom_server_url = auth::normalize_server_url(custom_url_input_.value);
+        if (custom_url_input_.value != settings_.custom_server_url) {
+            custom_url_input_.value = settings_.custom_server_url;
+            custom_url_input_.cursor = ui::utf8_codepoint_count(custom_url_input_.value);
+        }
+        clear_session_if_server_changed(previous_url, settings_);
+    }
+
+    const std::string active_url = active_server_url(settings_);
+    const ui::row_state active_row =
+        ui::draw_row(settings::kGeneralRows[2], g_theme->row, g_theme->row_hover, g_theme->border);
+    const Rectangle active_content = ui::inset(active_row.visual, ui::edge_insets::symmetric(0.0f, 18.0f));
+    const ui::rect_pair active_columns = ui::split_columns(active_content, 180.0f);
+    ui::draw_text_in_rect("Active URL", 22, active_columns.first, g_theme->text, ui::text_align::left);
+    ui::draw_text_in_rect(active_url.c_str(), 18, active_columns.second, g_theme->text_dim, ui::text_align::right);
+
+    const ui::row_state sign_in_row =
+        ui::draw_row(settings::kGeneralRows[3], g_theme->row, g_theme->row_hover, g_theme->border);
+    const Rectangle sign_in_content = ui::inset(sign_in_row.visual, ui::edge_insets::symmetric(0.0f, 18.0f));
+    ui::draw_text_in_rect("Switching servers uses a separate sign-in session", 20,
+                          sign_in_content, g_theme->text_dim, ui::text_align::left);
 }
 
 settings_key_config_page::settings_key_config_page(game_settings& settings) : settings_(settings) {

--- a/src/scenes/settings/settings_pages.h
+++ b/src/scenes/settings/settings_pages.h
@@ -3,6 +3,7 @@
 #include "game_settings.h"
 #include "settings/settings_key_config_state.h"
 #include "settings/settings_runtime_applier.h"
+#include "ui_text_input.h"
 
 class settings_gameplay_page {
 public:
@@ -47,6 +48,19 @@ private:
     game_settings& settings_;
     const settings_runtime_applier& runtime_applier_;
     bool dragging_frame_rate_ = false;
+};
+
+class settings_network_page {
+public:
+    explicit settings_network_page(game_settings& settings);
+
+    void reset_interaction();
+    void update();
+    void draw() const;
+
+private:
+    game_settings& settings_;
+    mutable ui::text_input_state custom_url_input_;
 };
 
 class settings_key_config_page {

--- a/src/scenes/settings_scene.cpp
+++ b/src/scenes/settings_scene.cpp
@@ -20,6 +20,7 @@ settings_scene::settings_scene(scene_manager& manager, return_target target)
       gameplay_page_(g_settings),
       audio_page_(g_settings, runtime_applier_),
       video_page_(g_settings, runtime_applier_),
+      network_page_(g_settings),
       key_config_page_(g_settings) {
 }
 
@@ -34,6 +35,7 @@ void settings_scene::on_enter() {
     gameplay_page_.reset_interaction();
     audio_page_.reset_interaction();
     video_page_.reset_interaction();
+    network_page_.reset_interaction();
     key_config_page_.reset();
 }
 
@@ -118,6 +120,9 @@ void settings_scene::update_current_page() {
         case settings::page_id::video:
             video_page_.update();
             break;
+        case settings::page_id::network:
+            network_page_.update();
+            break;
         case settings::page_id::key_config:
             key_config_page_.update();
             break;
@@ -135,6 +140,9 @@ void settings_scene::draw_current_page() const {
         case settings::page_id::video:
             video_page_.draw();
             break;
+        case settings::page_id::network:
+            network_page_.draw();
+            break;
         case settings::page_id::key_config:
             key_config_page_.draw();
             break;
@@ -145,6 +153,7 @@ void settings_scene::change_page(settings::page_id next_page) {
     gameplay_page_.reset_interaction();
     audio_page_.reset_interaction();
     video_page_.reset_interaction();
+    network_page_.reset_interaction();
     if (current_page_ == settings::page_id::key_config && next_page != settings::page_id::key_config) {
         key_config_page_.clear_selection();
     }

--- a/src/scenes/settings_scene.h
+++ b/src/scenes/settings_scene.h
@@ -10,7 +10,7 @@
 
 struct editor_resume_state;
 
-// 設定画面。Gameplay / Audio / Video / Key Config の4ページ構成。
+// 設定画面。Gameplay / Audio / Video / Network / Key Config の5ページ構成。
 class settings_scene final : public scene {
 public:
     enum class return_target { title, song_select, editor };
@@ -36,5 +36,6 @@ private:
     settings_gameplay_page gameplay_page_;
     settings_audio_page audio_page_;
     settings_video_page video_page_;
+    settings_network_page network_page_;
     settings_key_config_page key_config_page_;
 };

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -6,6 +6,8 @@
 #include <thread>
 #include <utility>
 
+#include "game_settings.h"
+#include "network/server_environment.h"
 #include "ui_notice.h"
 
 namespace {
@@ -64,7 +66,8 @@ void start_request(controller& controller_state,
     }
 
     controller_state.request_active = true;
-    const std::string server_url = auth::kDefaultServerUrl;
+    const std::string server_url = auth::normalize_server_url(
+        server_environment::configured_url(g_settings.server_env, g_settings.custom_server_url));
     const std::string display_name = dialog_state.display_name_input.value;
     const std::string email = dialog_state.email_input.value;
     const std::string password = dialog_state.password_input.value;

--- a/src/scenes/song_select/song_catalog_service.cpp
+++ b/src/scenes/song_select/song_catalog_service.cpp
@@ -13,6 +13,7 @@
 #include "mv/mv_storage.h"
 #include "network/auth_client.h"
 #include "network/ranking_client.h"
+#include "network/server_environment.h"
 #include "path_utils.h"
 #include "player_note_offsets.h"
 #include "ranking_service.h"
@@ -95,7 +96,7 @@ std::string current_manifest_server_url() {
     if (!summary.server_url.empty()) {
         return auth::normalize_server_url(summary.server_url);
     }
-    return auth::normalize_server_url(auth::kDefaultServerUrl);
+    return server_environment::active_server_url_from_settings();
 }
 
 std::string expected_remote_song_id(const std::string& server_url,

--- a/src/scenes/title/online_download_remote_client.cpp
+++ b/src/scenes/title/online_download_remote_client.cpp
@@ -8,6 +8,7 @@
 
 #include "network/auth_client.h"
 #include "network/json_helpers.h"
+#include "network/server_environment.h"
 #include "title/online_download_view.h"
 
 #ifdef _WIN32
@@ -87,16 +88,7 @@ void push_candidate_server_url(std::vector<std::string>& urls, std::string url) 
 
 std::vector<std::string> resolve_server_urls() {
     std::vector<std::string> urls;
-    if (const std::optional<auth::session> saved = auth::load_saved_session(); saved.has_value()) {
-        push_candidate_server_url(urls, saved->server_url);
-    }
-
-    push_candidate_server_url(urls, auth::kDefaultServerUrl);
-    push_candidate_server_url(urls, auth::kLanServerUrl);
-    push_candidate_server_url(urls, "http://127.0.0.1:3000");
-    push_candidate_server_url(urls, "http://localhost:3000");
-    push_candidate_server_url(urls, "http://127.0.0.1");
-    push_candidate_server_url(urls, "http://localhost");
+    push_candidate_server_url(urls, server_environment::active_server_url_from_settings());
     return urls;
 }
 

--- a/src/scenes/title/title_settings_overlay.cpp
+++ b/src/scenes/title/title_settings_overlay.cpp
@@ -67,6 +67,7 @@ title_settings_overlay::title_settings_overlay(game_settings& settings)
     : gameplay_page_(settings),
       audio_page_(settings, runtime_applier_),
       video_page_(settings, runtime_applier_),
+      network_page_(settings),
       key_config_page_(settings) {
 }
 
@@ -77,6 +78,7 @@ void title_settings_overlay::open() {
     gameplay_page_.reset_interaction();
     audio_page_.reset_interaction();
     video_page_.reset_interaction();
+    network_page_.reset_interaction();
     key_config_page_.reset();
 }
 
@@ -201,6 +203,9 @@ void title_settings_overlay::update_current_page() {
         case settings::page_id::video:
             video_page_.update();
             break;
+        case settings::page_id::network:
+            network_page_.update();
+            break;
         case settings::page_id::key_config:
             key_config_page_.update();
             break;
@@ -218,6 +223,9 @@ void title_settings_overlay::draw_current_page() const {
         case settings::page_id::video:
             video_page_.draw();
             break;
+        case settings::page_id::network:
+            network_page_.draw();
+            break;
         case settings::page_id::key_config:
             key_config_page_.draw();
             break;
@@ -228,6 +236,7 @@ void title_settings_overlay::change_page(settings::page_id next_page) {
     gameplay_page_.reset_interaction();
     audio_page_.reset_interaction();
     video_page_.reset_interaction();
+    network_page_.reset_interaction();
     if (current_page_ == settings::page_id::key_config && next_page != settings::page_id::key_config) {
         key_config_page_.clear_selection();
     }

--- a/src/scenes/title/title_settings_overlay.h
+++ b/src/scenes/title/title_settings_overlay.h
@@ -28,6 +28,7 @@ private:
     settings_gameplay_page gameplay_page_;
     settings_audio_page audio_page_;
     settings_video_page video_page_;
+    settings_network_page network_page_;
     settings_key_config_page key_config_page_;
     settings::page_id current_page_ = settings::page_id::gameplay;
     float animation_ = 0.0f;

--- a/src/scenes/title_scene.cpp
+++ b/src/scenes/title_scene.cpp
@@ -557,6 +557,7 @@ bool title_scene::handle_home_input(bool suppress_pointer_this_frame) {
 void title_scene::update_settings_mode(float dt) {
     if (settings_overlay_.closing()) {
         if (settings_overlay_.closed()) {
+            auth_overlay::refresh_auth_state(play_state_.auth);
             const hub_mode return_mode = settings_return_mode_;
             switch (return_mode) {
                 case hub_mode::title:

--- a/src/tests/settings_io_smoke.cpp
+++ b/src/tests/settings_io_smoke.cpp
@@ -81,6 +81,8 @@ int main() {
         defaults.target_fps = 240;
         defaults.fullscreen = true;
         defaults.dark_mode = true;
+        defaults.server_env = server_environment::environment::development;
+        defaults.custom_server_url = "http://localhost:3000/dev";
 
         initialize_settings_storage(defaults);
 
@@ -108,6 +110,15 @@ int main() {
                ok);
         expect(loaded.dark_mode == defaults.dark_mode,
                "Expected default dark mode flag to be written to settings.json.",
+               ok);
+        expect(loaded.server_env == defaults.server_env,
+               "Expected server environment to be written to settings.json.",
+               ok);
+        expect(loaded.custom_server_url == defaults.custom_server_url,
+               "Expected custom server URL to be written to settings.json.",
+               ok);
+        expect(server_environment::active_server_url_from_settings() == "https://dev-api.raythm.net",
+               "Expected active server URL to resolve the development environment.",
                ok);
 
         game_settings different_defaults = defaults;


### PR DESCRIPTION
## 概要
- API 接続先を CMake 変数で決める `server_environment` に整理
- ローカル/通常ビルドの default は `RAYTHM_SERVER_ENV=development` とし、`https://dev-api.raythm.net` を使用
- release workflow は production 固定にせず、GitHub repository variable `RAYTHM_SERVER_ENV` があればその値、未設定なら `development` を使用
- ローカル検証用に `RAYTHM_API_BASE_URL` で明示 override 可能
- 認証、オンラインカタログ、ランキング manifest / ruleset の参照先を active server URL に統一
- prod/dev/LAN の自動 fallback とユーザー向け URL 入力/設定 UI を削除
- 認証クライアント内に残っていた legacy/fallback/candidate 系ヘルパー名と複数URL試行経路も削除
- `.rchart` の `songId` 必須/書き出しを廃止
- 譜面の保存先を `songs/{songId}/charts/{chartId}.rchart` に統一し、外部 `charts/` 読み取り口を削除
- `chart_identity_store` と `local_chart_id -> local_song_id` 所属リンクを削除し、オンライン用 `chart_bindings` からも `local_song_id` を除去
- サーバーの曲 metadata を配布DTOとして扱い、ダウンロード時に `localSongId` を `songId` として付与したローカル `song.json` へ正規化
- 配布 `.rchart` に `level` / `isPublic` などのサーバー管理metadataが含まれていても取り込み可能にし、保存時は書き出さない正規形式へ変換
- 譜面 fingerprint は `chartId` / `songId` とサーバー管理metadataを除外して、配布ID・ローカルID・DB保存項目差分に依存しない比較へ整理
- オンラインカタログ表示用の `calculatedLevel` / `noteCount` / `minBpm` / `maxBpm` はサーバー計算値を受け取り、ローカル保存済み譜面はクライアント計算値/キャッシュを使う整理

## サーバー側の前提
- `/songs/:songId/metadata` は配布DTOとして `songId` を含めなくてよい
- `/charts/:chartId/file` の `.rchart` は譜面プレイに必要な最小metadataだけを返す
  - 残す: `chartId`, `keyCount`, `difficulty`, `chartAuthor`, `formatVersion`, `resolution`, `offset`
  - 可能なら含めない: `songId`, `level`, `calculatedLevel`, `isPublic`, `contentSource`, `metadataSchemaVersion`, `clientChartId`, `clientSongId`, `difficultyRulesetId`, `difficultyRulesetVersion`
- `isPublic`, `contentSource`, `calculatedLevel`, `noteCount`, `minBpm`, `maxBpm`, `difficultyRulesetId`, `difficultyRulesetVersion`, `clientChartId`, `clientSongId` などはサーバーDB / catalog API / manifest API 側で保持する
- オンラインカタログ/譜面一覧APIは、譜面ファイルを未ダウンロードのクライアントでも表示できるように以下を返す
  - `calculatedLevel`: サーバー側で譜面を parse して計算した表示レベル
  - `noteCount`: サーバー側で譜面を parse して計算したノーツ数
  - `minBpm` / `maxBpm`: サーバー側で `[Timing]` の BPM イベントから算出したBPM範囲
- クライアントはオンライン表示では上記サーバー計算値を使い、ダウンロード後のローカル表示ではローカル `.rchart` から計算/キャッシュする
- Official / Community 判定用 manifest は raw SHA だけでなく `songJsonFingerprint` と `chartFingerprint` を返す
  - `songJsonFingerprint`: `songId` 等のローカル保存差分を除いた曲 metadata fingerprint
  - `chartFingerprint`: `chartId` / `songId` / サーバー管理metadataを除いた譜面 fingerprint

## 確認
- `cmake -S . -B cmake-build-codex -G "MinGW Makefiles" -DCMAKE_C_COMPILER=C:/Users/rento/Documents/w64devkit/bin/gcc.exe -DCMAKE_CXX_COMPILER=C:/Users/rento/Documents/w64devkit/bin/g++.exe -DRAYTHM_SERVER_ENV=development`
- `cmake-build-codex/CMakeCache.txt`: `RAYTHM_SERVER_ENV:STRING=development`
- `cmake-build-codex/CMakeFiles/raythm.dir/flags.make`: `-DRAYTHM_SERVER_ENV=\"development\"`
- `cmake --build cmake-build-codex --target raythm chart_parser_smoke chart_serializer_smoke -j 2`
- `ctest --test-dir cmake-build-codex --output-on-failure -j 2`
  - 28 tests: 27 passed, 1 skipped (`audio_manager_smoke`)
- `git diff --check`
- 旧式検索: `serverEnvironment`, `settings_network_page`, `active_server_url_from_settings`, `customServerUrl`, `send_auth_json_with_fallback`, `candidate_server_urls`, `localhost`, `127.0.0.1`, `192.168` は残存なし
- 譜面旧式検索: `charts_root`, `chart_identity_store`, `attach_external_charts`, `link_chart_to_song`, `linked_song_for_chart`, `unlink_chart`, `unlink_charts_for_song`, `chart_identity::` は残存なし