### PR TITLE
Fallback preview duration to stream length

### DIFF
--- a/src/scenes/song_select/song_preview_controller.cpp
+++ b/src/scenes/song_select/song_preview_controller.cpp
@@ -15,18 +15,15 @@ constexpr double kPreviewLoopTailSeconds = 1.0;
 
 double effective_preview_length_seconds(const song_data& song) {
     const double metadata_length = static_cast<double>(song.meta.duration_seconds);
-    if (!song.meta.audio_url.empty()) {
+    if (metadata_length > 0.0) {
         return metadata_length;
     }
 
     const double stream_length = audio_manager::instance().get_preview_length_seconds();
-    if (metadata_length > 0.0) {
-        if (stream_length <= 0.0) {
-            return metadata_length;
-        }
+    if (stream_length > 0.0) {
         return stream_length;
     }
-    return stream_length;
+    return 0.0;
 }
 
 }  // namespace

--- a/src/scenes/title/online_download_state.cpp
+++ b/src/scenes/title/online_download_state.cpp
@@ -324,17 +324,11 @@ std::string format_time_label(double seconds) {
 
 double preview_display_length_seconds(const song_entry_state& song) {
     const double metadata_length = static_cast<double>(song.song.song.meta.duration_seconds);
-    if (!song.song.song.meta.audio_url.empty()) {
+    if (metadata_length > 0.0) {
         return metadata_length;
     }
 
     const double stream_length = audio_manager::instance().get_preview_length_seconds();
-    if (metadata_length > 0.0) {
-        if (stream_length <= 0.0) {
-            return metadata_length;
-        }
-        return stream_length;
-    }
     if (stream_length > 0.0) {
         return stream_length;
     }


### PR DESCRIPTION
## Summary
- use durationSec first for preview total time
- fall back to loaded preview stream length when remote catalog durationSec is missing
- apply the same fallback in song select preview looping

## Verification
- cmake --build cmake-build-codex --target raythm -j 2
- checked dev-api official catalog: ColorArRay currently returns durationSec: null