### PR TITLE
Remove remote preview duration stream fallback

### DIFF
--- a/src/scenes/song_select/song_preview_controller.cpp
+++ b/src/scenes/song_select/song_preview_controller.cpp
@@ -15,15 +15,18 @@ constexpr double kPreviewLoopTailSeconds = 1.0;
 
 double effective_preview_length_seconds(const song_data& song) {
     const double metadata_length = static_cast<double>(song.meta.duration_seconds);
-    if (metadata_length > 0.0) {
+    if (!song.meta.audio_url.empty()) {
         return metadata_length;
     }
 
     const double stream_length = audio_manager::instance().get_preview_length_seconds();
-    if (stream_length > 0.0) {
+    if (metadata_length > 0.0) {
+        if (stream_length <= 0.0) {
+            return metadata_length;
+        }
         return stream_length;
     }
-    return 0.0;
+    return stream_length;
 }
 
 }  // namespace

--- a/src/scenes/title/online_download_state.cpp
+++ b/src/scenes/title/online_download_state.cpp
@@ -324,11 +324,17 @@ std::string format_time_label(double seconds) {
 
 double preview_display_length_seconds(const song_entry_state& song) {
     const double metadata_length = static_cast<double>(song.song.song.meta.duration_seconds);
-    if (metadata_length > 0.0) {
+    if (!song.song.song.meta.audio_url.empty()) {
         return metadata_length;
     }
 
     const double stream_length = audio_manager::instance().get_preview_length_seconds();
+    if (metadata_length > 0.0) {
+        if (stream_length <= 0.0) {
+            return metadata_length;
+        }
+        return stream_length;
+    }
     if (stream_length > 0.0) {
         return stream_length;
     }


### PR DESCRIPTION
## Summary
- revert the preview duration stream-length fallback from PR #329
- keep remote total time dependent on server-provided durationSec instead of BASS stream length

## Verification
- cmake --build cmake-build-codex --target raythm -j 2