### PR TITLE
ランキング送信形式名をサーバー仕様に合わせる

### DIFF
--- a/src/gameplay/ranking_service.cpp
+++ b/src/gameplay/ranking_service.cpp
@@ -33,7 +33,8 @@
 namespace {
 
 constexpr char kLocalRankingFileHeader[] = "RAYTHM_LOCAL_RANKING_V6";
-constexpr char kAuthoritativeAcceptedInput[] = "note_results_v1";
+constexpr char kAuthoritativeAcceptedInput[] = "noteResultsV1";
+constexpr char kLegacyAuthoritativeAcceptedInput[] = "note_results_v1";
 constexpr wchar_t kEntropyLabel[] = L"raythm-local-ranking";
 
 std::string trim(std::string_view value) {
@@ -48,6 +49,13 @@ std::string trim(std::string_view value) {
     }
 
     return std::string(value.substr(start, end - start));
+}
+
+std::string normalize_accepted_input(std::string_view value) {
+    const std::string normalized = trim(value);
+    return normalized == kLegacyAuthoritativeAcceptedInput
+        ? std::string(kAuthoritativeAcceptedInput)
+        : normalized;
 }
 
 std::string current_timestamp_utc() {
@@ -299,7 +307,7 @@ std::vector<stored_local_record> parse_records(const std::string& content) {
                     continue;
                 }
                 record.scoring_ruleset_version = trim(ruleset_version_token);
-                record.scoring_accepted_input = trim(accepted_input_token);
+                record.scoring_accepted_input = normalize_accepted_input(accepted_input_token);
                 const std::optional<std::vector<note_result_entry>> note_results =
                     parse_note_results(note_results_token);
                 if (!note_results.has_value()) {
@@ -479,7 +487,7 @@ std::optional<std::pair<std::string, ranking_client::scoring_ruleset>> load_cach
         } else if (key == "active") {
             ruleset.active = trim(value) == "1";
         } else if (key == "accepted_input") {
-            ruleset.accepted_input = trim(value);
+            ruleset.accepted_input = normalize_accepted_input(value);
         } else if (key == "ruleset_version") {
             ruleset.ruleset_version = trim(value);
         } else if (key == "score_model") {
@@ -982,7 +990,7 @@ local_submit_result submit_local_result_detailed(const chart_meta& chart, const 
     new_record.scoring_accepted_input =
         result.scoring_accepted_input.empty()
             ? std::string(kAuthoritativeAcceptedInput)
-            : result.scoring_accepted_input;
+            : normalize_accepted_input(result.scoring_accepted_input);
     new_record.note_results = result.note_results;
     entry new_entry = resolve_record_entry(new_record, ruleset);
 
@@ -1087,6 +1095,7 @@ online_submit_result submit_online_result(const song_data& song,
         return submission;
     }
 
+    ruleset->accepted_input = normalize_accepted_input(ruleset->accepted_input);
     if (!ruleset->active ||
         ruleset->accepted_input != kAuthoritativeAcceptedInput) {
         submission.message = "The server does not accept this ranking submission format.";
@@ -1100,7 +1109,7 @@ online_submit_result submit_online_result(const song_data& song,
     const std::string submission_input_format =
         result.scoring_accepted_input.empty()
             ? std::string(kAuthoritativeAcceptedInput)
-            : result.scoring_accepted_input;
+            : normalize_accepted_input(result.scoring_accepted_input);
     if (submission_input_format != ruleset->accepted_input) {
         submission.message = "The score input format changed. Start the chart again to submit online ranking.";
         return submission;

--- a/src/gameplay/scoring_ruleset_runtime.h
+++ b/src/gameplay/scoring_ruleset_runtime.h
@@ -16,7 +16,7 @@ struct rank_threshold {
 
 struct ruleset {
     bool active = true;
-    std::string accepted_input = "note_results_v1";
+    std::string accepted_input = "noteResultsV1";
     std::string ruleset_version = "local-default";
     std::string score_model = "combo-progress-squared";
     int max_score = 1'000'000;

--- a/src/models/data_models.h
+++ b/src/models/data_models.h
@@ -209,6 +209,6 @@ struct result_data {
     bool is_full_combo = false;
     bool is_all_perfect = false;
     std::string scoring_ruleset_version;
-    std::string scoring_accepted_input = "note_results_v1";
+    std::string scoring_accepted_input = "noteResultsV1";
     std::vector<note_result_entry> note_results;
 };

--- a/src/tests/score_system_smoke.cpp
+++ b/src/tests/score_system_smoke.cpp
@@ -58,7 +58,7 @@ int main() {
     ruleset_score.on_judge({judge_result::perfect, 0.0, 0});
     const result_data ruleset_result = ruleset_score.get_result_data();
     if (ruleset_result.scoring_ruleset_version != "smoke-ruleset" ||
-        ruleset_result.scoring_accepted_input != "note_results_v1" ||
+        ruleset_result.scoring_accepted_input != "noteResultsV1" ||
         ruleset_result.score != 123456) {
         std::cerr << "Score result should retain the ruleset used during play\n";
         return EXIT_FAILURE;


### PR DESCRIPTION
## 概要
- ランキング送信の accepted input 名をサーバーが返す noteResultsV1 に統一
- 旧 note_results_v1 はローカルランキング/キャッシュ読込時に互換正規化
- score_system smoke の期待値を更新

## 確認
- cmake --build cmake-build-codex --target raythm score_system_smoke ranking_service_smoke -j 2
- ctest --test-dir cmake-build-codex --output-on-failure -R "score_system_smoke|ranking_service_smoke"