### PR TITLE
profile外部リンク移行とgenre表示対応

### DIFF
--- a/documents/metadata-flow-normalization.md
+++ b/documents/metadata-flow-normalization.md
@@ -96,7 +96,6 @@ Song upload fields:
 - `songJsonFingerprint`
 - `audioSha256`
 - `jacketSha256`
-- `externalLinks`
 - files: `audio`, `jacket`
 
 Chart upload fields:

--- a/src/gameplay/song_loader.cpp
+++ b/src/gameplay/song_loader.cpp
@@ -182,6 +182,7 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
     const std::optional<std::string> song_id = extract_json_string(content, "songId");
     const std::optional<std::string> title = extract_json_string(content, "title");
     const std::optional<std::string> artist = extract_json_string(content, "artist");
+    const std::optional<std::string> genre = extract_json_string(content, "genre");
     const std::optional<std::string> audio_file = extract_json_string(content, "audioFile");
     const std::optional<std::string> jacket_file = extract_json_string(content, "jacketFile");
     const std::optional<std::string> difficulty_bpm = extract_json_number_token(content, "baseBpm");
@@ -204,6 +205,10 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
         errors.push_back("Missing required field artist in " + path_utils::to_utf8(song_json_path));
     } else {
         meta.artist = *artist;
+    }
+
+    if (genre.has_value()) {
+        meta.genre = *genre;
     }
 
     if (!audio_file.has_value()) {
@@ -239,19 +244,6 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
         }
     } else {
         errors.push_back("Missing required field previewStartMs in " + path_utils::to_utf8(song_json_path));
-    }
-
-    const std::optional<std::string> sns_youtube = extract_json_string(content, "snsYoutube");
-    if (sns_youtube.has_value()) {
-        meta.sns_youtube = *sns_youtube;
-    }
-    const std::optional<std::string> sns_niconico = extract_json_string(content, "snsNiconico");
-    if (sns_niconico.has_value()) {
-        meta.sns_niconico = *sns_niconico;
-    }
-    const std::optional<std::string> sns_x = extract_json_string(content, "snsX");
-    if (sns_x.has_value()) {
-        meta.sns_x = *sns_x;
     }
 
     if (!song_version.has_value()) {

--- a/src/gameplay/song_writer.cpp
+++ b/src/gameplay/song_writer.cpp
@@ -51,21 +51,14 @@ bool song_writer::write_song_json(const song_meta& meta, const std::string& dire
     out << "  \"songId\": \"" << escape_json_string(meta.song_id) << "\",\n";
     out << "  \"title\": \"" << escape_json_string(meta.title) << "\",\n";
     out << "  \"artist\": \"" << escape_json_string(meta.artist) << "\",\n";
+    if (!meta.genre.empty()) {
+        out << "  \"genre\": \"" << escape_json_string(meta.genre) << "\",\n";
+    }
     out << "  \"baseBpm\": " << format_float(meta.base_bpm) << ",\n";
     out << "  \"audioFile\": \"" << escape_json_string(meta.audio_file) << "\",\n";
     out << "  \"jacketFile\": \"" << escape_json_string(meta.jacket_file) << "\",\n";
     out << "  \"previewStartMs\": " << meta.preview_start_ms << ",\n";
     out << "  \"songVersion\": " << meta.song_version;
-
-    if (!meta.sns_youtube.empty()) {
-        out << ",\n  \"snsYoutube\": \"" << escape_json_string(meta.sns_youtube) << "\"";
-    }
-    if (!meta.sns_niconico.empty()) {
-        out << ",\n  \"snsNiconico\": \"" << escape_json_string(meta.sns_niconico) << "\"";
-    }
-    if (!meta.sns_x.empty()) {
-        out << ",\n  \"snsX\": \"" << escape_json_string(meta.sns_x) << "\"";
-    }
 
     out << "\n}\n";
 

--- a/src/models/data_models.h
+++ b/src/models/data_models.h
@@ -12,6 +12,7 @@ struct song_meta {
     std::string song_id;
     std::string title;
     std::string artist;
+    std::string genre;
     float base_bpm = 0.0f;
     std::string audio_file;
     std::string jacket_file;
@@ -21,9 +22,6 @@ struct song_meta {
     float preview_start_seconds = 0.0f;
     int preview_start_ms = 0;
     int song_version = 0;
-    std::string sns_youtube;
-    std::string sns_niconico;
-    std::string sns_x;
 };
 
 // 曲一覧で扱う読み込み済み楽曲データ。

--- a/src/network/auth_client.cpp
+++ b/src/network/auth_client.cpp
@@ -42,12 +42,27 @@ std::optional<auth::public_user> parse_user_object(const std::string& content) {
     }
 
     const bool email_verified = json::extract_bool(content, "emailVerified").value_or(false);
+    std::vector<auth::external_link> external_links;
+    if (const std::optional<std::string> links_array = json::extract_array(content, "externalLinks");
+        links_array.has_value()) {
+        for (const std::string& link_object : json::extract_objects_from_array(*links_array)) {
+            const std::string url = json::extract_string(link_object, "url").value_or("");
+            if (url.empty()) {
+                continue;
+            }
+            external_links.push_back({
+                .label = json::extract_string(link_object, "label").value_or(""),
+                .url = url,
+            });
+        }
+    }
 
     return auth::public_user{
         .id = *id,
         .email = *email,
         .display_name = *display_name,
         .email_verified = email_verified,
+        .external_links = std::move(external_links),
     };
 }
 
@@ -131,6 +146,7 @@ std::optional<auth::community_song_upload> parse_community_song_upload(const std
         .client_song_id = json::extract_string(object, "clientSongId").value_or(""),
         .title = *title,
         .artist = json::extract_string(object, "artist").value_or(""),
+        .genre = json::extract_string(object, "genre").value_or(""),
         .content_source = json::extract_string(object, "contentSource").value_or("community"),
         .visibility = json::extract_string(object, "visibility").value_or("public"),
         .base_bpm = json::extract_float(object, "baseBpm").value_or(0.0f),
@@ -191,6 +207,7 @@ std::optional<auth::profile_ranking_record> parse_profile_ranking_record(const s
         .song_id = *song_id,
         .song_title = *song_title,
         .artist = json::extract_string(object, "artist").value_or(""),
+        .genre = json::extract_string(object, "genre").value_or(""),
         .difficulty_name = *difficulty_name,
         .chart_author = json::extract_string(object, "chartAuthor").value_or(""),
         .clear_rank = json::extract_string(object, "clearRank").value_or(""),
@@ -243,7 +260,17 @@ bool write_session_file(const auth::session& session_data) {
     output << "    \"id\": \"" << json::escape_string(session_data.user.id) << "\",\n";
     output << "    \"email\": \"" << json::escape_string(session_data.user.email) << "\",\n";
     output << "    \"displayName\": \"" << json::escape_string(session_data.user.display_name) << "\",\n";
-    output << "    \"emailVerified\": " << (session_data.user.email_verified ? "true" : "false") << "\n";
+    output << "    \"emailVerified\": " << (session_data.user.email_verified ? "true" : "false") << ",\n";
+    output << "    \"externalLinks\": [";
+    for (size_t i = 0; i < session_data.user.external_links.size(); ++i) {
+        const auth::external_link& link = session_data.user.external_links[i];
+        if (i > 0) {
+            output << ", ";
+        }
+        output << "{\"label\":\"" << json::escape_string(link.label)
+               << "\",\"url\":\"" << json::escape_string(link.url) << "\"}";
+    }
+    output << "]\n";
     output << "  }\n";
     output << "}\n";
     return output.good();
@@ -446,6 +473,7 @@ session_summary load_session_summary() {
             .email = {},
             .display_name = {},
             .email_verified = false,
+            .external_links = {},
         };
     }
 
@@ -455,6 +483,7 @@ session_summary load_session_summary() {
         .email = stored->user.email,
         .display_name = stored->user.display_name,
         .email_verified = stored->user.email_verified,
+        .external_links = stored->user.external_links,
     };
 }
 

--- a/src/network/auth_client.h
+++ b/src/network/auth_client.h
@@ -12,11 +12,17 @@ inline constexpr const char* kProductionServerUrl = server_environment::kProduct
 inline constexpr const char* kDevelopmentServerUrl = server_environment::kDevelopmentServerUrl;
 inline constexpr const char* kDefaultServerUrl = kProductionServerUrl;
 
+struct external_link {
+    std::string label;
+    std::string url;
+};
+
 struct public_user {
     std::string id;
     std::string email;
     std::string display_name;
     bool email_verified = false;
+    std::vector<external_link> external_links;
 };
 
 struct session {
@@ -32,6 +38,7 @@ struct session_summary {
     std::string email;
     std::string display_name;
     bool email_verified = false;
+    std::vector<external_link> external_links;
 };
 
 enum class verification_purpose {
@@ -54,6 +61,7 @@ struct community_song_upload {
     std::string client_song_id;
     std::string title;
     std::string artist;
+    std::string genre;
     std::string content_source;
     std::string visibility;
     float base_bpm = 0.0f;
@@ -93,6 +101,7 @@ struct profile_ranking_record {
     std::string song_id;
     std::string song_title;
     std::string artist;
+    std::string genre;
     std::string difficulty_name;
     std::string chart_author;
     std::string clear_rank;

--- a/src/scenes/shared/auth_overlay_controller.cpp
+++ b/src/scenes/shared/auth_overlay_controller.cpp
@@ -48,6 +48,7 @@ void refresh_auth_state(song_select::auth_state& auth_state) {
     auth_state.email = summary.email;
     auth_state.display_name = summary.display_name;
     auth_state.email_verified = summary.email_verified;
+    auth_state.external_links = summary.external_links;
 }
 
 void start_restore(controller& controller_state, song_select::login_dialog_state&) {

--- a/src/scenes/song_create_scene.cpp
+++ b/src/scenes/song_create_scene.cpp
@@ -99,11 +99,9 @@ song_create_scene::song_create_scene(scene_manager& manager, song_data song_to_e
     const song_meta& meta = editing_song_->meta;
     title_input_.value = meta.title;
     artist_input_.value = meta.artist;
+    genre_input_.value = meta.genre;
     bpm_input_.value = meta.base_bpm > 0.0f ? TextFormat("%.6g", meta.base_bpm) : "";
     preview_ms_input_.value = std::to_string(meta.preview_start_ms);
-    sns_youtube_input_.value = meta.sns_youtube;
-    sns_niconico_input_.value = meta.sns_niconico;
-    sns_x_input_.value = meta.sns_x;
 
     if (!meta.audio_file.empty()) {
         audio_path_input_.value = path_utils::to_utf8(path_utils::join_utf8(editing_song_->directory, meta.audio_file));
@@ -192,6 +190,9 @@ void song_create_scene::draw_song_metadata() {
     ui::draw_text_input(make_row(row++), artist_input_, "Artist", "Artist name",
                         nullptr, kLayer, 16, 128, wide_text_filter, kTextInputLabelWidth);
 
+    ui::draw_text_input(make_row(row++), genre_input_, "Genre", "Genre (optional)",
+                        nullptr, kLayer, 16, 100, wide_text_filter, kTextInputLabelWidth);
+
     ui::draw_text_input(make_row(row++), bpm_input_, "BPM", "120.0",
                         nullptr, kLayer, 16, 16, numeric_filter, kTextInputLabelWidth);
 
@@ -232,13 +233,6 @@ void song_create_scene::draw_song_metadata() {
 
     ui::draw_text_input(make_row(row++), preview_ms_input_, "Preview (ms)", "0",
                         "0", kLayer, 16, 10, int_filter, kTextInputLabelWidth);
-
-    ui::draw_text_input(make_row(row++), sns_youtube_input_, "YouTube", "URL (optional)",
-                        nullptr, kLayer, 16, 256, nullptr, kTextInputLabelWidth);
-    ui::draw_text_input(make_row(row++), sns_niconico_input_, "Niconico", "URL (optional)",
-                        nullptr, kLayer, 16, 256, nullptr, kTextInputLabelWidth);
-    ui::draw_text_input(make_row(row++), sns_x_input_, "X", "URL (optional)",
-                        nullptr, kLayer, 16, 256, nullptr, kTextInputLabelWidth);
 
     const float button_y = kFormStartY + static_cast<float>(row) * (kRowHeight + kRowGap) + kButtonTopGap;
     const Rectangle create_rect = {kFormX + kFormWidth - kButtonWidth, button_y, kButtonWidth, kButtonHeight};
@@ -369,15 +363,13 @@ bool song_create_scene::create_song() {
     meta.song_id = song_id;
     meta.title = title_input_.value;
     meta.artist = artist_input_.value;
+    meta.genre = genre_input_.value;
     meta.base_bpm = base_bpm;
     meta.audio_file = audio_filename;
     meta.jacket_file = jacket_filename;
     meta.preview_start_ms = preview_ms;
     meta.preview_start_seconds = static_cast<float>(preview_ms) / 1000.0f;
     meta.song_version = 1;
-    meta.sns_youtube = sns_youtube_input_.value;
-    meta.sns_niconico = sns_niconico_input_.value;
-    meta.sns_x = sns_x_input_.value;
 
     if (!song_writer::write_song_json(meta, path_utils::to_utf8(song_dir))) {
         error_ = "Failed to write song.json.";
@@ -476,14 +468,12 @@ bool song_create_scene::save_song_edits() {
     song_meta meta = editing_song_->meta;
     meta.title = title_input_.value;
     meta.artist = artist_input_.value;
+    meta.genre = genre_input_.value;
     meta.base_bpm = base_bpm;
     meta.audio_file = audio_filename;
     meta.jacket_file = jacket_filename;
     meta.preview_start_ms = preview_ms;
     meta.preview_start_seconds = static_cast<float>(preview_ms) / 1000.0f;
-    meta.sns_youtube = sns_youtube_input_.value;
-    meta.sns_niconico = sns_niconico_input_.value;
-    meta.sns_x = sns_x_input_.value;
     if (meta.song_version <= 0) {
         meta.song_version = 1;
     }

--- a/src/scenes/song_create_scene.h
+++ b/src/scenes/song_create_scene.h
@@ -40,13 +40,11 @@ private:
     // Song metadata inputs
     ui::text_input_state title_input_;
     ui::text_input_state artist_input_;
+    ui::text_input_state genre_input_;
     ui::text_input_state bpm_input_;
     ui::text_input_state audio_path_input_;
     ui::text_input_state jacket_path_input_;
     ui::text_input_state preview_ms_input_;
-    ui::text_input_state sns_youtube_input_;
-    ui::text_input_state sns_niconico_input_;
-    ui::text_input_state sns_x_input_;
     square_image_picker::state jacket_picker_;
     std::string jacket_crop_source_;
 

--- a/src/scenes/song_select/local_catalog_database.cpp
+++ b/src/scenes/song_select/local_catalog_database.cpp
@@ -21,6 +21,7 @@ using local_sqlite::exec;
 using local_sqlite::statement;
 
 void ensure_optional_schema(sqlite3* database) {
+    exec(database, "ALTER TABLE local_songs ADD COLUMN genre TEXT NOT NULL DEFAULT '';");
     exec(database, "ALTER TABLE local_charts ADD COLUMN min_bpm REAL NOT NULL DEFAULT 0;");
     exec(database, "ALTER TABLE local_charts ADD COLUMN max_bpm REAL NOT NULL DEFAULT 0;");
 }
@@ -33,6 +34,7 @@ bool ensure_schema(sqlite3* database) {
              "song_id TEXT PRIMARY KEY,"
              "title TEXT NOT NULL,"
              "artist TEXT NOT NULL,"
+             "genre TEXT NOT NULL DEFAULT '',"
              "directory TEXT NOT NULL,"
              "audio_file TEXT NOT NULL,"
              "jacket_file TEXT NOT NULL,"
@@ -156,12 +158,13 @@ content_status parse_status(std::string value) {
 
 void put_song(sqlite3* database, const song_entry& song) {
     statement query(database,
-                    "INSERT INTO local_songs(song_id, title, artist, directory, audio_file, jacket_file, "
+                    "INSERT INTO local_songs(song_id, title, artist, genre, directory, audio_file, jacket_file, "
                     "base_bpm, preview_start_ms, song_version, status, updated_at) "
-                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now')) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now')) "
                     "ON CONFLICT(song_id) DO UPDATE SET "
                     "title = excluded.title,"
                     "artist = excluded.artist,"
+                    "genre = excluded.genre,"
                     "directory = excluded.directory,"
                     "audio_file = excluded.audio_file,"
                     "jacket_file = excluded.jacket_file,"
@@ -177,13 +180,14 @@ void put_song(sqlite3* database, const song_entry& song) {
     bind_text(query.get(), 1, song.song.meta.song_id);
     bind_text(query.get(), 2, song.song.meta.title);
     bind_text(query.get(), 3, song.song.meta.artist);
-    bind_text(query.get(), 4, song.song.directory);
-    bind_text(query.get(), 5, song.song.meta.audio_file);
-    bind_text(query.get(), 6, song.song.meta.jacket_file);
-    sqlite3_bind_double(query.get(), 7, song.song.meta.base_bpm);
-    sqlite3_bind_int(query.get(), 8, song.song.meta.preview_start_ms);
-    sqlite3_bind_int(query.get(), 9, song.song.meta.song_version);
-    bind_text(query.get(), 10, status_label(song.status));
+    bind_text(query.get(), 4, song.song.meta.genre);
+    bind_text(query.get(), 5, song.song.directory);
+    bind_text(query.get(), 6, song.song.meta.audio_file);
+    bind_text(query.get(), 7, song.song.meta.jacket_file);
+    sqlite3_bind_double(query.get(), 8, song.song.meta.base_bpm);
+    sqlite3_bind_int(query.get(), 9, song.song.meta.preview_start_ms);
+    sqlite3_bind_int(query.get(), 10, song.song.meta.song_version);
+    bind_text(query.get(), 11, status_label(song.status));
     sqlite3_step(query.get());
 }
 
@@ -239,7 +243,7 @@ catalog_data load_cached_catalog() {
 
     std::map<std::string, song_entry> by_song_id;
     statement songs(database.get(),
-                    "SELECT song_id, title, artist, directory, audio_file, jacket_file, base_bpm, "
+                    "SELECT song_id, title, artist, genre, directory, audio_file, jacket_file, base_bpm, "
                     "preview_start_ms, song_version, status FROM local_songs ORDER BY title, song_id;");
     if (!songs.valid()) {
         return catalog;
@@ -249,14 +253,15 @@ catalog_data load_cached_catalog() {
         entry.song.meta.song_id = column_text(songs.get(), 0);
         entry.song.meta.title = column_text(songs.get(), 1);
         entry.song.meta.artist = column_text(songs.get(), 2);
-        entry.song.directory = column_text(songs.get(), 3);
-        entry.song.meta.audio_file = column_text(songs.get(), 4);
-        entry.song.meta.jacket_file = column_text(songs.get(), 5);
-        entry.song.meta.base_bpm = static_cast<float>(sqlite3_column_double(songs.get(), 6));
-        entry.song.meta.preview_start_ms = sqlite3_column_int(songs.get(), 7);
+        entry.song.meta.genre = column_text(songs.get(), 3);
+        entry.song.directory = column_text(songs.get(), 4);
+        entry.song.meta.audio_file = column_text(songs.get(), 5);
+        entry.song.meta.jacket_file = column_text(songs.get(), 6);
+        entry.song.meta.base_bpm = static_cast<float>(sqlite3_column_double(songs.get(), 7));
+        entry.song.meta.preview_start_ms = sqlite3_column_int(songs.get(), 8);
         entry.song.meta.preview_start_seconds = static_cast<float>(entry.song.meta.preview_start_ms) / 1000.0f;
-        entry.song.meta.song_version = sqlite3_column_int(songs.get(), 8);
-        entry.status = parse_status(column_text(songs.get(), 9));
+        entry.song.meta.song_version = sqlite3_column_int(songs.get(), 9);
+        entry.status = parse_status(column_text(songs.get(), 10));
         by_song_id[entry.song.meta.song_id] = std::move(entry);
     }
 

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -136,8 +136,11 @@ void draw_song_details(const state& state, const preview_controller& preview_con
         song->status, content_alpha, 12);
     draw_marquee_text(song->song.meta.artist.c_str(), detail_x + content_offset_x, layout::kJacketRect.y + 56.0f, 28,
                       with_alpha(theme.text_secondary, content_alpha), detail_max_width, now);
-    ui::draw_text_f(TextFormat("BPM %.0f", song->song.meta.base_bpm), detail_x + content_offset_x,
-                    layout::kJacketRect.y + 100.0f, 24, with_alpha(theme.text_muted, content_alpha));
+    const std::string song_meta_line = song->song.meta.genre.empty()
+        ? TextFormat("BPM %.0f", song->song.meta.base_bpm)
+        : TextFormat("%s / BPM %.0f", song->song.meta.genre.c_str(), song->song.meta.base_bpm);
+    draw_marquee_text(song_meta_line.c_str(), detail_x + content_offset_x, layout::kJacketRect.y + 100.0f, 24,
+                      with_alpha(theme.text_muted, content_alpha), detail_max_width, now);
     if (selected_chart != nullptr) {
         const float key_x = detail_x + content_offset_x + chart_offset_x;
         const float key_y = layout::kJacketRect.y + 126.0f;

--- a/src/scenes/song_select/song_select_state.h
+++ b/src/scenes/song_select/song_select_state.h
@@ -101,6 +101,7 @@ struct auth_state {
     std::string email;
     std::string display_name;
     bool email_verified = false;
+    std::vector<auth::external_link> external_links;
 };
 
 enum class login_dialog_mode {

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -167,37 +167,6 @@ std::string detect_image_content_type(const fs::path& path) {
     return "image/jpeg";
 }
 
-std::string build_external_links_json(const song_meta& meta) {
-    struct external_link {
-        const char* label;
-        const std::string* url;
-    };
-
-    const external_link links[] = {
-        {"YouTube", &meta.sns_youtube},
-        {"Niconico", &meta.sns_niconico},
-        {"X", &meta.sns_x},
-    };
-
-    std::ostringstream stream;
-    stream << '[';
-    bool first = true;
-    for (const external_link& link : links) {
-        if (link.url == nullptr || link.url->empty()) {
-            continue;
-        }
-
-        if (!first) {
-            stream << ',';
-        }
-        first = false;
-        stream << "{\"url\":\"" << json::escape_string(*link.url)
-               << "\",\"label\":\"" << json::escape_string(link.label) << "\"}";
-    }
-    stream << ']';
-    return stream.str();
-}
-
 std::string format_float_field(float value) {
     std::ostringstream stream;
     stream << std::setprecision(std::numeric_limits<float>::max_digits10) << value;
@@ -639,6 +608,9 @@ upload_request_result send_song_upload_request(const auth::session& session,
     std::vector<multipart_field> fields;
     fields.push_back({"title", meta.title});
     fields.push_back({"artist", meta.artist});
+    if (!meta.genre.empty()) {
+        fields.push_back({"genre", meta.genre});
+    }
     fields.push_back({"baseBpm", format_float_field(meta.base_bpm)});
     if (meta.duration_seconds > 0.0f) {
         fields.push_back({"durationSec", std::to_string(static_cast<int>(meta.duration_seconds + 0.5f))});
@@ -646,10 +618,6 @@ upload_request_result send_song_upload_request(const auth::session& session,
     fields.push_back({"previewStartMs", std::to_string(std::max(0, meta.preview_start_ms))});
     fields.push_back({"visibility", "public"});
     append_song_contract_fields(fields, song, song_dir, audio_path, jacket_path);
-    const std::string external_links_json = build_external_links_json(meta);
-    if (external_links_json != "[]") {
-        fields.push_back({"externalLinks", external_links_json});
-    }
 
     std::vector<multipart_file> files;
     files.push_back({

--- a/src/scenes/title/online_download_catalog.cpp
+++ b/src/scenes/title/online_download_catalog.cpp
@@ -69,6 +69,7 @@ song_select::song_entry make_remote_song_entry(const remote_song_payload& song, 
     entry.song.meta.song_id = song.id;
     entry.song.meta.title = song.title;
     entry.song.meta.artist = song.artist;
+    entry.song.meta.genre = song.genre;
     entry.song.meta.base_bpm = song.base_bpm;
     entry.song.meta.duration_seconds = song.duration_seconds;
     entry.song.meta.audio_url = make_absolute_remote_url(server_url, song.audio_url);

--- a/src/scenes/title/online_download_remote_client.cpp
+++ b/src/scenes/title/online_download_remote_client.cpp
@@ -363,6 +363,7 @@ std::optional<remote_song_payload> parse_remote_song(const std::string& object) 
         .id = *id,
         .title = *title,
         .artist = *artist,
+        .genre = json::extract_string(object, "genre").value_or(""),
         .base_bpm = json::extract_float(object, "baseBpm").value_or(0.0f),
         .duration_seconds = json::extract_float(object, "durationSec").value_or(0.0f),
         .preview_start_ms = json::extract_int(object, "previewStartMs").value_or(0),

--- a/src/scenes/title/online_download_remote_client.h
+++ b/src/scenes/title/online_download_remote_client.h
@@ -12,6 +12,7 @@ struct remote_song_payload {
     std::string id;
     std::string title;
     std::string artist;
+    std::string genre;
     float base_bpm = 0.0f;
     float duration_seconds = 0.0f;
     int preview_start_ms = 0;

--- a/src/scenes/title/online_download_render.cpp
+++ b/src/scenes/title/online_download_render.cpp
@@ -491,7 +491,10 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
             draw_marquee_text(song.song.song.meta.title.c_str(),
                               {card.x + 14.0f, card.y + 154.0f, card.width - 28.0f, 30.0f},
                               18, with_alpha(t.text, grid_alpha), now);
-            draw_marquee_text(song.song.song.meta.artist.c_str(),
+            const std::string card_subtitle = song.song.song.meta.genre.empty()
+                ? song.song.song.meta.artist
+                : song.song.song.meta.artist + " / " + song.song.song.meta.genre;
+            draw_marquee_text(card_subtitle.c_str(),
                               {card.x + 14.0f, card.y + 184.0f, card.width - 28.0f, 22.0f},
                               13, with_alpha(t.text_muted, grid_alpha), now);
         }
@@ -556,7 +559,10 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
         27.0f
     };
     draw_marquee_text(song->song.song.meta.title.c_str(), title_rect, 28, with_alpha(t.text, detail_alpha), now);
-    draw_marquee_text(song->song.song.meta.artist.c_str(), artist_rect, 17,
+    const std::string detail_subtitle = song->song.song.meta.genre.empty()
+        ? song->song.song.meta.artist
+        : song->song.song.meta.artist + " / " + song->song.song.meta.genre;
+    draw_marquee_text(detail_subtitle.c_str(), artist_rect, 17,
                       with_alpha(t.text_secondary, detail_alpha), now);
 
     const audio_manager& audio = audio_manager::instance();

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -102,15 +102,13 @@ std::optional<song_meta> parse_downloaded_song_metadata(const std::string& metad
     meta.song_id = local_song_id;
     meta.title = trim_ascii(json::extract_string(metadata_json, "title").value_or(""));
     meta.artist = trim_ascii(json::extract_string(metadata_json, "artist").value_or(""));
+    meta.genre = trim_ascii(json::extract_string(metadata_json, "genre").value_or(""));
     meta.audio_file = trim_ascii(json::extract_string(metadata_json, "audioFile").value_or(""));
     meta.jacket_file = trim_ascii(json::extract_string(metadata_json, "jacketFile").value_or(""));
     meta.base_bpm = json::extract_float(metadata_json, "baseBpm").value_or(0.0f);
     meta.preview_start_ms = json::extract_int(metadata_json, "previewStartMs").value_or(0);
     meta.preview_start_seconds = static_cast<float>(meta.preview_start_ms) / 1000.0f;
     meta.song_version = json::extract_int(metadata_json, "songVersion").value_or(1);
-    meta.sns_youtube = trim_ascii(json::extract_string(metadata_json, "snsYoutube").value_or(""));
-    meta.sns_niconico = trim_ascii(json::extract_string(metadata_json, "snsNiconico").value_or(""));
-    meta.sns_x = trim_ascii(json::extract_string(metadata_json, "snsX").value_or(""));
 
     if (meta.song_id.empty()) {
         error_message = "Downloaded song metadata was missing a local song ID.";

--- a/src/scenes/title/profile_view.cpp
+++ b/src/scenes/title/profile_view.cpp
@@ -123,6 +123,31 @@ std::string song_label(const auth::community_song_upload& song) {
     return song.title.empty() ? song.id : song.title;
 }
 
+std::string song_subtitle(const auth::community_song_upload& song) {
+    if (!song.genre.empty() && !song.artist.empty()) {
+        return song.artist + " / " + song.genre;
+    }
+    if (!song.genre.empty()) {
+        return song.genre;
+    }
+    return song.artist;
+}
+
+std::string ranking_subtitle(const activity_item& item) {
+    std::string result = item.artist;
+    if (!item.genre.empty()) {
+        result += result.empty() ? item.genre : " / " + item.genre;
+    }
+    if (!item.difficulty_name.empty()) {
+        result += result.empty() ? item.difficulty_name : " / " + item.difficulty_name;
+    }
+    return result;
+}
+
+std::string profile_link_label(const auth::external_link& link) {
+    return link.label.empty() ? link.url : link.label;
+}
+
 std::string chart_label(const auth::community_chart_upload& chart) {
     if (!chart.song_title.empty() && !chart.difficulty_name.empty()) {
         return chart.song_title + " / " + chart.difficulty_name;
@@ -424,6 +449,19 @@ void draw(state& profile, const song_select::auth_state& auth_state, bool reques
                               13,
                               {avatar.x + avatar.width + 25.0f, avatar.y + 76.0f, 260.0f, 24.0f},
                               auth_state.email_verified ? t.success : t.error, ui::text_align::left);
+        if (!auth_state.external_links.empty()) {
+            std::string links_label;
+            const size_t count = std::min<size_t>(auth_state.external_links.size(), 3);
+            for (size_t i = 0; i < count; ++i) {
+                if (i > 0) {
+                    links_label += " / ";
+                }
+                links_label += profile_link_label(auth_state.external_links[i]);
+            }
+            ui::draw_text_in_rect(links_label.c_str(), 12,
+                                  {avatar.x + avatar.width + 25.0f, avatar.y + 106.0f, 620.0f, 22.0f},
+                                  t.accent, ui::text_align::left);
+        }
 
         const std::string songs_count = std::to_string(profile.uploads.songs.size()) + " songs";
         const std::string charts_count = std::to_string(profile.uploads.charts.size()) + " charts";
@@ -496,7 +534,8 @@ void draw(state& profile, const song_select::auth_state& auth_state, bool reques
                 ui::draw_text_in_rect(item.song_title.c_str(), 15,
                                       {recent.x + 18.0f, recent.y + 48.0f, 540.0f, 24.0f},
                                       t.text, ui::text_align::left);
-                ui::draw_text_in_rect((item.artist + " / " + item.difficulty_name).c_str(), 11,
+                const std::string subtitle = ranking_subtitle(item);
+                ui::draw_text_in_rect(subtitle.c_str(), 11,
                                       {recent.x + 18.0f, recent.y + 76.0f, 540.0f, 18.0f},
                                       t.text_muted, ui::text_align::left);
                 ui::draw_text_in_rect(item.local_summary.c_str(), 13,
@@ -529,7 +568,8 @@ void draw(state& profile, const song_select::auth_state& auth_state, bool reques
                 ui::draw_text_in_rect(item.song_title.c_str(), 15,
                                       {first_place.x + 18.0f, first_place.y + 48.0f, 540.0f, 24.0f},
                                       t.text, ui::text_align::left);
-                ui::draw_text_in_rect((item.artist + " / " + item.difficulty_name).c_str(), 11,
+                const std::string subtitle = ranking_subtitle(item);
+                ui::draw_text_in_rect(subtitle.c_str(), 11,
                                       {first_place.x + 18.0f, first_place.y + 76.0f, 540.0f, 18.0f},
                                       t.text_muted, ui::text_align::left);
                 ui::draw_text_in_rect(item.online_summary.c_str(), 13,
@@ -551,7 +591,8 @@ void draw(state& profile, const song_select::auth_state& auth_state, bool reques
                     ui::draw_text_in_rect(item.song_title.c_str(), 15,
                                           {row.x + 18.0f, row.y + 9.0f, 520.0f, 24.0f},
                                           t.text, ui::text_align::left);
-                    ui::draw_text_in_rect((item.artist + " / " + item.difficulty_name).c_str(), 11,
+                    const std::string subtitle = ranking_subtitle(item);
+                    ui::draw_text_in_rect(subtitle.c_str(), 11,
                                           {row.x + 18.0f, row.y + 38.0f, 520.0f, 18.0f},
                                           t.text_muted, ui::text_align::left);
                     ui::draw_text_in_rect(item.local_summary.c_str(), 13,
@@ -581,7 +622,8 @@ void draw(state& profile, const song_select::auth_state& auth_state, bool reques
                     ui::draw_text_in_rect(song_label(song).c_str(), 15,
                                           {row.x + 18.0f, row.y + 9.0f, row.width - 160.0f, 24.0f},
                                           t.text, ui::text_align::left);
-                    ui::draw_text_in_rect(song.artist.c_str(), 11,
+                    const std::string subtitle = song_subtitle(song);
+                    ui::draw_text_in_rect(subtitle.c_str(), 11,
                                           {row.x + 18.0f, row.y + 38.0f, row.width - 160.0f, 18.0f},
                                           t.text_muted, ui::text_align::left);
                     draw_profile_button(row_action_rect(row), "DELETE", !busy, t.error);

--- a/src/scenes/title/profile_view.h
+++ b/src/scenes/title/profile_view.h
@@ -43,6 +43,7 @@ struct command {
 struct activity_item {
     std::string song_title;
     std::string artist;
+    std::string genre;
     std::string difficulty_name;
     std::string local_summary;
     std::string online_summary;

--- a/src/scenes/title/title_profile_controller.cpp
+++ b/src/scenes/title/title_profile_controller.cpp
@@ -14,6 +14,7 @@ title_profile_view::activity_item to_activity_item(const auth::profile_ranking_r
     return {
         .song_title = record.song_title,
         .artist = record.artist,
+        .genre = record.genre,
         .difficulty_name = record.difficulty_name,
         .local_summary = "Score " + std::to_string(record.score),
         .online_summary = "Online #" + std::to_string(record.placement) + " / " + std::to_string(record.score),

--- a/src/tests/local_catalog_database_smoke.cpp
+++ b/src/tests/local_catalog_database_smoke.cpp
@@ -42,6 +42,7 @@ song_select::song_entry make_song(const fs::path& song_dir, const fs::path& char
     song.song.meta.song_id = "song-a";
     song.song.meta.title = "Alpha";
     song.song.meta.artist = "Artist";
+    song.song.meta.genre = "Fusion";
     song.song.meta.audio_file = "audio.ogg";
     song.song.meta.jacket_file = "jacket.png";
     song.song.meta.base_bpm = 128.0f;
@@ -77,6 +78,7 @@ int main() {
     song_select::catalog_data cached = song_select::local_catalog_database::load_cached_catalog();
     assert(cached.songs.size() == 1);
     assert(cached.songs[0].song.meta.song_id == "song-a");
+    assert(cached.songs[0].song.meta.genre == "Fusion");
     assert(cached.songs[0].song.meta.preview_start_seconds == 12.0f);
     assert(cached.songs[0].status == content_status::community);
     assert(cached.songs[0].charts.size() == 1);

--- a/src/tests/song_loader_smoke.cpp
+++ b/src/tests/song_loader_smoke.cpp
@@ -186,6 +186,7 @@ int main() {
     written_meta.song_id = "external-local-id";
     written_meta.title = "Written Song";
     written_meta.artist = "Codex";
+    written_meta.genre = "Artcore";
     written_meta.base_bpm = 128.0f;
     written_meta.audio_file = "audio.ogg";
     written_meta.jacket_file = "jacket.png";
@@ -200,6 +201,14 @@ int main() {
                                           std::istreambuf_iterator<char>()};
         if (written_content.find("\"songId\": \"external-local-id\"") == std::string::npos) {
             std::cerr << "Expected song writer to persist songId in song.json\n";
+            ok = false;
+        }
+        if (written_content.find("\"genre\": \"Artcore\"") == std::string::npos) {
+            std::cerr << "Expected song writer to persist genre in song.json\n";
+            ok = false;
+        }
+        if (written_content.find("sns") != std::string::npos) {
+            std::cerr << "Expected song writer to omit legacy SNS fields\n";
             ok = false;
         }
     }


### PR DESCRIPTION
## 概要
- song.json / song upload から旧SNS・song-level externalLinksを撤去
- genreを曲メタとして保存・読込・アップロード・オンライン取得・ローカルDBキャッシュ・表示に反映
- profile externalLinksをセッション経由で表示

## 確認
- cmake --build cmake-build-codex --target raythm song_loader_smoke local_catalog_database_smoke -j 2
- ctest --test-dir cmake-build-codex --output-on-failure