### PR TITLE
durationSecを保存してカタログに表示

### DIFF
--- a/src/gameplay/song_loader.cpp
+++ b/src/gameplay/song_loader.cpp
@@ -186,6 +186,7 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
     const std::optional<std::string> audio_file = extract_json_string(content, "audioFile");
     const std::optional<std::string> jacket_file = extract_json_string(content, "jacketFile");
     const std::optional<std::string> difficulty_bpm = extract_json_number_token(content, "baseBpm");
+    const std::optional<std::string> duration_sec = extract_json_number_token(content, "durationSec");
     const std::optional<std::string> preview_start_ms = extract_json_number_token(content, "previewStartMs");
     const std::optional<std::string> song_version = extract_json_number_token(content, "songVersion");
 
@@ -231,6 +232,15 @@ std::optional<song_meta> parse_song_meta(const fs::path& song_json_path,
             errors.push_back("baseBpm must be a number in " + path_utils::to_utf8(song_json_path));
         } else {
             meta.base_bpm = *parsed;
+        }
+    }
+
+    if (duration_sec.has_value()) {
+        const std::optional<float> parsed = parse_float(*duration_sec);
+        if (!parsed.has_value()) {
+            errors.push_back("durationSec must be a number in " + path_utils::to_utf8(song_json_path));
+        } else {
+            meta.duration_seconds = *parsed;
         }
     }
 

--- a/src/gameplay/song_writer.cpp
+++ b/src/gameplay/song_writer.cpp
@@ -55,6 +55,9 @@ bool song_writer::write_song_json(const song_meta& meta, const std::string& dire
         out << "  \"genre\": \"" << escape_json_string(meta.genre) << "\",\n";
     }
     out << "  \"baseBpm\": " << format_float(meta.base_bpm) << ",\n";
+    if (meta.duration_seconds > 0.0f) {
+        out << "  \"durationSec\": " << format_float(meta.duration_seconds) << ",\n";
+    }
     out << "  \"audioFile\": \"" << escape_json_string(meta.audio_file) << "\",\n";
     out << "  \"jacketFile\": \"" << escape_json_string(meta.jacket_file) << "\",\n";
     out << "  \"previewStartMs\": " << meta.preview_start_ms << ",\n";

--- a/src/scenes/song_select/local_catalog_database.cpp
+++ b/src/scenes/song_select/local_catalog_database.cpp
@@ -22,6 +22,7 @@ using local_sqlite::statement;
 
 void ensure_optional_schema(sqlite3* database) {
     exec(database, "ALTER TABLE local_songs ADD COLUMN genre TEXT NOT NULL DEFAULT '';");
+    exec(database, "ALTER TABLE local_songs ADD COLUMN duration_seconds REAL NOT NULL DEFAULT 0;");
     exec(database, "ALTER TABLE local_charts ADD COLUMN min_bpm REAL NOT NULL DEFAULT 0;");
     exec(database, "ALTER TABLE local_charts ADD COLUMN max_bpm REAL NOT NULL DEFAULT 0;");
 }
@@ -39,6 +40,7 @@ bool ensure_schema(sqlite3* database) {
              "audio_file TEXT NOT NULL,"
              "jacket_file TEXT NOT NULL,"
              "base_bpm REAL NOT NULL,"
+             "duration_seconds REAL NOT NULL DEFAULT 0,"
              "preview_start_ms INTEGER NOT NULL,"
              "song_version INTEGER NOT NULL,"
              "status TEXT NOT NULL,"
@@ -159,8 +161,8 @@ content_status parse_status(std::string value) {
 void put_song(sqlite3* database, const song_entry& song) {
     statement query(database,
                     "INSERT INTO local_songs(song_id, title, artist, genre, directory, audio_file, jacket_file, "
-                    "base_bpm, preview_start_ms, song_version, status, updated_at) "
-                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now')) "
+                    "base_bpm, duration_seconds, preview_start_ms, song_version, status, updated_at) "
+                    "VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now')) "
                     "ON CONFLICT(song_id) DO UPDATE SET "
                     "title = excluded.title,"
                     "artist = excluded.artist,"
@@ -169,6 +171,7 @@ void put_song(sqlite3* database, const song_entry& song) {
                     "audio_file = excluded.audio_file,"
                     "jacket_file = excluded.jacket_file,"
                     "base_bpm = excluded.base_bpm,"
+                    "duration_seconds = excluded.duration_seconds,"
                     "preview_start_ms = excluded.preview_start_ms,"
                     "song_version = excluded.song_version,"
                     "status = excluded.status,"
@@ -185,9 +188,10 @@ void put_song(sqlite3* database, const song_entry& song) {
     bind_text(query.get(), 6, song.song.meta.audio_file);
     bind_text(query.get(), 7, song.song.meta.jacket_file);
     sqlite3_bind_double(query.get(), 8, song.song.meta.base_bpm);
-    sqlite3_bind_int(query.get(), 9, song.song.meta.preview_start_ms);
-    sqlite3_bind_int(query.get(), 10, song.song.meta.song_version);
-    bind_text(query.get(), 11, status_label(song.status));
+    sqlite3_bind_double(query.get(), 9, song.song.meta.duration_seconds);
+    sqlite3_bind_int(query.get(), 10, song.song.meta.preview_start_ms);
+    sqlite3_bind_int(query.get(), 11, song.song.meta.song_version);
+    bind_text(query.get(), 12, status_label(song.status));
     sqlite3_step(query.get());
 }
 
@@ -244,7 +248,7 @@ catalog_data load_cached_catalog() {
     std::map<std::string, song_entry> by_song_id;
     statement songs(database.get(),
                     "SELECT song_id, title, artist, genre, directory, audio_file, jacket_file, base_bpm, "
-                    "preview_start_ms, song_version, status FROM local_songs ORDER BY title, song_id;");
+                    "duration_seconds, preview_start_ms, song_version, status FROM local_songs ORDER BY title, song_id;");
     if (!songs.valid()) {
         return catalog;
     }
@@ -258,10 +262,11 @@ catalog_data load_cached_catalog() {
         entry.song.meta.audio_file = column_text(songs.get(), 5);
         entry.song.meta.jacket_file = column_text(songs.get(), 6);
         entry.song.meta.base_bpm = static_cast<float>(sqlite3_column_double(songs.get(), 7));
-        entry.song.meta.preview_start_ms = sqlite3_column_int(songs.get(), 8);
+        entry.song.meta.duration_seconds = static_cast<float>(sqlite3_column_double(songs.get(), 8));
+        entry.song.meta.preview_start_ms = sqlite3_column_int(songs.get(), 9);
         entry.song.meta.preview_start_seconds = static_cast<float>(entry.song.meta.preview_start_ms) / 1000.0f;
-        entry.song.meta.song_version = sqlite3_column_int(songs.get(), 9);
-        entry.status = parse_status(column_text(songs.get(), 10));
+        entry.song.meta.song_version = sqlite3_column_int(songs.get(), 10);
+        entry.status = parse_status(column_text(songs.get(), 11));
         by_song_id[entry.song.meta.song_id] = std::move(entry);
     }
 

--- a/src/scenes/song_select/song_select_detail_view.cpp
+++ b/src/scenes/song_select/song_select_detail_view.cpp
@@ -62,6 +62,26 @@ std::string format_recent_offset_label(float offset_ms) {
     return "0ms";
 }
 
+std::string format_duration_label(float seconds) {
+    if (seconds <= 0.0f) {
+        return "--:--";
+    }
+    const int total_seconds = static_cast<int>(std::round(seconds));
+    return TextFormat("%d:%02d", total_seconds / 60, total_seconds % 60);
+}
+
+std::string song_meta_line(const song_meta& meta) {
+    std::string result;
+    if (!meta.genre.empty()) {
+        result += meta.genre + " / ";
+    }
+    result += TextFormat("BPM %.0f", meta.base_bpm);
+    if (meta.duration_seconds > 0.0f) {
+        result += " / " + format_duration_label(meta.duration_seconds);
+    }
+    return result;
+}
+
 }  // namespace
 
 namespace song_select {
@@ -136,10 +156,8 @@ void draw_song_details(const state& state, const preview_controller& preview_con
         song->status, content_alpha, 12);
     draw_marquee_text(song->song.meta.artist.c_str(), detail_x + content_offset_x, layout::kJacketRect.y + 56.0f, 28,
                       with_alpha(theme.text_secondary, content_alpha), detail_max_width, now);
-    const std::string song_meta_line = song->song.meta.genre.empty()
-        ? TextFormat("BPM %.0f", song->song.meta.base_bpm)
-        : TextFormat("%s / BPM %.0f", song->song.meta.genre.c_str(), song->song.meta.base_bpm);
-    draw_marquee_text(song_meta_line.c_str(), detail_x + content_offset_x, layout::kJacketRect.y + 100.0f, 24,
+    const std::string meta_line = song_meta_line(song->song.meta);
+    draw_marquee_text(meta_line.c_str(), detail_x + content_offset_x, layout::kJacketRect.y + 100.0f, 24,
                       with_alpha(theme.text_muted, content_alpha), detail_max_width, now);
     if (selected_chart != nullptr) {
         const float key_x = detail_x + content_offset_x + chart_offset_x;

--- a/src/scenes/song_select/song_select_list_view.cpp
+++ b/src/scenes/song_select/song_select_list_view.cpp
@@ -1,5 +1,7 @@
 #include "song_select/song_select_list_view.h"
 
+#include <cmath>
+
 #include "scene_common.h"
 #include "song_select/song_select_layout.h"
 #include "theme.h"
@@ -45,6 +47,14 @@ Color rank_color(rank value) {
     return theme.text_secondary;
 }
 
+std::string format_duration_label(float seconds) {
+    if (seconds <= 0.0f) {
+        return "";
+    }
+    const int total_seconds = static_cast<int>(std::round(seconds));
+    return TextFormat("%d:%02d", total_seconds / 60, total_seconds % 60);
+}
+
 void draw_song_row(const song_select::song_entry& song, float item_y, bool is_selected, double now) {
     const auto& theme = *g_theme;
     const Rectangle row_rect = {song_select::layout::kSongListRect.x + 14.0f, item_y - 8.0f,
@@ -54,6 +64,7 @@ void draw_song_row(const song_select::song_entry& song, float item_y, bool is_se
     const Rectangle title_clip_rect = {text_x, item_y - 3.0f, list_text_max_w, 24.0f};
     const Rectangle artist_clip_rect = {text_x, item_y + 19.0f, list_text_max_w, 16.0f};
     const Rectangle status_rect = {row_rect.x + row_rect.width - 118.0f, item_y - 1.0f, 96.0f, 18.0f};
+    const std::string duration_label = format_duration_label(song.song.meta.duration_seconds);
 
     if (ui::is_hovered(row_rect, song_select::layout::kSceneLayer) || is_selected) {
         const ui::row_state row_state = ui::draw_selectable_row(row_rect, is_selected, 0.0f);
@@ -62,8 +73,18 @@ void draw_song_row(const song_select::song_entry& song, float item_y, bool is_se
 
     draw_marquee_text(song.song.meta.title.c_str(), title_clip_rect,
                       24, is_selected ? theme.text : theme.text_secondary, now);
-    draw_marquee_text(song.song.meta.artist.c_str(), artist_clip_rect,
+    const Rectangle artist_text_rect = duration_label.empty()
+        ? artist_clip_rect
+        : Rectangle{artist_clip_rect.x, artist_clip_rect.y, artist_clip_rect.width - 56.0f, artist_clip_rect.height};
+    draw_marquee_text(song.song.meta.artist.c_str(), artist_text_rect,
                       16, theme.text_muted, now);
+    if (!duration_label.empty()) {
+        ui::draw_text_in_rect(duration_label.c_str(),
+                              13,
+                              {artist_clip_rect.x + artist_clip_rect.width - 52.0f,
+                               artist_clip_rect.y, 52.0f, artist_clip_rect.height},
+                              theme.text_muted, ui::text_align::right);
+    }
     content_status_badge::draw(status_rect, song.status, 255, 10);
 }
 

--- a/src/scenes/title/online_download_render.cpp
+++ b/src/scenes/title/online_download_render.cpp
@@ -494,8 +494,16 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
             const std::string card_subtitle = song.song.song.meta.genre.empty()
                 ? song.song.song.meta.artist
                 : song.song.song.meta.artist + " / " + song.song.song.meta.genre;
+            const bool has_duration = song.song.song.meta.duration_seconds > 0.0f;
+            if (song.song.song.meta.duration_seconds > 0.0f) {
+                ui::draw_text_in_rect(detail::format_time_label(song.song.song.meta.duration_seconds).c_str(),
+                                      12,
+                                      {card.x + card.width - 72.0f, card.y + 186.0f, 58.0f, 18.0f},
+                                      with_alpha(t.text_muted, grid_alpha), ui::text_align::right);
+            }
             draw_marquee_text(card_subtitle.c_str(),
-                              {card.x + 14.0f, card.y + 184.0f, card.width - 28.0f, 22.0f},
+                              {card.x + 14.0f, card.y + 184.0f,
+                               card.width - (has_duration ? 88.0f : 28.0f), 22.0f},
                               13, with_alpha(t.text_muted, grid_alpha), now);
         }
     }
@@ -564,6 +572,12 @@ void draw(state& state, float anim_t, Rectangle origin_rect) {
         : song->song.song.meta.artist + " / " + song->song.song.meta.genre;
     draw_marquee_text(detail_subtitle.c_str(), artist_rect, 17,
                       with_alpha(t.text_secondary, detail_alpha), now);
+    if (song->song.song.meta.duration_seconds > 0.0f) {
+        ui::draw_text_in_rect(detail::format_time_label(song->song.song.meta.duration_seconds).c_str(),
+                              14,
+                              {artist_rect.x, artist_rect.y + 26.0f, artist_rect.width, 20.0f},
+                              with_alpha(t.text_muted, detail_alpha), ui::text_align::left);
+    }
 
     const audio_manager& audio = audio_manager::instance();
     const double preview_length = detail::preview_display_length_seconds(*song);

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -106,6 +106,7 @@ std::optional<song_meta> parse_downloaded_song_metadata(const std::string& metad
     meta.audio_file = trim_ascii(json::extract_string(metadata_json, "audioFile").value_or(""));
     meta.jacket_file = trim_ascii(json::extract_string(metadata_json, "jacketFile").value_or(""));
     meta.base_bpm = json::extract_float(metadata_json, "baseBpm").value_or(0.0f);
+    meta.duration_seconds = json::extract_float(metadata_json, "durationSec").value_or(0.0f);
     meta.preview_start_ms = json::extract_int(metadata_json, "previewStartMs").value_or(0);
     meta.preview_start_seconds = static_cast<float>(meta.preview_start_ms) / 1000.0f;
     meta.song_version = json::extract_int(metadata_json, "songVersion").value_or(1);

--- a/src/scenes/title/song_list_view.cpp
+++ b/src/scenes/title/song_list_view.cpp
@@ -1,6 +1,7 @@
 #include "title/song_list_view.h"
 
 #include <algorithm>
+#include <cmath>
 
 #include "theme.h"
 #include "ui_clip.h"
@@ -25,6 +26,14 @@ constexpr float kArtistHeight = 27.0f;
 constexpr float kStatusBadgeWidth = 96.0f;
 constexpr float kStatusBadgeHeight = 24.0f;
 constexpr float kStatusBadgeInset = 15.0f;
+
+std::string format_duration_label(float seconds) {
+    if (seconds <= 0.0f) {
+        return "";
+    }
+    const int total_seconds = static_cast<int>(std::round(seconds));
+    return TextFormat("%d:%02d", total_seconds / 60, total_seconds % 60);
+}
 
 }  // namespace
 
@@ -104,10 +113,18 @@ void draw(const song_select::state& state, const draw_config& config) {
                           {row.x + kTextPaddingX, row.y + kTitleOffsetY,
                            row.width - kTextPaddingX * 2.0f - kStatusBadgeWidth, kTitleHeight},
                           20, with_alpha(t.text, config.alpha), config.now);
+        const std::string duration_label = format_duration_label(song.song.meta.duration_seconds);
+        const float artist_reserved_width = duration_label.empty() ? 0.0f : 62.0f;
         draw_marquee_text(song.song.meta.artist.c_str(),
                           {row.x + kTextPaddingX, row.y + kArtistOffsetY,
-                           row.width - kTextPaddingX * 2.0f - kStatusBadgeWidth, kArtistHeight},
+                           row.width - kTextPaddingX * 2.0f - kStatusBadgeWidth - artist_reserved_width, kArtistHeight},
                           14, with_alpha(t.text_muted, config.alpha), config.now);
+        if (!duration_label.empty()) {
+            ui::draw_text_in_rect(duration_label.c_str(),
+                                  13,
+                                  {badge_rect.x - 70.0f, row.y + kArtistOffsetY + 2.0f, 58.0f, 18.0f},
+                                  with_alpha(t.text_muted, config.alpha), ui::text_align::right);
+        }
         content_status_badge::draw(badge_rect, song.status, config.alpha, 12);
     }
 }

--- a/src/tests/local_catalog_database_smoke.cpp
+++ b/src/tests/local_catalog_database_smoke.cpp
@@ -43,6 +43,7 @@ song_select::song_entry make_song(const fs::path& song_dir, const fs::path& char
     song.song.meta.title = "Alpha";
     song.song.meta.artist = "Artist";
     song.song.meta.genre = "Fusion";
+    song.song.meta.duration_seconds = 95.0f;
     song.song.meta.audio_file = "audio.ogg";
     song.song.meta.jacket_file = "jacket.png";
     song.song.meta.base_bpm = 128.0f;
@@ -79,6 +80,7 @@ int main() {
     assert(cached.songs.size() == 1);
     assert(cached.songs[0].song.meta.song_id == "song-a");
     assert(cached.songs[0].song.meta.genre == "Fusion");
+    assert(cached.songs[0].song.meta.duration_seconds == 95.0f);
     assert(cached.songs[0].song.meta.preview_start_seconds == 12.0f);
     assert(cached.songs[0].status == content_status::community);
     assert(cached.songs[0].charts.size() == 1);

--- a/src/tests/song_loader_smoke.cpp
+++ b/src/tests/song_loader_smoke.cpp
@@ -187,6 +187,7 @@ int main() {
     written_meta.title = "Written Song";
     written_meta.artist = "Codex";
     written_meta.genre = "Artcore";
+    written_meta.duration_seconds = 123.0f;
     written_meta.base_bpm = 128.0f;
     written_meta.audio_file = "audio.ogg";
     written_meta.jacket_file = "jacket.png";
@@ -207,8 +208,18 @@ int main() {
             std::cerr << "Expected song writer to persist genre in song.json\n";
             ok = false;
         }
+        if (written_content.find("\"durationSec\": 123") == std::string::npos) {
+            std::cerr << "Expected song writer to persist durationSec in song.json\n";
+            ok = false;
+        }
         if (written_content.find("sns") != std::string::npos) {
             std::cerr << "Expected song writer to omit legacy SNS fields\n";
+            ok = false;
+        }
+        const song_load_result written_load_result = song_loader::load_directory(written_song_dir.string());
+        if (written_load_result.songs.size() != 1 ||
+            written_load_result.songs.front().meta.duration_seconds != 123.0f) {
+            std::cerr << "Expected song loader to parse durationSec from song.json\n";
             ok = false;
         }
     }


### PR DESCRIPTION
## 概要
- song.json の durationSec 読み書きに対応
- ダウンロード保存時に durationSec をローカル song.json へ反映
- ローカルカタログDBに duration_seconds をキャッシュ
- Song Select / Title / Online catalog の曲表示に時間を表示

## 確認
- cmake --build cmake-build-codex --target raythm song_loader_smoke local_catalog_database_smoke -j 2
- ctest --test-dir cmake-build-codex --output-on-failure -R "song_loader_smoke|local_catalog_database_smoke"