### PR TITLE
Move chart song linkage out of rchart

### DIFF
--- a/documents/SpecificationSheet.md
+++ b/documents/SpecificationSheet.md
@@ -106,13 +106,16 @@ Song/
 | フィールド           | 型        | 説明                |
 |-----------------|----------|-------------------|
 | `chartId`       | `string` | 譜面の一意識別子          |
-| `songId`        | `string` | 紐づく楽曲の識別子         |
 | `keyCount`      | `int`    | キー数（4 or 6）       |
 | `difficulty`    | `string` | 難易度名              |
 | `chartAuthor`   | `string` | 譜面作者              |
 | `formatVersion` | `int`    | フォーマットバージョン       |
 | `resolution`    | `int`    | tick解像度（ファイルごと指定） |
 | `offset`        | `int`    | 譜面オフセット（ms）       |
+
+`songId` は譜面ファイルには保存しない。ローカルでは
+`songs/<songId>/charts/*.rchart` の配置とカタログDB、サーバーでは
+`Chart.songId` のDBリレーションで曲と譜面を紐づける。
 
 `level` は譜面ファイルには保存しない。実行時またはサーバー側で譜面内容から
 `calculatedLevel` として計算し、表示用メタとして扱う。

--- a/documents/content-storage-and-song-catalog.md
+++ b/documents/content-storage-and-song-catalog.md
@@ -4,7 +4,6 @@
 
 - 配布物として同梱される `assets/`
 - ローカル楽曲を置く `AppData/Local/raythm/songs/`
-- ローカル譜面を置く `AppData/Local/raythm/charts/`
 - ローカル MV を置く `AppData/Local/raythm/mvs/`
 
 このドキュメントは、どこに何が保存され、song select がどこを参照しているかを整理したものです。
@@ -20,8 +19,6 @@
   - `AppData/Local/raythm/`
 - `songs_root()`
   - `AppData/Local/raythm/songs/`
-- `charts_root()`
-  - `AppData/Local/raythm/charts/`
 - `mvs_root()`
   - `AppData/Local/raythm/mvs/`
 - `mv_dir(mv_id)`
@@ -47,8 +44,8 @@
   - `AppData/Local/raythm/songs/{song_id}/song.json`
   - `AppData/Local/raythm/songs/{song_id}/...audio...`
   - 必要なら jacket
-- 外部譜面:
-  - `AppData/Local/raythm/charts/{chart_id}.rchart`
+- 譜面:
+  - `AppData/Local/raythm/songs/{song_id}/charts/{chart_id}.rchart`
 - MV:
   - `AppData/Local/raythm/mvs/{mv_id}/mv.json`
   - `AppData/Local/raythm/mvs/{mv_id}/script.rmv`
@@ -60,7 +57,7 @@
 - 譜面拡張子は `.rchart`
 - 楽曲パッケージ拡張子は `.rpack`
 - imported song は `songs_root()`
-- imported chart は `charts_root()`
+- imported chart は対象楽曲の `songs_root()/{song_id}/charts/`
 - MV は `mvs_root()`
 
 ## Song Catalog Build
@@ -70,7 +67,8 @@ song select の一覧は [song_catalog_service.cpp](C:/Users/rento/CLionProjects
 読み込み順は次です。
 
 1. `songs_root()` からローカル楽曲を読む
-2. `charts_root()` の外部譜面を `song_id` でローカル楽曲へ紐付ける
+2. 各楽曲ディレクトリの `charts/*.rchart` を読み、親楽曲IDを実行時メタに反映する
+3. ローカルカタログDBへ `local_charts.song_id` として保存する
 
 その後:
 
@@ -88,8 +86,8 @@ song select の一覧は [song_catalog_service.cpp](C:/Users/rento/CLionProjects
 - 譜面拡張子は `.rchart` のみ
 - 楽曲ディレクトリには `song.json` が必要
 - `song.json` には `songId`, `title`, `artist`, `audioFile`, `jacketFile`, `baseBpm`, `previewStartMs`, `songVersion` が必要
-- `.rchart` には `chartId`, `songId`, `keyCount`, `difficulty`, `chartAuthor`, `formatVersion`, `resolution`, `offset` が必要
-- 外部譜面は `chart.meta.song_id` が一致した楽曲にだけ紐付きます
+- `.rchart` には `chartId`, `keyCount`, `difficulty`, `chartAuthor`, `formatVersion`, `resolution`, `offset` が必要
+- 譜面と曲の紐づけは `songs/<songId>/charts/*.rchart` の配置とローカルカタログDBで決まり、`.rchart` 内の `songId` は使いません
 
 ## MV Package Layout
 
@@ -115,8 +113,8 @@ MV は曲から独立したパッケージとして保存されます。
   - `.rpack` を作る
 - `IMPORT CHART`
   - `.rchart` を読む
-  - `chart.meta.song_id` と一致する楽曲を自動で探す
-  - `charts_root()/chart_id.rchart` に保存
+  - 選択中の楽曲ディレクトリ配下へ保存
+  - `songs_root()/song_id/charts/chart_id.rchart` に保存
 - `EXPORT CHART`
   - 既存譜面を `.rchart` として書き出す
 
@@ -126,8 +124,8 @@ MV は曲から独立したパッケージとして保存されます。
   - `AppData/Local/raythm/songs/`
   - 対象の `song.json`
 - imported chart が出ない
-  - `AppData/Local/raythm/charts/`
-  - `chart.meta.song_id`
+  - `AppData/Local/raythm/songs/<songId>/charts/`
+  - ローカルカタログDBの `local_charts.song_id`
 - MV が出ない / 読まれない
   - `AppData/Local/raythm/mvs/`
   - 対象の `mv.json`

--- a/documents/metadata-flow-normalization.md
+++ b/documents/metadata-flow-normalization.md
@@ -27,12 +27,16 @@ Authoritative fields:
 - Remote source: `/charts`
 - Runtime model: `chart_meta`
 
-`chart_meta` contains chart identity and authored metadata only:
-`chartId`, `songId`, `keyCount`, `difficulty`, `chartAuthor`, `formatVersion`,
-`resolution`, and `offset`.
+`chart_meta` contains chart identity, authored metadata, and a runtime-only
+parent song ID:
+`chartId`, `keyCount`, `difficulty`, `chartAuthor`, `formatVersion`,
+`resolution`, and `offset` are serialized in `.rchart`; `songId` is filled from
+the parent song folder/catalog row after loading.
 
-`.rchart` files must include `chartId` and `songId`. `level` remains excluded
-from the file format because runtime level is derived from chart notes.
+`.rchart` files must include `chartId`, `keyCount`, `difficulty`,
+`chartAuthor`, `formatVersion`, `resolution`, and `offset`. `songId` is not a
+file-format relationship field. `level` remains excluded from the file format
+because runtime level is derived from chart notes.
 
 ## Display Metadata
 
@@ -103,7 +107,7 @@ Chart upload fields:
 - `metadataSchemaVersion`: `2`
 - `contentSource`: `community`
 - `songId`: remote song ID assigned by the server
-- `clientSongId`: local song ID
+- `clientSongId`: local song ID from the parent song, not from the `.rchart`
 - `clientChartId`: local chart ID
 - `visibility`: currently `public`
 - `keyCount`

--- a/src/scenes/editor/editor_session_loader.cpp
+++ b/src/scenes/editor/editor_session_loader.cpp
@@ -70,7 +70,9 @@ editor_session_load_result load(const editor_start_request& request) {
     } else if (request.chart_path.has_value()) {
         const chart_parse_result parse_result = chart_parser::parse(*request.chart_path);
         if (parse_result.success && parse_result.data.has_value()) {
-            result.state->load(*parse_result.data, *request.chart_path);
+            chart_data loaded_chart = *parse_result.data;
+            loaded_chart.meta.song_id = request.song.meta.song_id;
+            result.state->load(loaded_chart, *request.chart_path);
             result.chart_path = request.chart_path;
         } else {
             result.state->load(make_new_chart_data(request), "");

--- a/src/scenes/play/play_session_loader.cpp
+++ b/src/scenes/play/play_session_loader.cpp
@@ -126,6 +126,7 @@ play_session_state load(const play_start_request& request, play_note_draw_queue&
         return state;
     }
 
+    state.chart_data->meta.song_id = state.song_data->meta.song_id;
     state.chart_data = play_chart_filter::prepare_chart_for_playback(*state.chart_data, state.start_tick);
 
     state.input_handler = input_handler(g_settings.keys);

--- a/src/scenes/song_select/song_import_export_service.cpp
+++ b/src/scenes/song_select/song_import_export_service.cpp
@@ -433,12 +433,13 @@ transfer_result import_chart_package(const chart_import_request& request) {
     app_paths::ensure_directories();
     const fs::path destination_path = app_paths::song_chart_path(request.target_song_id, request.chart.meta.chart_id);
     chart_data chart_data_for_save = request.chart;
-    chart_data_for_save.meta.song_id = request.target_song_id;
     if (!chart_serializer::serialize(chart_data_for_save, path_utils::to_utf8(destination_path))) {
         result.message = "Failed to save the imported chart.";
         return result;
     }
-    chart_level_cache::calculate_and_store(path_utils::to_utf8(destination_path), chart_data_for_save);
+    chart_data chart_data_for_cache = chart_data_for_save;
+    chart_data_for_cache.meta.song_id = request.target_song_id;
+    chart_level_cache::calculate_and_store(path_utils::to_utf8(destination_path), chart_data_for_cache);
 
     result.success = true;
     result.reload_catalog = true;
@@ -711,12 +712,13 @@ transfer_result import_song_package(const song_import_request& request) {
             const fs::path destination_chart_path = charts_destination / chart_file_name;
             const std::string destination_chart_utf8 = path_utils::to_utf8(destination_chart_path);
             chart_data chart_data_for_save = *parsed_chart.data;
-            chart_data_for_save.meta.song_id = request.imported_song.meta.song_id;
             if (!chart_serializer::serialize(chart_data_for_save, destination_chart_utf8)) {
                 result.message = "Failed to import the song package charts.";
                 return result;
             }
-            chart_level_cache::calculate_and_store(destination_chart_utf8, chart_data_for_save);
+            chart_data chart_data_for_cache = chart_data_for_save;
+            chart_data_for_cache.meta.song_id = request.imported_song.meta.song_id;
+            chart_level_cache::calculate_and_store(destination_chart_utf8, chart_data_for_cache);
         }
     }
 

--- a/src/scenes/title/create_upload_client.cpp
+++ b/src/scenes/title/create_upload_client.cpp
@@ -693,8 +693,7 @@ void append_chart_contract_fields(std::vector<multipart_field>& fields,
     fields.push_back({"metadataSchemaVersion", "2"});
     fields.push_back({"contentSource", "community"});
     push_string_field(fields, "clientChartId", chart.meta.chart_id);
-    push_string_field(fields, "clientSongId",
-                      chart.meta.song_id.empty() ? song.song.meta.song_id : chart.meta.song_id);
+    push_string_field(fields, "clientSongId", song.song.meta.song_id);
     push_positive_int_field(fields, "keyCount", chart.meta.key_count);
     push_string_field(fields, "difficultyName", chart.meta.difficulty);
     push_string_field(fields, "chartAuthor", chart.meta.chart_author);

--- a/src/scenes/title/online_download_transfer.cpp
+++ b/src/scenes/title/online_download_transfer.cpp
@@ -68,7 +68,6 @@ bool write_binary_file(const std::filesystem::path& path,
 
 bool write_chart_file(const std::filesystem::path& path,
                       const std::vector<unsigned char>& bytes,
-                      const std::string& local_song_id,
                       std::string& error_message) {
     std::filesystem::create_directories(path.parent_path());
     const std::filesystem::path temp_path = path.parent_path() / (path.filename().string() + ".download.tmp");
@@ -83,9 +82,7 @@ bool write_chart_file(const std::filesystem::path& path,
         return false;
     }
 
-    chart_data data = *parsed.data;
-    data.meta.song_id = local_song_id;
-    if (!chart_serializer::serialize(data, path_utils::to_utf8(path))) {
+    if (!chart_serializer::serialize(*parsed.data, path_utils::to_utf8(path))) {
         std::filesystem::remove(temp_path);
         error_message = "Failed to write downloaded chart data to disk.";
         return false;
@@ -367,7 +364,6 @@ download_song_result download_chart_file(const song_entry_state song,
     app_paths::ensure_directories();
     if (!write_chart_file(app_paths::song_chart_path(local_song_id, local_chart_id),
                           chart_fetch.bytes,
-                          local_song_id,
                           error_message)) {
         result.message = error_message;
         return result;


### PR DESCRIPTION
## Summary
- stop using chart metadata songId as the client-side song linkage source
- keep runtime chart song_id derived from the selected/catalog parent song
- document that local chart-song linkage is folder/catalog DB owned and .rchart omits songId

## Verification
- cmake --build cmake-build-codex --target raythm chart_parser_smoke chart_serializer_smoke song_loader_smoke local_catalog_database_smoke -j 2
- ctest --test-dir cmake-build-codex --output-on-failure -R "chart_parser_smoke|chart_serializer_smoke|song_loader_smoke|local_catalog_database_smoke"