### PR TITLE
Allow dragging online preview seek bar

### DIFF
--- a/src/scenes/title/online_download_update.cpp
+++ b/src/scenes/title/online_download_update.cpp
@@ -14,6 +14,7 @@ namespace {
 void reset_chart_scroll(state& state) {
     state.chart_scroll_y = 0.0f;
     state.chart_scroll_y_target = 0.0f;
+    state.preview_bar_dragging = false;
 }
 
 void reset_browse_scrolls(state& state) {
@@ -25,6 +26,7 @@ void reset_browse_scrolls(state& state) {
 bool handle_back_or_close_input(state& state, update_result& result) {
     if (state.detail_open && (IsKeyPressed(KEY_ESCAPE) || IsMouseButtonPressed(MOUSE_BUTTON_RIGHT))) {
         state.detail_open = false;
+        state.preview_bar_dragging = false;
         reset_chart_scroll(state);
         return true;
     }
@@ -135,14 +137,25 @@ bool handle_detail_actions(state& state,
         request_charts_for_selected_song(state);
     }
 
+    if (IsMouseButtonReleased(MOUSE_BUTTON_LEFT)) {
+        state.preview_bar_dragging = false;
+    }
+
     if (song != nullptr && left_pressed && CheckCollisionPointRec(mouse, current.preview_bar_rect)) {
+        state.preview_bar_dragging = true;
+    }
+
+    if (song != nullptr && state.preview_bar_dragging) {
         const double preview_length = detail::preview_display_length_seconds(*song);
         if (preview_length > 0.0 && audio_manager::instance().is_preview_loaded()) {
             const float ratio = std::clamp((mouse.x - current.preview_bar_rect.x) / current.preview_bar_rect.width,
                                            0.0f, 1.0f);
             audio_manager::instance().seek_preview(preview_length * static_cast<double>(ratio));
         }
-        return true;
+        if (IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+            return true;
+        }
+        state.preview_bar_dragging = false;
     }
 
     if (ui::is_clicked(current.preview_play_rect)) {
@@ -259,6 +272,9 @@ update_result update(state& state, float anim_t, Rectangle origin_rect, float dt
     const layout current = make_layout(anim_t, origin_rect);
     const Vector2 mouse = virtual_screen::get_virtual_mouse();
     const bool left_pressed = IsMouseButtonPressed(MOUSE_BUTTON_LEFT);
+    if (!IsMouseButtonDown(MOUSE_BUTTON_LEFT)) {
+        state.preview_bar_dragging = false;
+    }
     const float wheel = GetMouseWheelMove();
     const float detail_target = state.detail_open ? 1.0f : 0.0f;
     const float detail_lerp_speed = state.detail_open ? 6.5f : 10.0f;

--- a/src/scenes/title/online_download_view.h
+++ b/src/scenes/title/online_download_view.h
@@ -154,6 +154,7 @@ struct state {
     catalog_mode reload_restore_mode = catalog_mode::official;
     std::string reload_restore_song_id;
     std::string reload_restore_chart_id;
+    bool preview_bar_dragging = false;
 };
 
 struct layout {


### PR DESCRIPTION
## Summary
- add drag state for the online preview seek bar
- seek continuously while the left mouse button is held down
- clear drag state when closing detail view or switching/resetting chart view

## Verification
- cmake --build cmake-build-codex --target raythm -j 2