### PR TITLE
Ignore rchart songId metadata

### DIFF
--- a/src/gameplay/chart_parser.cpp
+++ b/src/gameplay/chart_parser.cpp
@@ -114,6 +114,7 @@ bool is_server_managed_metadata_key(const std::string& key) {
            key == "metadataSchemaVersion" ||
            key == "clientChartId" ||
            key == "clientSongId" ||
+           key == "songId" ||
            key == "difficultyRulesetId" ||
            key == "difficultyRulesetVersion";
 }
@@ -256,8 +257,6 @@ chart_meta chart_parser::parse_metadata(const std::vector<numbered_line>& lines,
                        !parse_int(value).has_value()) {
                 errors.push_back(format_line_error(line.first, key + " must be an integer"));
             }
-        } else if (key == "songId") {
-            meta.song_id = value;
         } else {
             errors.push_back(format_line_error(line.first, "Unknown metadata key: " + key));
         }

--- a/src/tests/chart_parser_smoke.cpp
+++ b/src/tests/chart_parser_smoke.cpp
@@ -137,6 +137,7 @@ bool expect_server_managed_metadata_success() {
            << "metadataSchemaVersion=2\n"
            << "clientChartId=local-chart\n"
            << "clientSongId=local-song\n"
+           << "songId=legacy-song\n"
            << "difficultyRulesetId=raythm-local\n"
            << "difficultyRulesetVersion=1\n"
            << "chartAuthor=Codex\n"
@@ -159,7 +160,7 @@ bool expect_server_managed_metadata_success() {
         }
         return false;
     }
-    return result.data->meta.level == 0.0f;
+    return result.data->meta.level == 0.0f && result.data->meta.song_id.empty();
 }
 }
 


### PR DESCRIPTION
## Summary
- ignore legacy songId metadata in chart parsing instead of loading it into chart_meta
- keep parser smoke coverage for legacy songId being ignored

## Verification
- cmake --build cmake-build-codex --target chart_parser_smoke raythm -j 2
- ctest --test-dir cmake-build-codex --output-on-failure -R "chart_parser_smoke|chart_serializer_smoke|song_loader_smoke|local_catalog_database_smoke"