### PR TITLE
譜面更新ラベルをchartVersionで判定

### DIFF
--- a/src/models/data_models.h
+++ b/src/models/data_models.h
@@ -45,6 +45,7 @@ struct song_load_result {
 struct chart_meta {
     std::string chart_id;
     std::string song_id;
+    int chart_version = 0;
     int key_count = 0;
     std::string difficulty;
     float level = 0.0f;

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -69,6 +69,7 @@ struct upload_request_result {
     std::string message;
     std::string remote_song_id;
     std::string remote_chart_id;
+    int remote_chart_version = 0;
 };
 
 #ifdef _WIN32
@@ -553,6 +554,7 @@ upload_request_result parse_chart_upload_response(const http_response& response,
 
     result.success = true;
     result.remote_chart_id = *chart_id;
+    result.remote_chart_version = json::extract_int(*chart_object, "chartVersion").value_or(0);
     result.message = updated_existing ? "Chart upload updated." : "Chart uploaded.";
     return result;
 }
@@ -948,6 +950,7 @@ upload_result upload_chart(const song_select::song_entry& song,
         .local_chart_id = chart.meta.chart_id,
         .remote_chart_id = request_result.remote_chart_id,
         .remote_song_id = *remote_song_id,
+        .remote_chart_version = request_result.remote_chart_version,
         .origin = local_content_index::online_origin::owned_upload,
     });
 

--- a/src/scenes/title/local_content_binding.h
+++ b/src/scenes/title/local_content_binding.h
@@ -23,6 +23,7 @@ struct chart_binding {
     std::string local_chart_id;
     std::string remote_chart_id;
     std::string remote_song_id;
+    int remote_chart_version = 0;
     origin origin = origin::owned_upload;
 };
 

--- a/src/scenes/title/local_content_database.cpp
+++ b/src/scenes/title/local_content_database.cpp
@@ -70,6 +70,19 @@ bool chart_bindings_has_local_song_id(sqlite3* database) {
     return false;
 }
 
+bool chart_bindings_has_remote_chart_version(sqlite3* database) {
+    statement columns(database, "PRAGMA table_info(chart_bindings);");
+    if (!columns.valid()) {
+        return false;
+    }
+    while (sqlite3_step(columns.get()) == SQLITE_ROW) {
+        if (column_text(columns.get(), 1) == "remote_chart_version") {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool migrate_chart_bindings_without_local_song_id(sqlite3* database) {
     if (!chart_bindings_has_local_song_id(database)) {
         return true;
@@ -84,14 +97,15 @@ bool migrate_chart_bindings_without_local_song_id(sqlite3* database) {
                 "local_chart_id TEXT NOT NULL,"
                 "remote_chart_id TEXT NOT NULL,"
                 "remote_song_id TEXT NOT NULL,"
+                "remote_chart_version INTEGER NOT NULL DEFAULT 0,"
                 "origin INTEGER NOT NULL,"
                 "updated_at INTEGER NOT NULL,"
                 "PRIMARY KEY (server_url, local_chart_id)"
                 ");") &&
            exec(database,
                 "INSERT OR REPLACE INTO chart_bindings_new("
-                "server_url, local_chart_id, remote_chart_id, remote_song_id, origin, updated_at) "
-                "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, origin, updated_at "
+                "server_url, local_chart_id, remote_chart_id, remote_song_id, remote_chart_version, origin, updated_at) "
+                "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, 0, origin, updated_at "
                 "FROM chart_bindings;") &&
            exec(database, "DROP TABLE chart_bindings;") &&
            exec(database, "ALTER TABLE chart_bindings_new RENAME TO chart_bindings;") &&
@@ -99,6 +113,11 @@ bool migrate_chart_bindings_without_local_song_id(sqlite3* database) {
                 "CREATE UNIQUE INDEX idx_chart_bindings_remote "
                 "ON chart_bindings(server_url, remote_chart_id);") &&
            tx.commit();
+}
+
+bool ensure_chart_binding_version_column(sqlite3* database) {
+    return chart_bindings_has_remote_chart_version(database) ||
+           exec(database, "ALTER TABLE chart_bindings ADD COLUMN remote_chart_version INTEGER NOT NULL DEFAULT 0;");
 }
 
 bool ensure_schema(sqlite3* database) {
@@ -121,6 +140,7 @@ bool ensure_schema(sqlite3* database) {
                 "local_chart_id TEXT NOT NULL,"
                 "remote_chart_id TEXT NOT NULL,"
                 "remote_song_id TEXT NOT NULL,"
+                "remote_chart_version INTEGER NOT NULL DEFAULT 0,"
                 "origin INTEGER NOT NULL,"
                 "updated_at INTEGER NOT NULL,"
                 "PRIMARY KEY (server_url, local_chart_id)"
@@ -129,6 +149,7 @@ bool ensure_schema(sqlite3* database) {
                 "CREATE UNIQUE INDEX IF NOT EXISTS idx_chart_bindings_remote "
                 "ON chart_bindings(server_url, remote_chart_id);") &&
            migrate_chart_bindings_without_local_song_id(database) &&
+           ensure_chart_binding_version_column(database) &&
            exec(database,
                 "INSERT INTO metadata(key, value) VALUES('schema_version', '2') "
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value;");
@@ -209,11 +230,12 @@ void put_chart(sqlite3* database, const local_content_binding::chart_binding& bi
 
     statement query(database,
                     "INSERT INTO chart_bindings(server_url, local_chart_id, remote_chart_id, "
-                    "remote_song_id, origin, updated_at) "
-                    "VALUES(?, ?, ?, ?, ?, ?) "
+                    "remote_song_id, remote_chart_version, origin, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?) "
                     "ON CONFLICT(server_url, local_chart_id) DO UPDATE SET "
                     "remote_chart_id = excluded.remote_chart_id,"
                     "remote_song_id = excluded.remote_song_id,"
+                    "remote_chart_version = excluded.remote_chart_version,"
                     "origin = excluded.origin,"
                     "updated_at = excluded.updated_at;");
     if (!query.valid()) {
@@ -223,8 +245,9 @@ void put_chart(sqlite3* database, const local_content_binding::chart_binding& bi
     bind_text(query.get(), 2, binding.local_chart_id);
     bind_text(query.get(), 3, binding.remote_chart_id);
     bind_text(query.get(), 4, binding.remote_song_id);
-    sqlite3_bind_int(query.get(), 5, origin_to_int(origin));
-    sqlite3_bind_int64(query.get(), 6, now_unix_seconds());
+    sqlite3_bind_int(query.get(), 5, binding.remote_chart_version);
+    sqlite3_bind_int(query.get(), 6, origin_to_int(origin));
+    sqlite3_bind_int64(query.get(), 7, now_unix_seconds());
     step_done(query.get());
 }
 
@@ -254,7 +277,8 @@ std::optional<local_content_binding::chart_binding> read_chart(sqlite3_stmt* sta
         .local_chart_id = column_text(statement, 1),
         .remote_chart_id = column_text(statement, 2),
         .remote_song_id = column_text(statement, 3),
-        .origin = origin_from_int(sqlite3_column_int(statement, 4)),
+        .remote_chart_version = sqlite3_column_int(statement, 4),
+        .origin = origin_from_int(sqlite3_column_int(statement, 5)),
     };
 }
 
@@ -314,7 +338,7 @@ local_content_binding::store load_mappings() {
     }
 
     statement charts(database.get(),
-                     "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, origin "
+                     "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, remote_chart_version, origin "
                      "FROM chart_bindings ORDER BY server_url, local_chart_id;");
     if (charts.valid()) {
         while (sqlite3_step(charts.get()) == SQLITE_ROW) {
@@ -323,7 +347,8 @@ local_content_binding::store load_mappings() {
                 .local_chart_id = column_text(charts.get(), 1),
                 .remote_chart_id = column_text(charts.get(), 2),
                 .remote_song_id = column_text(charts.get(), 3),
-                .origin = origin_from_int(sqlite3_column_int(charts.get(), 4)),
+                .remote_chart_version = sqlite3_column_int(charts.get(), 4),
+                .origin = origin_from_int(sqlite3_column_int(charts.get(), 5)),
             });
         }
     }
@@ -362,7 +387,7 @@ std::optional<local_content_binding::chart_binding> find_chart_by_local(const st
     local_sqlite::database database = open_ready_database();
     if (database.valid()) {
         return find_chart(database.get(),
-                          "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, origin "
+                          "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, remote_chart_version, origin "
                           "FROM chart_bindings WHERE server_url = ? AND local_chart_id = ?;",
                           server_url,
                           local_chart_id);
@@ -375,7 +400,7 @@ std::optional<local_content_binding::chart_binding> find_chart_by_remote(const s
     local_sqlite::database database = open_ready_database();
     if (database.valid()) {
         return find_chart(database.get(),
-                          "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, origin "
+                          "SELECT server_url, local_chart_id, remote_chart_id, remote_song_id, remote_chart_version, origin "
                           "FROM chart_bindings WHERE server_url = ? AND remote_chart_id = ?;",
                           server_url,
                           remote_chart_id);

--- a/src/scenes/title/local_content_index.cpp
+++ b/src/scenes/title/local_content_index.cpp
@@ -20,6 +20,7 @@ online_chart_binding to_index_binding(const local_content_binding::chart_binding
         .local_chart_id = entry.local_chart_id,
         .remote_chart_id = entry.remote_chart_id,
         .remote_song_id = entry.remote_song_id,
+        .remote_chart_version = entry.remote_chart_version,
         .origin = entry.origin,
     };
 }
@@ -127,6 +128,7 @@ void put_chart_binding(const online_chart_binding& binding) {
         .local_chart_id = binding.local_chart_id,
         .remote_chart_id = binding.remote_chart_id,
         .remote_song_id = binding.remote_song_id,
+        .remote_chart_version = binding.remote_chart_version,
         .origin = binding.origin,
     });
 }

--- a/src/scenes/title/local_content_index.h
+++ b/src/scenes/title/local_content_index.h
@@ -22,6 +22,7 @@ struct online_chart_binding {
     std::string local_chart_id;
     std::string remote_chart_id;
     std::string remote_song_id;
+    int remote_chart_version = 0;
     online_origin origin = online_origin::owned_upload;
 };
 

--- a/src/scenes/title/online_download_catalog.cpp
+++ b/src/scenes/title/online_download_catalog.cpp
@@ -187,6 +187,12 @@ void append_chart_page(song_entry_state& song_state,
                             }
                             return matches;
                         });
+        const bool chart_update_available =
+            local_chart_installed &&
+            binding.has_value() &&
+            chart.chart_version > (binding->remote_chart_version > 0
+                ? binding->remote_chart_version
+                : 1);
 
         song_state.charts.push_back({
             {
@@ -194,6 +200,7 @@ void append_chart_page(song_entry_state& song_state,
                 chart_meta{
                     .chart_id = chart.id,
                     .song_id = chart.song_id,
+                    .chart_version = chart.chart_version,
                     .key_count = chart.key_count,
                     .difficulty = chart.difficulty_name,
                     .level = chart.level,
@@ -211,7 +218,7 @@ void append_chart_page(song_entry_state& song_state,
             },
             installed_local_chart_id,
             local_chart_installed,
-            false,
+            chart_update_available,
         });
     }
 

--- a/src/scenes/title/online_download_remote_client.cpp
+++ b/src/scenes/title/online_download_remote_client.cpp
@@ -386,6 +386,7 @@ std::optional<remote_chart_payload> parse_remote_chart(const std::string& object
         .song_id = *song_id,
         .key_count = json::extract_int(object, "keyCount").value_or(4),
         .difficulty_name = *difficulty_name,
+        .chart_version = json::extract_int(object, "chartVersion").value_or(0),
         .level = json::extract_float(object, "calculatedLevel").value_or(0.0f),
         .chart_author = json::extract_string(object, "chartAuthor").value_or(""),
         .format_version = json::extract_int(object, "formatVersion").value_or(0),

--- a/src/scenes/title/online_download_remote_client.h
+++ b/src/scenes/title/online_download_remote_client.h
@@ -26,6 +26,7 @@ struct remote_chart_payload {
     std::string song_id;
     int key_count = 0;
     std::string difficulty_name;
+    int chart_version = 0;
     float level = 0.0f;
     std::string chart_author;
     int format_version = 0;

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -386,6 +386,7 @@ download_song_result download_chart_file(const song_entry_state song,
         .local_chart_id = local_chart_id,
         .remote_chart_id = result.chart_id,
         .remote_song_id = result.song_id,
+        .remote_chart_version = chart.chart.meta.chart_version,
         .origin = local_content_index::online_origin::downloaded,
     });
 

--- a/src/tests/chart_serializer_smoke.cpp
+++ b/src/tests/chart_serializer_smoke.cpp
@@ -21,6 +21,7 @@ bool almost_equal(float left, float right) {
 bool equal_chart_meta(const chart_meta& left, const chart_meta& right) {
     return left.chart_id == right.chart_id &&
            left.song_id == right.song_id &&
+           left.chart_version == right.chart_version &&
            left.key_count == right.key_count &&
            left.difficulty == right.difficulty &&
            left.chart_author == right.chart_author &&

--- a/src/tests/local_content_index_smoke.cpp
+++ b/src/tests/local_content_index_smoke.cpp
@@ -35,6 +35,7 @@ int main() {
         .local_chart_id = "local-chart",
         .remote_chart_id = "remote-chart",
         .remote_song_id = "remote-song",
+        .remote_chart_version = 7,
         .origin = local_content_index::online_origin::downloaded,
     });
 
@@ -53,6 +54,7 @@ int main() {
     ok = chart_by_local.has_value() && chart_by_local->remote_chart_id == "remote-chart" && ok;
     ok = chart_by_remote.has_value() && chart_by_remote->local_chart_id == "local-chart" && ok;
     ok = chart_by_local.has_value() &&
+         chart_by_local->remote_chart_version == 7 &&
          chart_by_local->origin == local_content_index::online_origin::downloaded && ok;
 
     std::filesystem::remove_all(appdata_root, ec);


### PR DESCRIPTION
## 概要
- リモート譜面の `chartVersion` を catalog DTO として受け取る
- `chart_bindings` にインストール済み remote chart version を保存する
- ローカルに入っている譜面の remote version が古い場合に `UPDATE CHART` を表示する
- 譜面ダウンロード/投稿成功時に binding の chart version を更新する

## 確認
- `cmake --build cmake-build-codex --target raythm local_content_index_smoke chart_serializer_smoke -j 2`
- `ctest --test-dir cmake-build-codex --output-on-failure -j 2`
- `git diff --check`

## サーバー側
- 対応PR: https://github.com/Rofutok112/raythm-server/pull/69